### PR TITLE
Issue #25: System / Enhance Filesystem Utilization

### DIFF
--- a/src/dashboards/System/System (MetricsHub).json
+++ b/src/dashboards/System/System (MetricsHub).json
@@ -27,7 +27,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "11.0.0"
+      "version": "11.2.0"
     },
     {
       "type": "panel",
@@ -203,7 +203,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -314,7 +314,7 @@
         "content": "\n<img src=\"https://metricshub.com/images/logo-darkgrey.svg\" alt=\"MetricsHub\" width=\"150\" height=\"150\">\n",
         "mode": "markdown"
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "11.2.0",
       "transparent": true,
       "type": "text"
     },
@@ -422,7 +422,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -629,6 +629,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -640,7 +641,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -702,6 +703,7 @@
         "graphMode": "area",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -713,7 +715,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -805,6 +807,18 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Filesystem"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "left"
+              }
+            ]
           }
         ]
       },
@@ -833,7 +847,7 @@
           }
         ]
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -842,7 +856,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "system_filesystem_utilization_ratio{host_name=\"$host_name\",system_filesystem_state=\"used\"}",
+          "expr": "sum(system_filesystem_utilization_ratio{host_name=\"$host_name\",system_filesystem_state=~\"used|reserved\"}) by (id)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1073,7 +1087,7 @@
         },
         "showHeader": false
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -1307,7 +1321,7 @@
         "showThresholdMarkers": true,
         "sizing": "auto"
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -1343,6 +1357,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 50,
             "gradientMode": "scheme",
@@ -1595,6 +1610,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 41,
             "gradientMode": "scheme",
@@ -1628,7 +1644,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "#EAB839",
@@ -1711,7 +1728,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               }
             ]
           },
@@ -1744,7 +1762,7 @@
         "sizing": "auto",
         "valueMode": "text"
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -1799,7 +1817,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1830,7 +1849,7 @@
         },
         "showHeader": false
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -1891,6 +1910,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 11,
             "gradientMode": "none",
@@ -1921,7 +1941,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1984,10 +2005,14 @@
       "interval": "10m",
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
         },
         "tooltip": {
           "maxHeight": 600,
@@ -2042,7 +2067,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "orange",
@@ -2070,6 +2096,7 @@
         "graphMode": "none",
         "justifyMode": "auto",
         "orientation": "auto",
+        "percentChangeColorMode": "standard",
         "reduceOptions": {
           "calcs": [
             "lastNotNull"
@@ -2082,7 +2109,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -2136,7 +2163,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2184,6 +2212,18 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Filesystem"
+            },
+            "properties": [
+              {
+                "id": "custom.align",
+                "value": "left"
+              }
+            ]
           }
         ]
       },
@@ -2212,7 +2252,7 @@
           }
         ]
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -2221,7 +2261,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "system_filesystem_utilization_ratio{host_name=\"$host_name\", system_filesystem_state=\"used\"}",
+          "expr": "sum(system_filesystem_utilization_ratio{host_name=\"$host_name\",system_filesystem_state=~\"used|reserved\"}) by (id)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -2290,35 +2330,45 @@
               "Time 1": true,
               "Time 2": true,
               "Time 3": true,
+              "__name__": true,
               "__name__ 1": true,
               "__name__ 2": true,
               "__name__ 3": true,
+              "agent_host_name": true,
               "agent_host_name 1": true,
               "agent_host_name 2": true,
               "agent_host_name 3": true,
+              "connector_id": true,
               "connector_id 1": true,
               "connector_id 2": true,
               "connector_id 3": true,
+              "host_id": true,
               "host_id 1": true,
               "host_id 2": true,
               "host_id 3": true,
+              "host_name": true,
               "host_name 1": true,
               "host_name 2": true,
               "host_name 3": true,
+              "host_type": true,
               "host_type 1": true,
               "host_type 2": true,
               "host_type 3": true,
+              "os_type": true,
               "os_type 1": true,
               "os_type 2": true,
               "os_type 3": true,
+              "site": true,
               "site 1": true,
               "site 2": true,
               "site 3": true,
+              "system_filesystem_device": true,
               "system_filesystem_device 1": true,
               "system_filesystem_device 2": true,
               "system_filesystem_device 3": true,
               "system_filesystem_mountpoint 2": true,
               "system_filesystem_mountpoint 3": true,
+              "system_filesystem_state": true,
               "system_filesystem_state 1": true,
               "system_filesystem_state 2": true,
               "system_filesystem_state 3": true,
@@ -2329,50 +2379,23 @@
             },
             "includeByName": {},
             "indexByName": {
-              "Capacity": 5,
-              "Time 1": 7,
-              "Time 2": 18,
-              "Time 3": 30,
-              "Value #A": 6,
-              "Value #B": 4,
-              "Value #C": 3,
-              "__name__ 1": 8,
-              "__name__ 2": 19,
-              "__name__ 3": 31,
-              "agent_host_name 1": 9,
-              "agent_host_name 2": 20,
-              "agent_host_name 3": 32,
-              "connector_id 1": 10,
-              "connector_id 2": 21,
-              "connector_id 3": 33,
-              "host_id 1": 11,
-              "host_id 2": 22,
-              "host_id 3": 34,
-              "host_name 1": 12,
-              "host_name 2": 23,
-              "host_name 3": 35,
-              "host_type 1": 13,
-              "host_type 2": 24,
-              "host_type 3": 36,
+              "Time 1": 5,
+              "Time 2": 6,
+              "Value #A": 4,
+              "Value #B": 3,
+              "__name__": 7,
+              "agent_host_name": 8,
+              "connector_id": 9,
+              "host_id": 10,
+              "host_name": 11,
+              "host_type": 12,
               "id": 0,
-              "os_type 1": 14,
-              "os_type 2": 25,
-              "os_type 3": 37,
-              "site 1": 15,
-              "site 2": 26,
-              "site 3": 38,
-              "system_filesystem_device 1": 16,
-              "system_filesystem_device 2": 27,
-              "system_filesystem_device 3": 39,
-              "system_filesystem_mountpoint 1": 1,
-              "system_filesystem_mountpoint 2": 42,
-              "system_filesystem_mountpoint 3": 43,
-              "system_filesystem_state 1": 17,
-              "system_filesystem_state 2": 28,
-              "system_filesystem_state 3": 40,
-              "system_filesystem_type 1": 2,
-              "system_filesystem_type 2": 29,
-              "system_filesystem_type 3": 41
+              "os_type": 13,
+              "site": 14,
+              "system_filesystem_device": 15,
+              "system_filesystem_mountpoint": 1,
+              "system_filesystem_state": 16,
+              "system_filesystem_type": 2
             },
             "renameByName": {
               "Capacity": "",
@@ -2381,8 +2404,10 @@
               "Value #B": "Free",
               "Value #C": "Used",
               "id": "Filesystem",
+              "system_filesystem_mountpoint": "Mountpoint",
               "system_filesystem_mountpoint 1": "Mountpoint",
               "system_filesystem_state 1": "",
+              "system_filesystem_type": "Type",
               "system_filesystem_type 1": "Type",
               "system_filesystem_type 3": "",
               "system_filesystem_volumeName 1": "Name"
@@ -2411,6 +2436,7 @@
             "axisSoftMax": 1,
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "hue",
@@ -2441,7 +2467,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "orange",
@@ -2466,10 +2493,14 @@
       "id": 78,
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
         },
         "tooltip": {
           "maxHeight": 600,
@@ -2524,6 +2555,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 16,
             "gradientMode": "none",
@@ -2554,7 +2586,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2562,7 +2595,7 @@
               }
             ]
           },
-          "unit": "bytes"
+          "unit": "binBps"
         },
         "overrides": []
       },
@@ -2576,10 +2609,14 @@
       "interval": "10m",
       "options": {
         "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
         },
         "tooltip": {
           "maxHeight": 600,
@@ -2594,7 +2631,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "irate (system_disk_io_bytes_total{host_name=\"$host_name\"}[$__rate_interval])",
+          "expr": "irate(system_disk_io_bytes_total{host_name=\"$host_name\"}[$__rate_interval])",
           "instant": false,
           "legendFormat": "{{id}} {{disk_io_direction}}",
           "range": true,
@@ -2654,7 +2691,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2735,7 +2773,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "11.0.0",
+      "pluginVersion": "11.2.0",
       "targets": [
         {
           "datasource": {
@@ -2839,7 +2877,7 @@
       "type": "table"
     }
   ],
-  "refresh": "1m",
+  "refresh": "5s",
   "schemaVersion": 39,
   "tags": [
     "System",
@@ -2848,11 +2886,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "prometheus",
-          "value": "edor7qzpnaarke"
-        },
+        "current": {},
         "hide": 2,
         "includeAll": false,
         "label": "Data Source",
@@ -2922,11 +2956,10 @@
     "from": "now-3h",
     "to": "now"
   },
-  "timeRangeUpdatedDuringEditOrView": false,
   "timepicker": {},
   "timezone": "",
   "title": "MetricsHub System",
   "uid": "eWQoMUTIk",
-  "version": 20,
+  "version": 2,
   "weekStart": ""
 }

--- a/src/dashboards/System/System (MetricsHub).json
+++ b/src/dashboards/System/System (MetricsHub).json
@@ -2877,7 +2877,7 @@
       "type": "table"
     }
   ],
-  "refresh": "5s",
+  "refresh": "30s",
   "schemaVersion": 39,
   "tags": [
     "System",


### PR DESCRIPTION
- Enhanced the PromQL query to include the filesystem utilization percentage.
- Added table legends to the network, filesystem utilization and disk activity graphs and displayed the last* value for each legend.
- Left aligned filesystem paths in the Filesystem tables.
- Updated unit in the legend of the disk activity graph.
- Removed extra whitespace from the PromQL used to report the disk activity graph.

-------------------------------
### Testing
![image](https://github.com/user-attachments/assets/d68e4f1f-e4dd-482e-978f-348818530150)
![image](https://github.com/user-attachments/assets/3fd5d59c-508b-4ed8-8a7e-0aee6bccccff)
![image](https://github.com/user-attachments/assets/dbf86051-627b-4978-a8f7-05391083fd55)


