### PR TITLE
Add Storage Dashboard and Migrate to Grafana v2 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # grafana-dashboards
 
-![License](https://img.shields.io/github/license/sentrysoftware/metricshub)
+This is a set of Grafana dashboards that allow users of MetricsHub products to visualize the collected data.
 
-This is a set of Grafana dashboards that allow users of Sentry Software products to visualize the collected data.
+Watch the [MetricsHub labs](https://m8b-demo.metricshub.com/) running Grafana with live data.
 
-## Hardware Sentry
+# Prerequisites
 
-The Hardware Sentry dashboards give you immediate visibility into your environment. The organized panels expose hardware health metrics for all monitored systems and bring real-time metrics and projected trends on electricity consumption and costs, as well as CO₂ emissions for your entire infrastructure.
+## Grafana version
 
-Watch the [Sentry Software labs](https://hws-demo.sentrysoftware.com/d/-GV2ChOnz/hardware-sentry-main?orgId=1) running on Grafana with live data.
+**Minimum: Grafana 13.0.1**
+These dashboard uses the v2 dashboard schema (Dynamic Dashboards), which is enabled by default in Grafana 13. No configuration required.
 
-## License
+## Data source
+
+These dashboard expects a **Prometheus** data source scraping metrics exposed by [MetricsHub](https://metricshub.com/). The data source is selectable at import time.
+
+# License
 
 The license is GNU Affero General Public License v3.0.

--- a/src/dashboards/Hardware/Hardware Host (MetricsHub).json
+++ b/src/dashboards/Hardware/Hardware Host (MetricsHub).json
@@ -1,6709 +1,8339 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "12.0.2"
-    },
-    {
-      "type": "panel",
-      "id": "heatmap",
-      "name": "Heatmap",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "piechart",
-      "name": "Pie chart",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "text",
-      "name": "Text",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "datasource",
-          "uid": "grafana"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "ad2prtc",
+    "generation": 7,
+    "creationTimestamp": "2026-04-29T13:50:02Z",
+    "labels": {},
+    "annotations": {}
   },
-  "description": "Collect hardware health and performance metrics as well as sustainability KPIs of your hosts with MetricsHub®; visualize the gathered telemetry data in the comprehensive Hardware Host (MetricsHub) dashboard.\r\nMetricsHubs collects metrics from servers (Cisco, Dell, HPE, Huawei, IBM Lenovo, SuperMicro, etc.), storage systems (NetApp, Dell EMC, Hitachi, HPE, IBM, Pure, Huawei, etc.), network devices (Cisco, Aruba, Dell, HP, F5, Juniper, Oracle) and other equipment like PDUs, UPS from APC, Raritan, Eaton, etc.",
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": null,
-  "links": [
-    {
-      "asDropdown": false,
-      "icon": "external link",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [
-        "hw_main"
-      ],
-      "targetBlank": false,
-      "title": "",
-      "tooltip": "",
-      "type": "dashboards",
-      "url": ""
-    },
-    {
-      "asDropdown": false,
-      "icon": "external link",
-      "includeVars": true,
-      "keepTime": true,
-      "tags": [
-        "hw_site"
-      ],
-      "targetBlank": false,
-      "title": "Site Information",
-      "tooltip": "",
-      "type": "dashboards",
-      "url": ""
-    }
-  ],
-  "panels": [
-    {
-      "gridPos": {
-        "h": 2,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 65,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<h1 style=\"\">\r\n  <center>${host_name}</center>\r\n</h1>",
-        "mode": "html"
-      },
-      "pluginVersion": "12.0.2",
-      "type": "text"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 2
-      },
-      "id": 208,
-      "panels": [],
-      "title": "Host Information, Alerts and Protocols Status",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#808080",
-            "mode": "fixed"
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "N/A",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "host_type"
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
             },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Host Type"
-              }
-            ]
+            "version": "v0"
           }
-        ]
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 0,
-        "y": 3
-      },
-      "id": 317,
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "/.*/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 24
-        },
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "hw_status{site=~\"$site\", host_name=~\"$host_name\", hw_type=\"enclosure\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
         }
-      ],
-      "title": "Host Type",
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "host_type"
+      }
+    ],
+    "cursorSync": "Off",
+    "description": "Collect hardware health and performance metrics as well as sustainability KPIs of your hosts with MetricsHub®; visualize the gathered telemetry data in the comprehensive Hardware Host (MetricsHub) dashboard.\r\nMetricsHubs collects metrics from servers (Cisco, Dell, HPE, Huawei, IBM Lenovo, SuperMicro, etc.), storage systems (NetApp, Dell EMC, Hitachi, HPE, IBM, Pure, Huawei, etc.), network devices (Cisco, Aruba, Dell, HP, F5, Juniper, Oracle) and other equipment like PDUs, UPS from APC, Raritan, Eaton, etc.",
+    "editable": true,
+    "elements": {
+      "panel-101": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[1y:1d]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[60d:1d])) * 24 * 365",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Yearly Consumption"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall power consumption reported for the host during the last year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
+          "id": 101,
+          "links": [],
+          "title": "Yearly",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "dark-blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "purple",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-103": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[1y:1d]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[60d:1d])) * scalar(avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[1y:1d])) * 365 * 24 / 1000",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Yearly Cost"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall energy cost reported for the host in the past year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
+          "id": 103,
+          "links": [],
+          "title": "Yearly",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "dark-green",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "purple",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-105": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[1y:1d]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[60d:1d])) * scalar(avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[1y:1d])) * 365 * 24 / 1000 / 1000 / 1000",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Yearly CO₂ Emissions"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall CO₂ emitted by the host during the past year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
+          "id": 105,
+          "links": [],
+          "title": "Yearly",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#414141",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "purple",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masst"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-109": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Power"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The host's current power consumption.",
+          "id": 109,
+          "links": [],
+          "title": "Power",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watt"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-110": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"} * scalar(avg(hw_site_pue_ratio{site=~\"$site\"}))",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Power * P.U.E"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The host's current power usage multiplied by the site's PUE.",
+          "id": 110,
+          "links": [],
+          "title": "Power * P.U.E",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watt"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-112": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "hw_host_ambient_temperature_celsius{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Ambient Temperature",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": [
+                {
+                  "kind": "reduce",
+                  "spec": {
+                    "id": "reduce",
+                    "options": {
+                      "reducers": []
+                    }
+                  }
+                }
               ]
             }
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The vendor and model information of the host (when available).",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#808080",
-            "mode": "fixed"
           },
+          "description": "The current estimated internal temperature of the host.",
+          "id": 112,
           "links": [],
-          "mappings": [],
-          "noValue": "N/A",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "vendor"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Host Vendor"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "model"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Host Model"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 7,
-        "x": 2,
-        "y": 3
-      },
-      "id": 319,
-      "options": {
-        "colorMode": "none",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "/.*/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 24
-        },
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "hw_status{site=~\"$site\", host_name=~\"$host_name\", hw_type=\"enclosure\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Vendor and Model",
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "pattern": "(vendor|model)"
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {},
-            "indexByName": {
-              "model": 1,
-              "vendor": 0
-            },
-            "renameByName": {}
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 9,
-        "y": 3
-      },
-      "id": 80,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(ALERTS_FOR_STATE{severity=\"critical\", site=~\"$site\", host_name=~\"$host_name\", alertname=~\"MetricsHub-Hardware-.*\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Critical Alerts",
-          "refId": "A"
-        }
-      ],
-      "title": "Critical Alerts",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": false
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "No alerts",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Severity"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 109
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "critical": {
-                        "color": "red",
-                        "index": 1,
-                        "text": "Critical"
-                      },
-                      "warning": {
-                        "color": "orange",
-                        "index": 0,
-                        "text": "Warning"
+          "title": "Ambient ",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-BlYlRd"
+                  },
+                  "decimals": 1,
+                  "links": [
+                    {
+                      "title": "",
+                      "url": "/d/PwSWpSN7k/device-temperature?orgId=1&${host_name:queryparam}&${site:queryparam}"
+                    }
+                  ],
+                  "max": 60,
+                  "min": 25,
+                  "noValue": "No sensors",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
                       }
+                    ]
+                  },
+                  "unit": "celsius"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-122": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": true,
+                        "expr": "hw_temperature_celsius{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "instant": false,
+                        "interval": "",
+                        "intervalFactor": 5,
+                        "legendFormat": "{{name}}"
+                      },
+                      "version": "v0"
                     },
-                    "type": "value"
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "hw_host_ambient_temperature_celsius{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "legendFormat": "Ambient",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The reading of the host's temperature sensors (when available).",
+          "id": 122,
+          "links": [],
+          "title": "Temperatures",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 7,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "graph": false,
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "celsius"
+                },
+                "overrides": []
+              },
+              "options": {
+                "graph": {},
+                "legend": {
+                  "calcs": [
+                    "last",
+                    "min",
+                    "max"
+                  ],
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-125": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "hw_host_heating_margin_celsius{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "format": "time_series",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Heating Margin"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The number of degrees Celsius (°C) remaining before the temperature reaches the closest warning temperature threshold of the host.\n\nA value of 0 indicates a critical temperature.",
+          "id": 125,
+          "links": [],
+          "title": "Heating Margin",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "links": [
+                    {
+                      "title": "More information about temperature sensors",
+                      "url": "/d/PwSWpSN7k/device-temperature?orgId=1&${host_name:queryparam}&${site:queryparam}"
+                    }
+                  ],
+                  "max": 20,
+                  "min": 0,
+                  "noValue": "No sensors",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 5
+                      },
+                      {
+                        "color": "green",
+                        "value": 10
+                      }
+                    ]
+                  },
+                  "unit": "celsius"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-133": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(increase(hw_host_energy_joules_total{site=~\"$site\", host_name=~\"$host_name\"}[$__range])) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[$__range:5m]) * avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[$__range:5m]) / 3600 / 1000",
+                        "legendFormat": "Today's Live Cost",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "hideTimeOverride": true,
+                "timeFrom": "now/d"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Today's energy cost for the host.",
+          "id": 133,
+          "links": [],
+          "title": "Cost",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-134": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[1d:5m]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m])) * scalar(avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[1d:5m])) * 24 / 1000 / 1000",
+                        "instant": true,
+                        "legendFormat": "Daily CO₂ Emissions",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall CO₂ emitted by the host during the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
+          "id": 134,
+          "links": [],
+          "title": "Daily",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masskg"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-138": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "last_over_time(timestamp(metricshub_agent_info{site=~\"$site\", agent_host_name=\"$agent\"})[6h:])",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "last_over_time(timestamp(metricshub_agent_info{agent_host_name=\"$agent\"})[6h:])",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": [
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Last Seen",
+                      "binary": {
+                        "left": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value"
+                          }
+                        },
+                        "operator": "*",
+                        "right": {
+                          "fixed": "1000"
+                        }
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "include": [
+                          "Last Seen"
+                        ],
+                        "reducer": "last"
+                      },
+                      "replaceFields": false
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "agent_host_name",
+                          "build_date",
+                          "build_number",
+                          "version",
+                          "Last Seen",
+                          "cc_version"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Value": true,
+                        "Value #A": true,
+                        "__name__": true,
+                        "agent_host_name": false,
+                        "build_number": false,
+                        "build_number 2": true,
+                        "hc_version 2": true,
+                        "host_id": true,
+                        "host_id 1": true,
+                        "host_id 2": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "job": true,
+                        "name": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "otel_version": true,
+                        "project_name": true,
+                        "project_name 1": true,
+                        "project_name 2": true,
+                        "project_version": true,
+                        "project_version 2": true,
+                        "service_name": true,
+                        "service_name 1": true,
+                        "service_name 2": true,
+                        "site": true,
+                        "site 2": true,
+                        "timestamp": true,
+                        "timestamp 1": true,
+                        "timestamp 2": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Last Seen": 5,
+                        "agent_host_name": 0,
+                        "build_date": 2,
+                        "build_number": 3,
+                        "cc_version": 4,
+                        "version": 1
+                      },
+                      "renameByName": {
+                        "Time": "",
+                        "Value": "",
+                        "agent_host_name": "Hostname",
+                        "build_date": "Build Date",
+                        "build_number": "Build Number",
+                        "build_number 1": "Agent Build Number",
+                        "cc_version": "Connectors Version",
+                        "hc_version": "Connectors Version",
+                        "hc_version 1": "Connectors Version",
+                        "project_version": "",
+                        "project_version 1": "Agent Version",
+                        "site": "",
+                        "site 1": "Site",
+                        "timestamp": "",
+                        "version": "Version"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 138,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Last Seen"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dateTimeFromNow"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Hostname"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
                   }
                 ]
               },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "basic",
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Site"
+                  }
+                ]
               }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "protocol"
             },
-            "properties": [
-              {
-                "id": "noValue",
-                "value": "N/A"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Device Type"
-            },
-            "properties": [
-              {
-                "id": "noValue",
-                "value": "N/A"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 219
-              }
-            ]
+            "version": "12.3.2"
           }
-        ]
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 3
-      },
-      "id": 206,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "enablePagination": true,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "Time"
-          }
-        ]
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "ALERTS_FOR_STATE{host_name=~\"$host_name\", site=~\"$site\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
         }
-      ],
-      "title": "Current Alerts",
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "Time",
-                "name",
-                "severity",
-                "hw_type",
-                "protocol"
+      },
+      "panel-144": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 144,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<h6 style=\"background-color:yyyyy\"><center>Today's Live Data</center></h6>",
+                "mode": "html"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-146": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 146,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<h6 style=\"background-color:yyyy\"><center>Cumulative Consumption</center></h6>",
+                "mode": "html"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-148": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "legendFormat": "Power Consumption",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The host's power consumption displayed as a graph.",
+          "id": 148,
+          "links": [],
+          "title": "Power Consumption",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "axisSoftMin": 0,
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "gradientMode": "hue",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 2,
+                    "pointSize": 6,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watt"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "min",
+                    "max",
+                    "last"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-154": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "metricshub_connector_status{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "filterByValue",
+                  "spec": {
+                    "id": "filterByValue",
+                    "options": {
+                      "filters": [
+                        {
+                          "config": {
+                            "id": "lower",
+                            "options": {
+                              "value": 1
+                            }
+                          },
+                          "fieldName": "Value"
+                        }
+                      ],
+                      "match": "any",
+                      "type": "exclude"
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "description",
+                          "name",
+                          "state"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Value": true,
+                        "__name__": true,
+                        "agent_host_name": true,
+                        "applies_to_os": true,
+                        "compiled_file_name": true,
+                        "connector_id": true,
+                        "description": false,
+                        "device_id": true,
+                        "display_name": true,
+                        "fqdn": true,
+                        "host_id": true,
+                        "host_name": true,
+                        "host_type": true,
+                        "id": true,
+                        "instance": true,
+                        "job": true,
+                        "os_type": true,
+                        "parent": true,
+                        "site": true,
+                        "zone": true
+                      },
+                      "indexByName": {
+                        "Value": 4,
+                        "applies_to_os": 11,
+                        "connector_id": 12,
+                        "description": 1,
+                        "host_id": 7,
+                        "host_name": 8,
+                        "host_type": 9,
+                        "id": 3,
+                        "name": 0,
+                        "os_type": 10,
+                        "parent": 5,
+                        "site": 6,
+                        "state": 2
+                      },
+                      "renameByName": {
+                        "Status": "Status",
+                        "Time": "",
+                        "Value": "",
+                        "__name__": "",
+                        "compiled_file_name": "",
+                        "description": "Description",
+                        "id": "",
+                        "identifying_information": "More Information",
+                        "label": "Name",
+                        "model": "Model",
+                        "name": "Name",
+                        "serial_number": "Serial Number",
+                        "site": "",
+                        "state": "Status",
+                        "type": "Type",
+                        "vendor": "Vendor"
+                      }
+                    }
+                  }
+                }
               ]
             }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": false,
-              "Value": true,
-              "Value #A": true,
-              "__name__": true,
-              "agent_host_name": true,
-              "alertstatus": true,
-              "alertstatus_code": true,
-              "applies_to_os": true,
-              "array_name": true,
-              "bandwidth": true,
-              "battery_state": true,
-              "blade_name": true,
-              "chemistry": true,
-              "compiled_file_name": true,
-              "connector_id": true,
-              "description": true,
-              "device_id": true,
-              "device_type": true,
-              "display_name": true,
-              "driver_version": true,
-              "firmware_version": true,
-              "fqdn": true,
-              "host_id": true,
-              "host_name": true,
-              "host_type": true,
-              "hw_type": false,
-              "id": true,
-              "identifying_information": true,
-              "info": true,
-              "instance": true,
-              "job": true,
-              "local_device_name": true,
-              "location": true,
-              "model": true,
-              "name": false,
-              "os_type": true,
-              "parent": true,
-              "physical_address": true,
-              "power_supply_type": true,
-              "raid_level": true,
-              "robotic_type": true,
-              "sensor_location": true,
-              "serial_number": true,
-              "severity": false,
-              "site": true,
-              "state": true,
-              "type": true,
-              "vendor": true,
-              "wwn": true,
-              "zone": true
-            },
-            "indexByName": {
-              "Time": 0,
-              "Value": 13,
-              "array_name": 20,
-              "battery_state": 23,
-              "device_id": 14,
-              "driver_version": 27,
-              "firmware_version": 28,
-              "host_id": 7,
-              "host_name": 8,
-              "host_type": 9,
-              "hw_type": 2,
-              "id": 5,
-              "info": 15,
-              "local_device_name": 21,
-              "location": 19,
-              "model": 16,
-              "name": 3,
-              "os_type": 10,
-              "parent": 6,
-              "power_supply_type": 26,
-              "protocol": 4,
-              "robotic_type": 25,
-              "sensor_location": 29,
-              "serial_number": 24,
-              "severity": 1,
-              "site": 11,
-              "state": 12,
-              "type": 17,
-              "vendor": 18,
-              "wwn": 22
-            },
-            "renameByName": {
-              "Time": "Time",
-              "alertname": "Alert Name",
-              "fqdn": "",
-              "hw_type": "Device Type",
-              "id": "",
-              "label": "Label",
-              "name": "Device Name",
-              "protocol": "Protocol",
-              "severity": "Severity"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Time"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The maximum speed of the host's CPU (when available).",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
           },
-          "mappings": [],
-          "noValue": "-",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text"
-              }
-            ]
-          },
-          "unit": "rothz"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 6
-      },
-      "id": 287,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max(hw_cpu_speed_limit_hertz{site=~\"$site\", host_name=~\"$host_name\"})",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "CPU Maximum Speed",
-          "range": false,
-          "refId": "B"
-        }
-      ],
-      "title": "CPU Max Speed",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The total memory size of the host (when available).",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "noValue": "-",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text"
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 3,
-        "y": 6
-      },
-      "id": 286,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(hw_memory_limit_bytes{site=~\"$site\", host_name=~\"$host_name\"})",
-          "hide": false,
-          "legendFormat": "Memory Size",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Memory",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The total disk size of the host (when available).",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "noValue": "-",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text"
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 6,
-        "y": 6
-      },
-      "id": 188,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(hw_physical_disk_size_bytes{site=~\"$site\", host_name=~\"$host_name\"})",
-          "legendFormat": "Disk Size",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Disk Size",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "description": "",
+          "id": 154,
           "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 9,
-        "y": 6
-      },
-      "id": 81,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(ALERTS_FOR_STATE{severity=\"warning\", site=~\"$site\", host_name=~\"$host_name\", alertname=~\"MetricsHub-Hardware-.*\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Warning Alerts",
-          "refId": "A"
-        }
-      ],
-      "title": "Warning Alerts",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "color-background"
-            },
-            "inspect": false
-          },
-          "fieldMinMax": false,
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Response Time"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "drawStyle": "line",
-                  "fillOpacity": 17,
-                  "gradientMode": "hue",
-                  "hideValue": true,
-                  "lineInterpolation": "stepBefore",
-                  "lineStyle": {
-                    "dash": [
-                      10,
-                      10
-                    ],
-                    "fill": "solid"
+          "title": "Connectors",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
                   },
-                  "type": "sparkline"
-                }
-              },
-              {
-                "id": "decimals"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "min",
-                "value": 0
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Highest"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "lcd",
-                  "type": "gauge",
-                  "valueDisplayMode": "text"
-                }
-              },
-              {
-                "id": "unit",
-                "value": "s"
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 7
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Lowest"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "lcd",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 0.5
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Average"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "lcd",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 2
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Up Percentage"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-text",
-                  "wrapText": false
-                }
-              },
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "red"
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
                     },
-                    {
-                      "color": "yellow",
-                      "value": 0.85
+                    "footer": {
+                      "reducers": []
                     },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "degraded": {
+                                "color": "orange",
+                                "index": 1,
+                                "text": "Degraded"
+                              },
+                              "failed": {
+                                "color": "red",
+                                "index": 2,
+                                "text": "Failed"
+                              },
+                              "ok": {
+                                "index": 0,
+                                "text": "OK"
+                              },
+                              "present": {
+                                "color": "red",
+                                "index": 3,
+                                "text": "Missing"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Description"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 920
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "showHeader": true,
+                "sortBy": []
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-156": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Power Consumption Reading Type"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "quality"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {},
+                      "indexByName": {},
+                      "renameByName": {
+                        "quality": "Power Consumption Reading Type"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The type of power consumption reading:\n- Measured, if the value is reported by the manufacturer's agent\n- Estimated, if the value is estimated by Hardware Sentry based on the discovered devices and their current usage.",
+          "id": 156,
+          "links": [],
+          "title": "Power Consumption",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#808080",
+                    "mode": "fixed"
+                  },
+                  "mappings": [
                     {
-                      "color": "green",
-                      "value": 0.99
+                      "options": {
+                        "estimated": {
+                          "index": 0,
+                          "text": "Estimated"
+                        },
+                        "measured": {
+                          "index": 1,
+                          "text": "Measured "
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "noValue": "N/A",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "fields": "/^Power Consumption Reading Type$/",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 28
+                },
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-158": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": true,
+                        "expr": "sum(rate(hw_network_io_bytes_total{site=~\"$site\", host_name=~\"$host_name\", direction=\"transmit\"}[5m]))",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "Transmitted"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(hw_network_io_bytes_total{site=~\"$site\", host_name=~\"$host_name\", direction=\"receive\"}[5m]))",
+                        "legendFormat": "Received",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Data transmitted and received by the host.\n\nPositive values correspond to transmitted data.\nNegative values correspond to received data.",
+          "id": 158,
+          "links": [],
+          "title": "Total Traffic (bytes/s)",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-YlBl"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 21,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "Bps"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Received"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.transform",
+                        "value": "negative-Y"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "last",
+                    "min",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-173": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": true,
+                        "expr": "hw_fan_speed_rpm{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "instant": false,
+                        "interval": "",
+                        "intervalFactor": 5,
+                        "legendFormat": "{{name}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The reading of the host's fans speed (when available).",
+          "id": 173,
+          "links": [],
+          "title": "Fans Speed",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "graph": false,
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "rotrpm"
+                },
+                "overrides": []
+              },
+              "options": {
+                "graph": {},
+                "legend": {
+                  "calcs": [
+                    "last",
+                    "min",
+                    "max"
+                  ],
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-175": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "hw_status{site=~\"$site\", host_name=~\"$host_name\", hw_type=\"network\", state=\"present\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "exemplar": false,
+                        "expr": "hw_network_up{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "seriesToColumns",
+                  "spec": {
+                    "id": "seriesToColumns",
+                    "options": {
+                      "byField": "id"
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "device_id",
+                          "info",
+                          "logical_address",
+                          "model",
+                          "name",
+                          "physical_address",
+                          "serial_number",
+                          "vendor",
+                          "Value #C"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Value #A": true,
+                        "Value #B": true,
+                        "__name__": true,
+                        "__name__ 1": true,
+                        "__name__ 2": true,
+                        "__name__ 3": true,
+                        "__name__ 4": true,
+                        "agent_host_name": true,
+                        "agent_host_name 1": true,
+                        "agent_host_name 2": true,
+                        "agent_host_name 3": true,
+                        "agent_host_name 4": true,
+                        "bandwidth 2": true,
+                        "bandwidth 3": true,
+                        "deviceId": true,
+                        "device_id 1": true,
+                        "device_id 2": true,
+                        "device_id 3": true,
+                        "device_id 4": true,
+                        "fqdn 1": true,
+                        "fqdn 2": true,
+                        "fqdn 3": true,
+                        "fqdn 4": true,
+                        "host_id": true,
+                        "host_id 1": true,
+                        "host_id 2": true,
+                        "host_id 3": true,
+                        "host_id 4": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_name 3": true,
+                        "host_name 4": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "host_type 3": true,
+                        "host_type 4": true,
+                        "hw_type": true,
+                        "hw_type 1": true,
+                        "hw_type 2": true,
+                        "id": true,
+                        "identifying_information 2": true,
+                        "identifying_information 3": true,
+                        "info 1": true,
+                        "info 2": true,
+                        "info 3": true,
+                        "info 4": true,
+                        "instance 1": true,
+                        "instance 2": true,
+                        "instance 3": true,
+                        "instance 4": true,
+                        "job 1": true,
+                        "job 2": true,
+                        "job 3": true,
+                        "job 4": true,
+                        "label": false,
+                        "label 2": true,
+                        "label 3": true,
+                        "label 4": true,
+                        "logical_address 1": true,
+                        "logical_address 2": true,
+                        "logical_address 3": true,
+                        "logical_address 4": true,
+                        "model 1": false,
+                        "model 2": true,
+                        "model 3": true,
+                        "model 4": true,
+                        "name 2": true,
+                        "name 3": true,
+                        "name 4": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "os_type 3": true,
+                        "os_type 4": true,
+                        "parent": true,
+                        "parent 1": true,
+                        "parent 2": true,
+                        "parent 3": true,
+                        "parent 4": true,
+                        "physical_address 2": true,
+                        "physical_address 3": true,
+                        "physical_address 4": true,
+                        "remote_physical_address 2": true,
+                        "remote_physical_address 3": true,
+                        "serial_number 1": true,
+                        "serial_number 2": true,
+                        "serial_number 3": true,
+                        "serial_number 4": true,
+                        "site": true,
+                        "site 1": true,
+                        "site 2": true,
+                        "site 3": true,
+                        "site 4": true,
+                        "state": true,
+                        "state 1": true,
+                        "state 2": true,
+                        "vendor 1": false,
+                        "vendor 2": true,
+                        "vendor 3": true,
+                        "vendor 4": true,
+                        "zone 1": true,
+                        "zone 2": true,
+                        "zone 3": true,
+                        "zone 4": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Value #C": 4,
+                        "model 1": 1,
+                        "model 2": 7,
+                        "name 1": 2,
+                        "name 2": 5,
+                        "physical_address 1": 3,
+                        "physical_address 2": 6,
+                        "vendor 1": 0,
+                        "vendor 2": 8
+                      },
+                      "renameByName": {
+                        "Value": "Present",
+                        "Value #A": "",
+                        "Value #B": "",
+                        "Value #C": "Link Status",
+                        "Value #D": "Duplex Mode",
+                        "__name__ 1": "",
+                        "additionalInformation1": "Additional Information",
+                        "bandwidth": "Bandwith",
+                        "bandwidth 1": "Bandwith",
+                        "device_id": "Device ID",
+                        "device_id 1": "",
+                        "fqdn 3": "",
+                        "hw_type 2": "",
+                        "identifying_information": "Identifying Information",
+                        "identifying_information 1": "Identifying Information",
+                        "info": "Information",
+                        "info 1": "Information",
+                        "label": "Name",
+                        "label 1": "Label",
+                        "logical_address": "Logical Address",
+                        "logical_address 1": "Logical Address",
+                        "maximumSpeed": "Maximum Speed",
+                        "maximum_speed": "Maximum Speed",
+                        "model": "Model",
+                        "model 1": "Model",
+                        "name": "Name",
+                        "name 1": "Name",
+                        "physical_address": "Physical Address",
+                        "physical_address 1": "Physical Address",
+                        "physical_address 3": "",
+                        "remote_physical_address": "Remote Physical Address",
+                        "remote_physical_address 1": "Remote Physical Address",
+                        "serial_number": "Serial Number",
+                        "serial_number 1": "Serial Number",
+                        "state": "",
+                        "state 2": "",
+                        "vendor": "Manufacturer",
+                        "vendor 1": "Vendor"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "Device ID"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The network interfaces and their current link status (plugged or unplugged).",
+          "id": 175,
+          "links": [],
+          "title": "Network Links",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "left",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Link Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "0": {
+                                "color": "orange",
+                                "index": 1,
+                                "text": "Unplugged"
+                              },
+                              "1": {
+                                "color": "transparent",
+                                "index": 0,
+                                "text": "Plugged"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Link Status"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-182": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": true,
+                        "expr": "hw_network_bandwidth_utilization_ratio{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "{{name}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The network interfaces bandwidth utilization.\n\nThe bandwidth utilization should stay under 90% at all times.",
+          "id": 182,
+          "links": [],
+          "title": "Bandwidth Utilization",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "area"
+                    }
+                  },
+                  "decimals": 0,
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 0.9
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "last",
+                    "min",
+                    "max"
+                  ],
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-183": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(hw_errors_total{site=\"$site\", host_name=\"$host_name\", hw_type=\"network\"})\r\n/ \r\n(sum(hw_network_packets_total{site=\"$site\", host_name=\"$host_name\", direction=\"receive\"})\r\n+ sum(hw_network_packets_total{site=\"$site\", host_name=\"$host_name\", direction=\"transmit\"}) * 100)",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The highest network interface error ratio (total traffic vs errors).\n\nThis value should be at 0% or as close to 0% as possible.",
+          "id": 183,
+          "links": [],
+          "title": "Max Error Ratio",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "min": -1,
+                  "noValue": "-",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": 0
+                      },
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 0.01
+                      },
+                      {
+                        "color": "red",
+                        "value": 10
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-188": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(hw_physical_disk_size_bytes{site=~\"$site\", host_name=~\"$host_name\"}) or avg(storage_size_bytes{site=~\"$site\", host_name=~\"$host_name\"})",
+                        "legendFormat": "Disk Size",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The total disk size of the host (when available).",
+          "id": 188,
+          "links": [],
+          "title": "Disk Size",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "-",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "decbytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-189": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "avg(hw_fan_speed_rpm{site=~\"$site\", host_name=~\"$host_name\"})",
+                        "legendFormat": "Average Fan Speed",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The average speed of all the host's fans.",
+          "id": 189,
+          "links": [],
+          "title": "Avg Fan Speed",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "rotrpm"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-194": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "min_over_time(timestamp(metricshub_host_configured{site=~\"$site\", host_name=\"$host_name\"})[1y:1d])",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "__auto"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": [
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Collect Started",
+                      "binary": {
+                        "left": "Value",
+                        "operator": "*",
+                        "reducer": "sum",
+                        "right": "1000"
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "include": [
+                          "Last Seen"
+                        ],
+                        "reducer": "last"
+                      },
+                      "replaceFields": false
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "agent_host_name",
+                          "site",
+                          "Collect Started"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Value": true,
+                        "Value #A": true,
+                        "__name__": true,
+                        "agent_host_name": false,
+                        "build_number": true,
+                        "build_number 2": true,
+                        "hc_version 2": true,
+                        "host_id": true,
+                        "host_id 1": true,
+                        "host_id 2": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "project_name": true,
+                        "project_name 1": true,
+                        "project_name 2": true,
+                        "project_version 2": true,
+                        "service_name": true,
+                        "service_name 1": true,
+                        "service_name 2": true,
+                        "site 2": true,
+                        "timestamp": true,
+                        "timestamp 1": true,
+                        "timestamp 2": true
+                      },
+                      "indexByName": {
+                        "Last Seen": 15,
+                        "Time": 6,
+                        "Value": 14,
+                        "agent_host_name": 1,
+                        "build_date": 3,
+                        "build_number": 4,
+                        "hc_version": 5,
+                        "host_id": 7,
+                        "host_name": 8,
+                        "host_type": 9,
+                        "os_type": 10,
+                        "project_name": 11,
+                        "project_version": 2,
+                        "service_name": 12,
+                        "site": 0,
+                        "timestamp": 13
+                      },
+                      "renameByName": {
+                        "Time": "",
+                        "Value": "",
+                        "agent_host_name": "Hostname",
+                        "build_date": "Agent Build Date",
+                        "build_number": "",
+                        "build_number 1": "Agent Build Number",
+                        "hc_version": "Connectors Version",
+                        "hc_version 1": "Connectors Version",
+                        "project_version": "Agent Version",
+                        "project_version 1": "Agent Version",
+                        "site": "Site",
+                        "site 1": "Site",
+                        "timestamp": ""
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Time since the monitoring of this host by Hardware Sentry was started.",
+          "id": 194,
+          "links": [],
+          "title": "Collect Started",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "text",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "dateTimeFromNow"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value * 1000"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Collect Started"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-196": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": true,
+                        "expr": "hw_physical_disk_endurance_utilization_ratio{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "{{name}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The disks remaining lifetime in percentage.\n\nA value lower than 3% indicates that the disk should be replaced.",
+          "id": 196,
+          "links": [],
+          "title": "Endurance Remaining",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "area"
+                    }
+                  },
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 0.1
+                      },
+                      {
+                        "color": "transparent",
+                        "value": 0.3
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-206": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "ALERTS_FOR_STATE{host_name=~\"$host_name\", site=~\"$site\", alertname=~\"MetricsHub-Hardware-.*\"}",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "Time",
+                          "name",
+                          "severity",
+                          "hw_type",
+                          "protocol"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": false,
+                        "Value": true,
+                        "Value #A": true,
+                        "__name__": true,
+                        "agent_host_name": true,
+                        "alertstatus": true,
+                        "alertstatus_code": true,
+                        "applies_to_os": true,
+                        "array_name": true,
+                        "bandwidth": true,
+                        "battery_state": true,
+                        "blade_name": true,
+                        "chemistry": true,
+                        "compiled_file_name": true,
+                        "connector_id": true,
+                        "description": true,
+                        "device_id": true,
+                        "device_type": true,
+                        "display_name": true,
+                        "driver_version": true,
+                        "firmware_version": true,
+                        "fqdn": true,
+                        "host_id": true,
+                        "host_name": true,
+                        "host_type": true,
+                        "hw_type": false,
+                        "id": true,
+                        "identifying_information": true,
+                        "info": true,
+                        "instance": true,
+                        "job": true,
+                        "local_device_name": true,
+                        "location": true,
+                        "model": true,
+                        "name": false,
+                        "os_type": true,
+                        "parent": true,
+                        "physical_address": true,
+                        "power_supply_type": true,
+                        "raid_level": true,
+                        "robotic_type": true,
+                        "sensor_location": true,
+                        "serial_number": true,
+                        "severity": false,
+                        "site": true,
+                        "state": true,
+                        "type": true,
+                        "vendor": true,
+                        "wwn": true,
+                        "zone": true
+                      },
+                      "indexByName": {
+                        "Time": 0,
+                        "Value": 13,
+                        "array_name": 20,
+                        "battery_state": 23,
+                        "device_id": 14,
+                        "driver_version": 27,
+                        "firmware_version": 28,
+                        "host_id": 7,
+                        "host_name": 8,
+                        "host_type": 9,
+                        "hw_type": 2,
+                        "id": 5,
+                        "info": 15,
+                        "local_device_name": 21,
+                        "location": 19,
+                        "model": 16,
+                        "name": 3,
+                        "os_type": 10,
+                        "parent": 6,
+                        "power_supply_type": 26,
+                        "protocol": 4,
+                        "robotic_type": 25,
+                        "sensor_location": 29,
+                        "serial_number": 24,
+                        "severity": 1,
+                        "site": 11,
+                        "state": 12,
+                        "type": 17,
+                        "vendor": 18,
+                        "wwn": 22
+                      },
+                      "renameByName": {
+                        "Time": "Time",
+                        "alertname": "Alert Name",
+                        "fqdn": "",
+                        "hw_type": "Device Type",
+                        "id": "",
+                        "label": "Label",
+                        "name": "Device Name",
+                        "protocol": "Protocol",
+                        "severity": "Severity"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "Time"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 206,
+          "links": [],
+          "title": "Current Hardware Alerts",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "noValue": "No alerts",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Severity"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 109
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "critical": {
+                                "color": "red",
+                                "index": 1,
+                                "text": "Critical"
+                              },
+                              "warning": {
+                                "color": "orange",
+                                "index": 0,
+                                "text": "Warning"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "protocol"
+                    },
+                    "properties": [
+                      {
+                        "id": "noValue",
+                        "value": "N/A"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Device Type"
+                    },
+                    "properties": [
+                      {
+                        "id": "noValue",
+                        "value": "N/A"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Time"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 219
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Time"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-211": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 211,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<h6 style=\"background-color:DimGreen\"><center>Cumulative Cost</center></h6>",
+                "mode": "html"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-212": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 212,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<h5 style=\"background-color:yyyyy\"><center>Cumulative CO₂</center></h5>",
+                "mode": "html"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-214": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (hw_type) (hw_energy_joules_total{site=~\"$site\", host_name=~\"$host_name\"})",
+                        "legendFormat": "{{hw_type}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The breakdown of the host's energy consumption per components.",
+          "id": 214,
+          "links": [],
+          "title": "Power per Device Type",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "displayLabels": [
+                  "name",
+                  "percent"
+                ],
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": false
+                },
+                "pieType": "donut",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-231": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg(hw_cpu_speed_hertz{site=~\"$site\", host_name=~\"$host_name\"})",
+                        "legendFormat": "Speed",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(hw_energy_joules_total{site=~\"$site\", host_name=~\"$host_name\", hw_type=\"cpu\"}[5m]))",
+                        "legendFormat": " Consumption",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 231,
+          "links": [],
+          "title": "CPUs Speed and Power Consumption",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Speed"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "rothz"
+                      },
+                      {
+                        "id": "custom.axisPlacement",
+                        "value": "left"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": " Consumption"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "watt"
+                      },
+                      {
+                        "id": "custom.axisPlacement",
+                        "value": "right"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-259": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "hw_voltage_volts{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "legendFormat": "{{name}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The reading of the host's voltage sensors (when available).",
+          "id": 259,
+          "links": [],
+          "title": "Voltages",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "volt"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "min",
+                    "max",
+                    "mean",
+                    "lastNotNull"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-261": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "hw_battery_charge_ratio{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "legendFormat": "{{name}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The percentage of battery charge (when available).",
+          "id": 261,
+          "links": [],
+          "title": "Battery Charge",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-286": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(hw_memory_limit_bytes{site=~\"$site\", host_name=~\"$host_name\"})",
+                        "legendFormat": "Memory Size",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The total memory size of the host (when available).",
+          "id": 286,
+          "links": [],
+          "title": "Memory",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "-",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-287": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "max(hw_cpu_speed_limit_hertz{site=~\"$site\", host_name=~\"$host_name\"})",
+                        "instant": true,
+                        "legendFormat": "CPU Maximum Speed",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The maximum speed of the host's CPU (when available).",
+          "id": 287,
+          "links": [],
+          "title": "CPU Max Speed",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "-",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "rothz"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-307": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count by (hw_type) (hw_status{site=~\"$site\", host_name=\"$host_name\", state=\"present\"})",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "{{ name}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": [
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "__name__": true,
+                        "agent_host_name": true,
+                        "device_id": true,
+                        "host_id": true,
+                        "host_name": true,
+                        "host_type": true,
+                        "id": true,
+                        "name": false,
+                        "os_type": true,
+                        "parent": true,
+                        "raid_level": true,
+                        "site": true
+                      },
+                      "indexByName": {},
+                      "renameByName": {}
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "hw_type"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The total number of discovered devices and sensors per type.",
+          "id": 307,
+          "links": [],
+          "title": "Monitored Devices",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "continuous-blues"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "battery": {
+                          "index": 0,
+                          "text": "Battery"
+                        },
+                        "blade": {
+                          "index": 1,
+                          "text": "Blade"
+                        },
+                        "cpu": {
+                          "index": 2,
+                          "text": "CPU"
+                        },
+                        "cpu_core": {
+                          "index": 3,
+                          "text": "CPU Core"
+                        },
+                        "disk_controller": {
+                          "index": 4,
+                          "text": "Disk Controller"
+                        },
+                        "enclosure": {
+                          "index": 5,
+                          "text": "Enclosure"
+                        },
+                        "fan": {
+                          "index": 6,
+                          "text": "Fan"
+                        },
+                        "gpu": {
+                          "index": 7,
+                          "text": "GPU"
+                        },
+                        "led": {
+                          "index": 8,
+                          "text": "LED"
+                        },
+                        "logical_disk": {
+                          "index": 9,
+                          "text": "Logical Disk"
+                        },
+                        "lun": {
+                          "index": 10,
+                          "text": "LUN"
+                        },
+                        "memory": {
+                          "index": 11,
+                          "text": "Memory"
+                        },
+                        "network": {
+                          "index": 12,
+                          "text": "Network"
+                        },
+                        "other_device": {
+                          "index": 13,
+                          "text": "Other Device"
+                        },
+                        "physical_disk": {
+                          "index": 14,
+                          "text": "Physical Disk"
+                        },
+                        "power_supply": {
+                          "index": 15,
+                          "text": "Power Supply"
+                        },
+                        "robotics": {
+                          "index": 16,
+                          "text": "Robotics"
+                        },
+                        "tape_drive": {
+                          "index": 17,
+                          "text": "Tape Drive"
+                        },
+                        "temperature": {
+                          "index": 18,
+                          "text": "Temperature"
+                        },
+                        "vm": {
+                          "index": 19,
+                          "text": "VM"
+                        },
+                        "voltage": {
+                          "index": 20,
+                          "text": "Voltage"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "max": 10,
+                  "min": -10,
+                  "noValue": "No discovered devices",
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "fields": "",
+                  "values": true
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-316": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(rate(hw_errors_total{site=~\"$site\", host_name=~\"$host_name\"}[1h])) by (hw_type)",
+                        "instant": false,
+                        "legendFormat": "{{hw_type}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {},
+                      "indexByName": {},
+                      "renameByName": {
+                        "cpu": "CPU",
+                        "gpu": "GPU",
+                        "logical_disk": "Logical Disk",
+                        "memory": "Memory",
+                        "network": "Network",
+                        "physical_disk": "Physical Disk",
+                        "robotics": "Robotics",
+                        "tape_drive": "Tape Drive"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The number of detected errors per hour and component type (when available).",
+          "id": 316,
+          "links": [],
+          "title": "Errors per Hour",
+          "vizConfig": {
+            "group": "heatmap",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "scaleDistribution": {
+                      "type": "linear"
+                    }
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "calculate": false,
+                "calculation": {},
+                "cellGap": 2,
+                "cellValues": {
+                  "unit": "Error"
+                },
+                "color": {
+                  "exponent": 0.5,
+                  "fill": "dark-orange",
+                  "max": 0.8,
+                  "min": 0,
+                  "mode": "scheme",
+                  "reverse": false,
+                  "scale": "exponential",
+                  "scheme": "RdYlGn",
+                  "steps": 128
+                },
+                "exemplars": {
+                  "color": "rgba(255,0,255,0.7)"
+                },
+                "filterValues": {
+                  "le": -1
+                },
+                "legend": {
+                  "show": true,
+                  "showLegend": true
+                },
+                "rowsFrame": {
+                  "layout": "auto"
+                },
+                "showValue": "never",
+                "tooltip": {
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "showColorScale": false,
+                  "yHistogram": false
+                },
+                "yAxis": {
+                  "axisPlacement": "left",
+                  "reverse": true,
+                  "unit": "short"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-317": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "exemplar": false,
+                        "expr": "hw_status{site=~\"$site\", host_name=~\"$host_name\", hw_type=\"enclosure\"}",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "host_type"
+                        ]
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 317,
+          "links": [],
+          "title": "Host Type",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#808080",
+                    "mode": "fixed"
+                  },
+                  "noValue": "N/A",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "host_type"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Host Type"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "fields": "/.*/",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 24
+                },
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-319": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "exemplar": false,
+                        "expr": "hw_status{site=~\"$site\", host_name=~\"$host_name\", hw_type=\"enclosure\"}",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "pattern": "(vendor|model)"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {},
+                      "indexByName": {
+                        "model": 1,
+                        "vendor": 0
+                      },
+                      "renameByName": {}
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The vendor and model information of the host (when available).",
+          "id": 319,
+          "links": [],
+          "title": "Vendor and Model",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#808080",
+                    "mode": "fixed"
+                  },
+                  "noValue": "N/A",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "vendor"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Host Vendor"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "model"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Host Model"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "fields": "/.*/",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 24
+                },
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-320": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "hw_logical_disk_limit_bytes{site=~\"$site\", host_name=~\"$host_name\"}",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "{{ name}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": [
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "name",
+                          "site",
+                          "Value"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Value": false,
+                        "__name__": true,
+                        "agent_host_name": true,
+                        "device_id": true,
+                        "host_id": true,
+                        "host_name": true,
+                        "host_type": true,
+                        "id": true,
+                        "info": true,
+                        "name": false,
+                        "os_type": true,
+                        "parent": true,
+                        "raid_level": true,
+                        "site": true
+                      },
+                      "indexByName": {},
+                      "renameByName": {
+                        "Value": "Size",
+                        "name": "Name"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "desc": true,
+                          "field": "Name"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 320,
+          "links": [],
+          "title": "Logical Disks",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "text",
+                        "value": 0
+                      },
+                      {
+                        "color": "blue",
+                        "value": 0.1
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Size"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Name"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-321": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[1d:5m]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m])) * 24",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Daily Consumption"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall power consumption reported for the host in last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
+          "id": 321,
+          "links": [],
+          "title": "Daily",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-325": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_join(hw_status{site=~\"$site\", host_name=~\"$host_name\", state=\"ok\"} > 0 or hw_status{site=~\"$site\", host_name=~\"$host_name\",  state=\"degraded\"} > 0 or hw_status{site=~\"$site\", host_name=~\"$host_name\", state=\"failed\"} > 0, \"device_id\", \"_\", \"hw_type\", \"id\")",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_join(hw_status{site=~\"$site\", host_name=~\"$host_name\", state=\"present\"}, \"device_id\", \"_\", \"hw_type\", \"id\")",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_join(hw_status{site=~\"$site\", host_name=~\"$host_name\", state=\"predicted_failure\"}, \"device_id\", \"_\", \"hw_type\", \"id\")",
+                        "format": "table",
+                        "instant": true,
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "seriesToColumns",
+                  "spec": {
+                    "id": "seriesToColumns",
+                    "options": {
+                      "byField": "device_id",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "byVariable": false,
+                      "include": {
+                        "pattern": "(name 1|name 2|info 1|info 2|Value #B|state 1|Value #C|hw_type 1|hw_type 2|id)"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Type",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "hw_type 2",
+                          "hw_type 1"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Name",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "name 1",
+                          "name 2"
+                        ],
+                        "reducer": "lastNotNull"
+                      },
+                      "replaceFields": false
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Information",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "info 1",
+                          "info 2"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Value": false,
+                        "Value #A": false,
+                        "Value #B": false,
+                        "__name__": true,
+                        "__name__ 1": true,
+                        "__name__ 2": false,
+                        "__name__ 3": true,
+                        "__name__ 4": true,
+                        "agent_host_name": true,
+                        "agent_host_name 1": true,
+                        "agent_host_name 2": true,
+                        "agent_host_name 3": true,
+                        "agent_host_name 4": true,
+                        "deviceId": true,
+                        "device_id 1": true,
+                        "device_id 2": true,
+                        "device_id 3": true,
+                        "device_id 4": true,
+                        "fqdn 1": true,
+                        "fqdn 2": true,
+                        "fqdn 3": true,
+                        "fqdn 4": true,
+                        "host_id": true,
+                        "host_id 1": true,
+                        "host_id 2": true,
+                        "host_id 3": true,
+                        "host_id 4": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_name 3": true,
+                        "host_name 4": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "host_type 3": true,
+                        "host_type 4": true,
+                        "hw_type": false,
+                        "hw_type 1": true,
+                        "hw_type 2": true,
+                        "hw_type 3": true,
+                        "id": false,
+                        "identifying_information 2": true,
+                        "identifying_information 3": true,
+                        "info 1": true,
+                        "info 2": true,
+                        "info 3": true,
+                        "info 4": true,
+                        "instance 1": true,
+                        "instance 2": true,
+                        "instance 3": true,
+                        "instance 4": true,
+                        "job 1": true,
+                        "job 2": true,
+                        "job 3": true,
+                        "job 4": true,
+                        "label": false,
+                        "label 2": true,
+                        "label 3": true,
+                        "label 4": true,
+                        "limit_type": true,
+                        "model 2": true,
+                        "model 3": true,
+                        "model 4": true,
+                        "name 1": true,
+                        "name 2": true,
+                        "name 3": true,
+                        "name 4": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "os_type 3": true,
+                        "os_type 4": true,
+                        "parent": true,
+                        "parent 1": true,
+                        "parent 2": true,
+                        "parent 3": true,
+                        "parent 4": true,
+                        "site": true,
+                        "site 1": true,
+                        "site 2": true,
+                        "site 3": true,
+                        "site 4": true,
+                        "state 1": false,
+                        "state 2": true,
+                        "state 3": true,
+                        "vendor 2": true,
+                        "vendor 3": true,
+                        "vendor 4": true,
+                        "zone 1": true,
+                        "zone 2": true,
+                        "zone 3": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Information": 2,
+                        "Name": 1,
+                        "Type": 0,
+                        "Value #B": 3,
+                        "hw_type 1": 6,
+                        "hw_type 2": 5,
+                        "info 1": 8,
+                        "info 2": 10,
+                        "name 1": 7,
+                        "name 2": 9,
+                        "state 1": 4
+                      },
+                      "renameByName": {
+                        "Information": "Information",
+                        "Name": "Name",
+                        "Type": "Type",
+                        "Value": "Present",
+                        "Value #A": "Present",
+                        "Value #B": "Present",
+                        "Value #C": "Predicted Failure",
+                        "Value #D": "Maximum Speed",
+                        "__name__ 2": "Name 2",
+                        "additionalInformation1": "Additional Information",
+                        "device_id": "Device ID",
+                        "device_id 1": "Device ID",
+                        "host_type 2": "",
+                        "hw_type": "Type",
+                        "hw_type 1": "",
+                        "hw_type 2": "Type2",
+                        "identifying_information": "Identifying Information",
+                        "identifying_information 1": "Identifying Information",
+                        "info": "Information",
+                        "info 1": "",
+                        "info 2": "",
+                        "label": "Name",
+                        "label 1": "Label",
+                        "maximumSpeed": "Maximum Speed",
+                        "maximum_speed": "Maximum Speed",
+                        "model": "Model",
+                        "model 1": "Model",
+                        "name": "Name",
+                        "name 1": "",
+                        "name 2": "",
+                        "os_type 1": "",
+                        "state": "",
+                        "state 1": "Status",
+                        "state 2": "",
+                        "state 3": "",
+                        "vendor": "Manufacturer",
+                        "vendor 1": "Vendor"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "Status"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 325,
+          "links": [],
+          "title": "Monitored Devices",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "left",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Present"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "0": {
+                                "color": "red",
+                                "index": 1,
+                                "text": "No"
+                              },
+                              "1": {
+                                "color": "transparent",
+                                "index": 0,
+                                "text": "Yes"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "degraded": {
+                                "color": "orange",
+                                "index": 1,
+                                "text": "Degraded"
+                              },
+                              "failed": {
+                                "color": "red",
+                                "index": 2,
+                                "text": "Failed"
+                              },
+                              "ok": {
+                                "color": "transparent",
+                                "index": 0,
+                                "text": "OK"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Predicted Failure"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "0": {
+                                "color": "transparent",
+                                "index": 0,
+                                "text": "OK"
+                              },
+                              "1": {
+                                "color": "red",
+                                "index": 1,
+                                "text": "Failure Predicted"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Device ID"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Present"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "0": {
+                                "color": "red",
+                                "index": 0,
+                                "text": "No"
+                              },
+                              "1": {
+                                "index": 1,
+                                "text": "Yes"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Type"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "battery": {
+                                "index": 11,
+                                "text": "Battery"
+                              },
+                              "blade": {
+                                "index": 12,
+                                "text": "Blade"
+                              },
+                              "cpu": {
+                                "index": 0,
+                                "text": "CPU"
+                              },
+                              "disk_controller": {
+                                "index": 1,
+                                "text": "Disk Controller"
+                              },
+                              "enclosure": {
+                                "index": 10,
+                                "text": "Enclosure"
+                              },
+                              "fan": {
+                                "index": 2,
+                                "text": "Fan"
+                              },
+                              "gpu": {
+                                "index": 13,
+                                "text": "GPU"
+                              },
+                              "led": {
+                                "index": 14,
+                                "text": "LED"
+                              },
+                              "logical_disk": {
+                                "index": 15,
+                                "text": "Logical Disk"
+                              },
+                              "lun": {
+                                "index": 16,
+                                "text": "LUN"
+                              },
+                              "memory": {
+                                "index": 3,
+                                "text": "Memory Module"
+                              },
+                              "network": {
+                                "index": 4,
+                                "text": "Network Interface"
+                              },
+                              "other_device": {
+                                "index": 5,
+                                "text": "Other Device"
+                              },
+                              "physical_disk": {
+                                "index": 6,
+                                "text": "Physical Disk"
+                              },
+                              "power_supply": {
+                                "index": 7,
+                                "text": "Power Supply"
+                              },
+                              "robotics": {
+                                "index": 17,
+                                "text": "Robotics"
+                              },
+                              "tape_drive": {
+                                "index": 18,
+                                "text": "Tape Drive"
+                              },
+                              "temperature": {
+                                "index": 8,
+                                "text": "Temperature"
+                              },
+                              "vm": {
+                                "index": 19,
+                                "text": "Virtual Machine"
+                              },
+                              "voltage": {
+                                "index": 9,
+                                "text": "Voltage"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 204
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Name"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 426
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Type"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-326": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum_over_time(metricshub_host_up{host_name=\"$host_name\"}[$__range]) / count_over_time(metricshub_host_up{host_name=\"$host_name\"}[$__range])",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Percentage"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "min_over_time(\r\n  (\r\n    (metricshub_host_response_time_seconds{host_name=\"$host_name\"} > 0) * 1 or\r\n    (metricshub_host_response_time_seconds{host_name=\"$host_name\"} <= 0) * +Inf\r\n  )[$__range:1m]\r\n)",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Min"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(metricshub_host_response_time_seconds{host_name=\"$host_name\"}[$__range])",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "{{protocol}}",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Avg"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "max_over_time(metricshub_host_response_time_seconds{host_name=\"$host_name\"}[$__range])",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "{{protocol}}",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Max"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "metricshub_host_response_time_seconds{host_name=\"$host_name\"}",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "{{protocol}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "metricshub_host_up{site=\"$site\", host_name=\"$host_name\"}",
+                        "instant": false,
+                        "legendFormat": "{{protocol}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "UP"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "metricshub_host_up{site=\"$site\", host_name=\"$host_name\"}",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Status"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "timeSeriesTable",
+                  "spec": {
+                    "id": "timeSeriesTable",
+                    "options": {
+                      "A": {
+                        "stat": "lastNotNull",
+                        "timeField": "Time"
+                      },
+                      "Avg": {
+                        "timeField": "Time"
+                      },
+                      "B": {
+                        "timeField": "Time"
+                      },
+                      "Max": {
+                        "timeField": "Time"
+                      },
+                      "Min": {
+                        "timeField": "Time"
+                      },
+                      "Percentage": {
+                        "timeField": "Time"
+                      },
+                      "Status": {
+                        "timeField": "Time"
+                      },
+                      "UP": {
+                        "timeField": "Time"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "protocol",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Status",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #Status"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "disabled": true,
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Status Over Time",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #UP"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Up Percentage",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #Percentage"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Lowest",
+                          "path": "value"
+                        }
+                      ],
+                      "keepTime": false,
+                      "replace": false,
+                      "source": "Trend #Min"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Average",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #Avg"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Highest",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #Max"
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Lowest": false,
+                        "Trend #Avg": true,
+                        "Trend #Max": true,
+                        "Trend #Min": true,
+                        "Trend #Percentage": true,
+                        "Trend #Status": true,
+                        "Trend #UP": true,
+                        "__name__": true,
+                        "__name__ 1": true,
+                        "__name__ 2": true,
+                        "__name__ 3": true,
+                        "agent_host_name": true,
+                        "agent_host_name 1": true,
+                        "agent_host_name 2": true,
+                        "agent_host_name 3": true,
+                        "agent_host_name 4": true,
+                        "agent_host_name 5": true,
+                        "agent_host_name 6": true,
+                        "agent_host_name 7": true,
+                        "entityName 1": true,
+                        "entityName 2": true,
+                        "entityName 3": true,
+                        "entityName 4": true,
+                        "entityName 5": true,
+                        "entityName 6": true,
+                        "entityName 7": true,
+                        "entityTypeId 1": true,
+                        "entityTypeId 2": true,
+                        "entityTypeId 3": true,
+                        "entityTypeId 4": true,
+                        "entityTypeId 5": true,
+                        "entityTypeId 6": true,
+                        "entityTypeId 7": true,
+                        "host_id": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_name 3": true,
+                        "host_name 4": true,
+                        "host_name 5": true,
+                        "host_name 6": true,
+                        "host_name 7": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "host_type 3": true,
+                        "host_type 4": true,
+                        "host_type 5": true,
+                        "host_type 6": true,
+                        "host_type 7": true,
+                        "hyperv 1": true,
+                        "hyperv 2": true,
+                        "hyperv 3": true,
+                        "hyperv 4": true,
+                        "hyperv 5": true,
+                        "hyperv 6": true,
+                        "hyperv 7": true,
+                        "id": true,
+                        "instanceName 1": true,
+                        "instanceName 2": true,
+                        "instanceName 3": true,
+                        "instanceName 4": true,
+                        "instanceName 5": true,
+                        "instanceName 6": true,
+                        "instanceName 7": true,
+                        "is_endpoint": true,
+                        "location": true,
+                        "name": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "os_type 3": true,
+                        "os_type 4": true,
+                        "os_type 5": true,
+                        "os_type 6": true,
+                        "os_type 7": true,
+                        "otel_scope_name 1": true,
+                        "otel_scope_name 2": true,
+                        "otel_scope_name 3": true,
+                        "otel_scope_name 4": true,
+                        "otel_scope_name 5": true,
+                        "otel_scope_name 6": true,
+                        "otel_scope_name 7": true,
+                        "site": true,
+                        "site 1": true,
+                        "site 2": true,
+                        "site 3": true,
+                        "site 4": true,
+                        "site 5": true,
+                        "site 6": true,
+                        "site 7": true,
+                        "virtual 1": true,
+                        "virtual 2": true,
+                        "virtual 3": true,
+                        "virtual 4": true,
+                        "virtual 5": true,
+                        "virtual 6": true,
+                        "virtual 7": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Average": 5,
+                        "Highest": 6,
+                        "Lowest": 4,
+                        "Status": 1,
+                        "Trend #A": 7,
+                        "Trend #Avg": 40,
+                        "Trend #Max": 18,
+                        "Trend #Min": 29,
+                        "Trend #Percentage": 51,
+                        "Trend #Status": 85,
+                        "Trend #UP": 2,
+                        "Up": 86,
+                        "Up Percentage": 3,
+                        "__name__ 1": 62,
+                        "__name__ 2": 63,
+                        "__name__ 3": 74,
+                        "agent_host_name 1": 8,
+                        "agent_host_name 2": 19,
+                        "agent_host_name 3": 30,
+                        "agent_host_name 4": 41,
+                        "agent_host_name 5": 52,
+                        "agent_host_name 6": 64,
+                        "agent_host_name 7": 75,
+                        "host_id 1": 9,
+                        "host_id 2": 20,
+                        "host_id 3": 31,
+                        "host_id 4": 42,
+                        "host_id 5": 53,
+                        "host_id 6": 65,
+                        "host_id 7": 76,
+                        "host_name 1": 10,
+                        "host_name 2": 21,
+                        "host_name 3": 32,
+                        "host_name 4": 43,
+                        "host_name 5": 54,
+                        "host_name 6": 66,
+                        "host_name 7": 77,
+                        "host_type 1": 11,
+                        "host_type 2": 22,
+                        "host_type 3": 33,
+                        "host_type 4": 44,
+                        "host_type 5": 55,
+                        "host_type 6": 67,
+                        "host_type 7": 78,
+                        "id 1": 12,
+                        "id 2": 23,
+                        "id 3": 34,
+                        "id 4": 45,
+                        "id 5": 56,
+                        "id 6": 68,
+                        "id 7": 79,
+                        "is_endpoint 1": 13,
+                        "is_endpoint 2": 24,
+                        "is_endpoint 3": 35,
+                        "is_endpoint 4": 46,
+                        "is_endpoint 5": 57,
+                        "is_endpoint 6": 69,
+                        "is_endpoint 7": 80,
+                        "location 1": 14,
+                        "location 2": 25,
+                        "location 3": 36,
+                        "location 4": 47,
+                        "location 5": 58,
+                        "location 6": 70,
+                        "location 7": 81,
+                        "name 1": 15,
+                        "name 2": 26,
+                        "name 3": 37,
+                        "name 4": 48,
+                        "name 5": 59,
+                        "name 6": 71,
+                        "name 7": 82,
+                        "os_type 1": 16,
+                        "os_type 2": 27,
+                        "os_type 3": 38,
+                        "os_type 4": 49,
+                        "os_type 5": 60,
+                        "os_type 6": 72,
+                        "os_type 7": 83,
+                        "protocol": 0,
+                        "site 1": 17,
+                        "site 2": 28,
+                        "site 3": 39,
+                        "site 4": 50,
+                        "site 5": 61,
+                        "site 6": 73,
+                        "site 7": 84
+                      },
+                      "renameByName": {
+                        "Lowest": "",
+                        "Max": "Highest",
+                        "Trend #A": "Response Time",
+                        "Trend #UP": "Status Over Time",
+                        "Up Percentage": "",
+                        "name": "",
+                        "protocol": "Protocol",
+                        "site 2": ""
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 326,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "color-background"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Response Time"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "drawStyle": "line",
+                          "fillOpacity": 17,
+                          "gradientMode": "hue",
+                          "hideValue": true,
+                          "lineInterpolation": "stepBefore",
+                          "lineStyle": {
+                            "dash": [
+                              10,
+                              10
+                            ],
+                            "fill": "solid"
+                          },
+                          "type": "sparkline"
+                        }
+                      },
+                      {
+                        "id": "decimals"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Highest"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 7
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-GrYlRd"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Lowest"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 0.5
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-GrYlRd"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Average"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 2
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-GrYlRd"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Up Percentage"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "custom.wrapText",
+                        "value": false
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 0.85
+                            },
+                            {
+                              "color": "green",
+                              "value": 0.99
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Response Time"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.minWidth",
+                        "value": 500
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Protocol"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "http": {
+                                "index": 5,
+                                "text": "HTTP"
+                              },
+                              "ping": {
+                                "index": 0,
+                                "text": "Ping"
+                              },
+                              "snmp": {
+                                "index": 1,
+                                "text": "SNMP"
+                              },
+                              "snmpv3": {
+                                "index": 6,
+                                "text": "SNMP v3"
+                              },
+                              "ssh": {
+                                "index": 2,
+                                "text": "SSH"
+                              },
+                              "wbem": {
+                                "index": 4,
+                                "text": "WBEM"
+                              },
+                              "wmi": {
+                                "index": 3,
+                                "text": "WMI"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "transparent",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend #UP"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "fillOpacity": 3,
+                          "hideValue": true,
+                          "lineInterpolation": "smooth",
+                          "lineStyle": {
+                            "dash": [
+                              10,
+                              10
+                            ],
+                            "fill": "solid"
+                          },
+                          "lineWidth": 1,
+                          "type": "sparkline"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "0": {
+                                "color": "red",
+                                "index": 0,
+                                "text": "Down"
+                              },
+                              "1": {
+                                "color": "green",
+                                "index": 1,
+                                "text": "Up"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "frameIndex": 0,
+                "showHeader": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-327": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {},
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 327,
+          "links": [],
+          "title": "Dashboard Version",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "2026.2",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "light-green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-65": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 65,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<h1 style=\"\">\r\n  <center>${host_name}</center>\r\n</h1>",
+                "mode": "html"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-80": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(ALERTS_FOR_STATE{severity=\"critical\", site=~\"$site\", host_name=~\"$host_name\", alertname=~\"MetricsHub-Hardware-.*\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Critical Alerts"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 80,
+          "links": [],
+          "title": "Critical Alerts",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-81": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(ALERTS_FOR_STATE{severity=\"warning\", site=~\"$site\", host_name=~\"$host_name\", alertname=~\"MetricsHub-Hardware-.*\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Warning Alerts"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 81,
+          "links": [],
+          "title": "Warning Alerts",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-89": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(increase(hw_host_energy_joules_total{site=~\"$site\", host_name=~\"$host_name\"}[$__range])) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[$__range:5m]) / 3600 ",
+                        "legendFormat": "Today's Live Consumption",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "hideTimeOverride": true,
+                "timeFrom": "now/d"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Today's power consumption for the host.",
+          "id": 89,
+          "links": [],
+          "title": "Daily Consumption",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-91": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[1d:5m]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m])) * scalar(avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[1d:5m])) * 24 / 1000",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Daily Cost"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall energy cost reported for the host during the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
+          "id": 91,
+          "links": [],
+          "title": "Daily",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-93": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(increase(hw_host_energy_joules_total{site=~\"$site\", host_name=~\"$host_name\"}[$__range])) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[$__range:5m]) * avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[$__range:5m]) / 3600 / 1000 / 1000",
+                        "legendFormat": "Today's Live CO₂ Emissions",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "hideTimeOverride": true,
+                "timeFrom": "now/d"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Today's CO₂ emitted by the host.",
+          "id": 93,
+          "links": [],
+          "title": "CO₂ Emissions",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masskg"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-95": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[30d:1h]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[30d:1h])) * 24 * 30.437",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Monthly Consumption"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall power consumption reported for the host during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on past collected data.",
+          "id": 95,
+          "links": [],
+          "title": "Monthly",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "semi-dark-blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-97": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[30d:1h]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[30d:1h])) * scalar(avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[30d:1h])) * 30.437 * 24 / 1000",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Monthly Cost"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall energy cost reported for the host during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on past collected data.",
+          "id": 97,
+          "links": [],
+          "title": "Monthly",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "semi-dark-green",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-99": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[30d:1h]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[30d:1h])) * scalar(avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[30d:1h])) * 30.467 * 24 / 1000 / 1000",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Monthly CO₂ Emissions"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall CO₂ emitted by the host during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on the past collected data.",
+          "id": 99,
+          "links": [],
+          "title": "Monthly",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#525252",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masskg"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "hideHeader": true,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-65"
+                        },
+                        "height": 2,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
                     }
                   ]
                 }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Response Time"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
               },
-              {
-                "id": "custom.minWidth",
-                "value": 500
-              }
-            ]
+              "title": ""
+            }
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "Protocol"
-            },
-            "properties": [
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "http": {
-                        "index": 5,
-                        "text": "HTTP"
-                      },
-                      "ping": {
-                        "index": 0,
-                        "text": "Ping"
-                      },
-                      "snmp": {
-                        "index": 1,
-                        "text": "SNMP"
-                      },
-                      "snmpv3": {
-                        "index": 6,
-                        "text": "SNMP v3"
-                      },
-                      "ssh": {
-                        "index": 2,
-                        "text": "SSH"
-                      },
-                      "wbem": {
-                        "index": 4,
-                        "text": "WBEM"
-                      },
-                      "wmi": {
-                        "index": 3,
-                        "text": "WMI"
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-317"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 0,
+                        "y": 0
                       }
                     },
-                    "type": "value"
-                  }
-                ]
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "transparent",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Trend #UP"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "fillOpacity": 3,
-                  "hideValue": true,
-                  "lineInterpolation": "smooth",
-                  "lineStyle": {
-                    "dash": [
-                      10,
-                      10
-                    ],
-                    "fill": "solid"
-                  },
-                  "lineWidth": 1,
-                  "type": "sparkline"
-                }
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 1
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Status"
-            },
-            "properties": [
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "0": {
-                        "color": "red",
-                        "index": 0,
-                        "text": "Down"
-                      },
-                      "1": {
-                        "color": "green",
-                        "index": 1,
-                        "text": "Up"
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-319"
+                        },
+                        "height": 3,
+                        "width": 7,
+                        "x": 2,
+                        "y": 0
                       }
                     },
-                    "type": "value"
-                  }
-                ]
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-80"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 9,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-206"
+                        },
+                        "height": 6,
+                        "width": 12,
+                        "x": 12,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-287"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-286"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 3,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-188"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 6,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-81"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 9,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-326"
+                        },
+                        "height": 5,
+                        "width": 24,
+                        "x": 0,
+                        "y": 6
+                      }
+                    }
+                  ]
+                }
               },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
+              "title": "Host Information, Alerts and Protocols Status"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": true,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-110"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-148"
+                        },
+                        "height": 8,
+                        "width": 8,
+                        "x": 3,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-214"
+                        },
+                        "height": 8,
+                        "width": 5,
+                        "x": 11,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-144"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 16,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-146"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 18,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-211"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 20,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-212"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 22,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-89"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 16,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-321"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 18,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-91"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 20,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-134"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 22,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-109"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-133"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 16,
+                        "y": 4
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-95"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 18,
+                        "y": 4
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-97"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 20,
+                        "y": 4
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-99"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 22,
+                        "y": 4
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-156"
+                        },
+                        "height": 2,
+                        "width": 3,
+                        "x": 0,
+                        "y": 6
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-93"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 16,
+                        "y": 6
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-101"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 18,
+                        "y": 6
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-103"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 20,
+                        "y": 6
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-105"
+                        },
+                        "height": 2,
+                        "width": 2,
+                        "x": 22,
+                        "y": 6
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Power, Costs and CO₂ Emissions"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-307"
+                        },
+                        "height": 9,
+                        "width": 12,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-316"
+                        },
+                        "height": 9,
+                        "width": 12,
+                        "x": 12,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-325"
+                        },
+                        "height": 11,
+                        "width": 24,
+                        "x": 0,
+                        "y": 9
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Devices"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-112"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-122"
+                        },
+                        "height": 8,
+                        "width": 10,
+                        "x": 3,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-173"
+                        },
+                        "height": 8,
+                        "width": 11,
+                        "x": 13,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-125"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-189"
+                        },
+                        "height": 2,
+                        "width": 3,
+                        "x": 0,
+                        "y": 6
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Temperatures and Fans"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-158"
+                        },
+                        "height": 11,
+                        "width": 12,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-175"
+                        },
+                        "height": 6,
+                        "width": 12,
+                        "x": 12,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-183"
+                        },
+                        "height": 5,
+                        "width": 2,
+                        "x": 12,
+                        "y": 6
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-182"
+                        },
+                        "height": 5,
+                        "width": 10,
+                        "x": 14,
+                        "y": 6
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": " Network "
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-231"
+                        },
+                        "height": 8,
+                        "width": 8,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-259"
+                        },
+                        "height": 8,
+                        "width": 8,
+                        "x": 8,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-261"
+                        },
+                        "height": 8,
+                        "width": 8,
+                        "x": 16,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "CPUs, Voltage and Batteries"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-320"
+                        },
+                        "height": 8,
+                        "width": 14,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-196"
+                        },
+                        "height": 8,
+                        "width": 10,
+                        "x": 14,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Disks"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-154"
+                        },
+                        "height": 5,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Monitoring Information"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-194"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-138"
+                        },
+                        "height": 3,
+                        "width": 18,
+                        "x": 3,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-327"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 21,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "MetricsHub Agent Status"
+            }
           }
         ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
-        "y": 9
-      },
-      "id": 326,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "frameIndex": 0,
-        "showHeader": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum_over_time(metricshub_host_up{host_name=\"$host_name\"}[$__range]) / count_over_time(metricshub_host_up{host_name=\"$host_name\"}[$__range])",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Percentage"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "min_over_time(\r\n  (\r\n    (metricshub_host_response_time_seconds{host_name=\"$host_name\"} > 0) * 1 or\r\n    (metricshub_host_response_time_seconds{host_name=\"$host_name\"} <= 0) * +Inf\r\n  )[$__range:1m]\r\n)",
-          "format": "time_series",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Min"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(metricshub_host_response_time_seconds{host_name=\"$host_name\"}[$__range])",
-          "format": "time_series",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "{{protocol}}",
-          "range": false,
-          "refId": "Avg"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max_over_time(metricshub_host_response_time_seconds{host_name=\"$host_name\"}[$__range])",
-          "format": "time_series",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "{{protocol}}",
-          "range": false,
-          "refId": "Max"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "metricshub_host_response_time_seconds{host_name=\"$host_name\"}",
-          "format": "time_series",
-          "instant": false,
-          "legendFormat": "{{protocol}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "metricshub_host_up{site=\"$site\", host_name=\"$host_name\"}",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{protocol}}",
-          "range": true,
-          "refId": "UP"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "metricshub_host_up{site=\"$site\", host_name=\"$host_name\"}",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "Status"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "timeSeriesTable",
-          "options": {
-            "A": {
-              "stat": "lastNotNull",
-              "timeField": "Time"
-            },
-            "Avg": {
-              "timeField": "Time"
-            },
-            "B": {
-              "timeField": "Time"
-            },
-            "Max": {
-              "timeField": "Time"
-            },
-            "Min": {
-              "timeField": "Time"
-            },
-            "Percentage": {
-              "timeField": "Time"
-            },
-            "Status": {
-              "timeField": "Time"
-            },
-            "UP": {
-              "timeField": "Time"
-            }
-          }
-        },
-        {
-          "id": "joinByField",
-          "options": {
-            "byField": "protocol",
-            "mode": "outer"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Status",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #Status"
-          }
-        },
-        {
-          "disabled": true,
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Status Over Time",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #UP"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Up Percentage",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #Percentage"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Lowest",
-                "path": "value"
-              }
-            ],
-            "keepTime": false,
-            "replace": false,
-            "source": "Trend #Min"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Average",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #Avg"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Highest",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #Max"
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Trend #Avg": true,
-              "Trend #Max": true,
-              "Trend #Min": true,
-              "Trend #Percentage": true,
-              "Trend #Status": true,
-              "Trend #UP": true,
-              "__name__": true,
-              "agent_host_name": true,
-              "host_id": true,
-              "host_name": true,
-              "host_type": true,
-              "id": true,
-              "is_endpoint": true,
-              "location": true,
-              "name": true,
-              "os_type": true,
-              "site": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Average": 5,
-              "Highest": 6,
-              "Lowest": 4,
-              "Status": 1,
-              "Trend #A": 7,
-              "Trend #Avg": 40,
-              "Trend #Max": 18,
-              "Trend #Min": 29,
-              "Trend #Percentage": 51,
-              "Trend #Status": 85,
-              "Trend #UP": 2,
-              "Up": 86,
-              "Up Percentage": 3,
-              "__name__ 1": 62,
-              "__name__ 2": 63,
-              "__name__ 3": 74,
-              "agent_host_name 1": 8,
-              "agent_host_name 2": 19,
-              "agent_host_name 3": 30,
-              "agent_host_name 4": 41,
-              "agent_host_name 5": 52,
-              "agent_host_name 6": 64,
-              "agent_host_name 7": 75,
-              "host_id 1": 9,
-              "host_id 2": 20,
-              "host_id 3": 31,
-              "host_id 4": 42,
-              "host_id 5": 53,
-              "host_id 6": 65,
-              "host_id 7": 76,
-              "host_name 1": 10,
-              "host_name 2": 21,
-              "host_name 3": 32,
-              "host_name 4": 43,
-              "host_name 5": 54,
-              "host_name 6": 66,
-              "host_name 7": 77,
-              "host_type 1": 11,
-              "host_type 2": 22,
-              "host_type 3": 33,
-              "host_type 4": 44,
-              "host_type 5": 55,
-              "host_type 6": 67,
-              "host_type 7": 78,
-              "id 1": 12,
-              "id 2": 23,
-              "id 3": 34,
-              "id 4": 45,
-              "id 5": 56,
-              "id 6": 68,
-              "id 7": 79,
-              "is_endpoint 1": 13,
-              "is_endpoint 2": 24,
-              "is_endpoint 3": 35,
-              "is_endpoint 4": 46,
-              "is_endpoint 5": 57,
-              "is_endpoint 6": 69,
-              "is_endpoint 7": 80,
-              "location 1": 14,
-              "location 2": 25,
-              "location 3": 36,
-              "location 4": 47,
-              "location 5": 58,
-              "location 6": 70,
-              "location 7": 81,
-              "name 1": 15,
-              "name 2": 26,
-              "name 3": 37,
-              "name 4": 48,
-              "name 5": 59,
-              "name 6": 71,
-              "name 7": 82,
-              "os_type 1": 16,
-              "os_type 2": 27,
-              "os_type 3": 38,
-              "os_type 4": 49,
-              "os_type 5": 60,
-              "os_type 6": 72,
-              "os_type 7": 83,
-              "protocol": 0,
-              "site 1": 17,
-              "site 2": 28,
-              "site 3": 39,
-              "site 4": 50,
-              "site 5": 61,
-              "site 6": 73,
-              "site 7": 84
-            },
-            "renameByName": {
-              "Lowest": "",
-              "Max": "Highest",
-              "Trend #A": "Response Time",
-              "Trend #UP": "Status Over Time",
-              "Up Percentage": "",
-              "name": "",
-              "protocol": "Protocol",
-              "site 2": ""
-            }
-          }
-        }
-      ],
-      "type": "table"
+      }
     },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 14
-      },
-      "id": 151,
-      "panels": [],
-      "title": "Power, Costs and CO₂ Emissions",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The host's current power usage multiplied by the site's PUE.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 15
-      },
-      "id": 110,
-      "interval": "1h",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"} * scalar(avg(hw_site_pue_ratio{site=~\"$site\"}))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Power * P.U.E",
-          "refId": "A"
-        }
-      ],
-      "title": "Power * P.U.E",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The host's power consumption displayed as a graph.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMin": 0,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "hue",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 2,
-            "pointSize": 6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue"
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 3,
-        "y": 15
-      },
-      "id": 148,
-      "interval": "5m",
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "last"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}",
-          "hide": false,
-          "legendFormat": "Power Consumption",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Power Consumption",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The breakdown of the host's energy consumption per components.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": []
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 5,
-        "x": 11,
-        "y": 15
-      },
-      "id": 214,
-      "options": {
-        "displayLabels": [
-          "name",
-          "percent"
+    "links": [
+      {
+        "asDropdown": false,
+        "icon": "external link",
+        "includeVars": false,
+        "keepTime": true,
+        "tags": [
+          "hw_main"
         ],
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": false
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (hw_type) (hw_energy_joules_total{site=~\"$site\", host_name=~\"$host_name\"})",
-          "hide": false,
-          "legendFormat": "{{hw_type}}",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Power per Device Type",
-      "type": "piechart"
-    },
-    {
-      "description": "",
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 16,
-        "y": 15
-      },
-      "id": 144,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<h6 style=\"background-color:yyyyy\"><center>Today's Live Data</center></h6>",
-        "mode": "html"
-      },
-      "pluginVersion": "12.0.2",
-      "type": "text"
-    },
-    {
-      "description": "",
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 18,
-        "y": 15
-      },
-      "id": 146,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<h6 style=\"background-color:yyyy\"><center>Cumulative Consumption</center></h6>",
-        "mode": "html"
-      },
-      "pluginVersion": "12.0.2",
-      "type": "text"
-    },
-    {
-      "description": "",
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 20,
-        "y": 15
-      },
-      "id": 211,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<h6 style=\"background-color:DimGreen\"><center>Cumulative Cost</center></h6>",
-        "mode": "html"
-      },
-      "pluginVersion": "12.0.2",
-      "type": "text"
-    },
-    {
-      "description": "",
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 22,
-        "y": 15
-      },
-      "id": 212,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<h5 style=\"background-color:yyyyy\"><center>Cumulative CO₂</center></h5>",
-        "mode": "html"
-      },
-      "pluginVersion": "12.0.2",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Today's power consumption for the host.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 16,
-        "y": 17
-      },
-      "hideTimeOverride": true,
-      "id": 89,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(increase(hw_host_energy_joules_total{site=~\"$site\", host_name=~\"$host_name\"}[$__range])) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[$__range:5m]) / 3600 ",
-          "hide": false,
-          "legendFormat": "Today's Live Consumption",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "timeFrom": "now/d",
-      "title": "Daily Consumption",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall power consumption reported for the host in last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 18,
-        "y": 17
-      },
-      "id": 321,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[1d:5m]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m])) * 24",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Daily Consumption",
-          "refId": "A"
-        }
-      ],
-      "title": "Daily",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall energy cost reported for the host during the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 20,
-        "y": 17
-      },
-      "id": 91,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[1d:5m]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m])) * scalar(avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[1d:5m])) * 24 / 1000",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Daily Cost",
-          "refId": "A"
-        }
-      ],
-      "title": "Daily",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall CO₂ emitted by the host during the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "masskg"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 22,
-        "y": 17
-      },
-      "id": 134,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[1d:5m]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m])) * scalar(avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[1d:5m])) * 24 / 1000 / 1000",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Daily CO₂ Emissions",
-          "range": false,
-          "refId": "B"
-        }
-      ],
-      "title": "Daily",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The host's current power consumption.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 18
-      },
-      "id": 109,
-      "interval": "1h",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Power",
-          "refId": "A"
-        }
-      ],
-      "title": "Power",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Today's energy cost for the host.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 16,
-        "y": 19
-      },
-      "hideTimeOverride": true,
-      "id": 133,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(increase(hw_host_energy_joules_total{site=~\"$site\", host_name=~\"$host_name\"}[$__range])) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[$__range:5m]) * avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[$__range:5m]) / 3600 / 1000",
-          "hide": false,
-          "legendFormat": "Today's Live Cost",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "timeFrom": "now/d",
-      "title": "Cost",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall power consumption reported for the host during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "semi-dark-blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue"
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 18,
-        "y": 19
-      },
-      "id": 95,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[30d:1h]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[30d:1h])) * 24 * 30.437",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Monthly Consumption",
-          "refId": "A"
-        }
-      ],
-      "title": "Monthly",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall energy cost reported for the host during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "semi-dark-green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue"
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 20,
-        "y": 19
-      },
-      "id": 97,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[30d:1h]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[30d:1h])) * scalar(avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[30d:1h])) * 30.437 * 24 / 1000",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Monthly Cost",
-          "refId": "A"
-        }
-      ],
-      "title": "Monthly",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall CO₂ emitted by the host during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on the past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#525252",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue"
-              }
-            ]
-          },
-          "unit": "masskg"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 22,
-        "y": 19
-      },
-      "id": 99,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[30d:1h]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[30d:1h])) * scalar(avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[30d:1h])) * 30.467 * 24 / 1000 / 1000",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Monthly CO₂ Emissions",
-          "refId": "A"
-        }
-      ],
-      "title": "Monthly",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The type of power consumption reading:\n- Measured, if the value is reported by the manufacturer's agent\n- Estimated, if the value is estimated by Hardware Sentry based on the discovered devices and their current usage.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#808080",
-            "mode": "fixed"
-          },
-          "links": [],
-          "mappings": [
-            {
-              "options": {
-                "estimated": {
-                  "index": 0,
-                  "text": "Estimated"
-                },
-                "measured": {
-                  "index": 1,
-                  "text": "Measured "
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "noValue": "N/A",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 3,
-        "x": 0,
-        "y": 21
-      },
-      "id": 156,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "/^Power Consumption Reading Type$/",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 28
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Power Consumption Reading Type",
-          "refId": "A"
-        }
-      ],
-      "title": "Power Consumption",
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "quality"
-              ]
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "quality": "Power Consumption Reading Type"
-            }
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Today's CO₂ emitted by the host.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "masskg"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 16,
-        "y": 21
-      },
-      "hideTimeOverride": true,
-      "id": 93,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(increase(hw_host_energy_joules_total{site=~\"$site\", host_name=~\"$host_name\"}[$__range])) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[$__range:5m]) * avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[$__range:5m]) / 3600 / 1000 / 1000",
-          "hide": false,
-          "legendFormat": "Today's Live CO₂ Emissions",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "timeFrom": "now/d",
-      "title": "CO₂ Emissions",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall power consumption reported for the host during the last year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "dark-blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "purple"
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 18,
-        "y": 21
-      },
-      "id": 101,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[1y:1d]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[60d:1d])) * 24 * 365",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Yearly Consumption",
-          "refId": "A"
-        }
-      ],
-      "title": "Yearly",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall energy cost reported for the host in the past year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "dark-green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "purple"
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 20,
-        "y": 21
-      },
-      "id": 103,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[1y:1d]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[60d:1d])) * scalar(avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[1y:1d])) * 365 * 24 / 1000",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Yearly Cost",
-          "refId": "A"
-        }
-      ],
-      "title": "Yearly",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall CO₂ emitted by the host during the past year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#414141",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "purple"
-              }
-            ]
-          },
-          "unit": "masst"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 2,
-        "x": 22,
-        "y": 21
-      },
-      "id": 105,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(hw_host_power_watts{site=~\"$site\", host_name=~\"$host_name\"}[1y:1d]) * scalar(avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[60d:1d])) * scalar(avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[1y:1d])) * 365 * 24 / 1000 / 1000 / 1000",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Yearly CO₂ Emissions",
-          "refId": "A"
-        }
-      ],
-      "title": "Yearly",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 23
-      },
-      "id": 121,
-      "panels": [],
-      "title": "Devices",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The total number of discovered devices and sensors per type.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "continuous-blues"
-          },
-          "links": [],
-          "mappings": [
-            {
-              "options": {
-                "battery": {
-                  "index": 0,
-                  "text": "Battery"
-                },
-                "blade": {
-                  "index": 1,
-                  "text": "Blade"
-                },
-                "cpu": {
-                  "index": 2,
-                  "text": "CPU"
-                },
-                "cpu_core": {
-                  "index": 3,
-                  "text": "CPU Core"
-                },
-                "disk_controller": {
-                  "index": 4,
-                  "text": "Disk Controller"
-                },
-                "enclosure": {
-                  "index": 5,
-                  "text": "Enclosure"
-                },
-                "fan": {
-                  "index": 6,
-                  "text": "Fan"
-                },
-                "gpu": {
-                  "index": 7,
-                  "text": "GPU"
-                },
-                "led": {
-                  "index": 8,
-                  "text": "LED"
-                },
-                "logical_disk": {
-                  "index": 9,
-                  "text": "Logical Disk"
-                },
-                "lun": {
-                  "index": 10,
-                  "text": "LUN"
-                },
-                "memory": {
-                  "index": 11,
-                  "text": "Memory"
-                },
-                "network": {
-                  "index": 12,
-                  "text": "Network"
-                },
-                "other_device": {
-                  "index": 13,
-                  "text": "Other Device"
-                },
-                "physical_disk": {
-                  "index": 14,
-                  "text": "Physical Disk"
-                },
-                "power_supply": {
-                  "index": 15,
-                  "text": "Power Supply"
-                },
-                "robotics": {
-                  "index": 16,
-                  "text": "Robotics"
-                },
-                "tape_drive": {
-                  "index": 17,
-                  "text": "Tape Drive"
-                },
-                "temperature": {
-                  "index": 18,
-                  "text": "Temperature"
-                },
-                "vm": {
-                  "index": 19,
-                  "text": "VM"
-                },
-                "voltage": {
-                  "index": 20,
-                  "text": "Voltage"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "max": 10,
-          "min": -10,
-          "noValue": "No discovered devices",
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "text"
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 0,
-        "y": 24
-      },
-      "id": 307,
-      "interval": "5m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "",
-          "values": true
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count by (hw_type) (hw_status{site=~\"$site\", host_name=\"$host_name\", state=\"present\"})",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{ name}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Monitored Devices",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "__name__": true,
-              "agent_host_name": true,
-              "device_id": true,
-              "host_id": true,
-              "host_name": true,
-              "host_type": true,
-              "id": true,
-              "name": false,
-              "os_type": true,
-              "parent": true,
-              "raid_level": true,
-              "site": true
-            },
-            "indexByName": {},
-            "renameByName": {}
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "hw_type"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The number of detected errors per hour and component type (when available).",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "scaleDistribution": {
-              "type": "linear"
-            }
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 12,
-        "x": 12,
-        "y": 24
-      },
-      "id": 316,
-      "options": {
-        "calculate": false,
-        "calculation": {},
-        "cellGap": 2,
-        "cellValues": {
-          "unit": "Error"
-        },
-        "color": {
-          "exponent": 0.5,
-          "fill": "dark-orange",
-          "max": 0.8,
-          "min": 0,
-          "mode": "scheme",
-          "reverse": false,
-          "scale": "exponential",
-          "scheme": "RdYlGn",
-          "steps": 128
-        },
-        "exemplars": {
-          "color": "rgba(255,0,255,0.7)"
-        },
-        "filterValues": {
-          "le": -1
-        },
-        "legend": {
-          "show": true,
-          "showLegend": true
-        },
-        "rowsFrame": {
-          "layout": "auto"
-        },
-        "showValue": "never",
-        "tooltip": {
-          "maxHeight": 600,
-          "mode": "single",
-          "showColorScale": false,
-          "yHistogram": false
-        },
-        "yAxis": {
-          "axisPlacement": "left",
-          "reverse": true,
-          "unit": "short"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(rate(hw_errors_total{site=~\"$site\", host_name=~\"$host_name\"}[1h])) by (hw_type)",
-          "instant": false,
-          "legendFormat": "{{hw_type}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Errors per Hour",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "cpu": "CPU",
-              "gpu": "GPU",
-              "logical_disk": "Logical Disk",
-              "memory": "Memory",
-              "network": "Network",
-              "physical_disk": "Physical Disk",
-              "robotics": "Robotics",
-              "tape_drive": "Tape Drive"
-            }
-          }
-        }
-      ],
-      "type": "heatmap"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "left",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Present"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "0": {
-                        "color": "red",
-                        "index": 1,
-                        "text": "No"
-                      },
-                      "1": {
-                        "color": "transparent",
-                        "index": 0,
-                        "text": "Yes"
-                      }
-                    },
-                    "type": "value"
-                  }
-                ]
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "basic",
-                  "type": "color-background"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Status"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "basic",
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "degraded": {
-                        "color": "orange",
-                        "index": 1,
-                        "text": "Degraded"
-                      },
-                      "failed": {
-                        "color": "red",
-                        "index": 2,
-                        "text": "Failed"
-                      },
-                      "ok": {
-                        "color": "transparent",
-                        "index": 0,
-                        "text": "OK"
-                      }
-                    },
-                    "type": "value"
-                  }
-                ]
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Predicted Failure"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "basic",
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "0": {
-                        "color": "transparent",
-                        "index": 0,
-                        "text": "OK"
-                      },
-                      "1": {
-                        "color": "red",
-                        "index": 1,
-                        "text": "Failure Predicted"
-                      }
-                    },
-                    "type": "value"
-                  }
-                ]
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Device ID"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "string"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Present"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "basic",
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "0": {
-                        "color": "red",
-                        "index": 0,
-                        "text": "No"
-                      },
-                      "1": {
-                        "index": 1,
-                        "text": "Yes"
-                      }
-                    },
-                    "type": "value"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Type"
-            },
-            "properties": [
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "battery": {
-                        "index": 11,
-                        "text": "Battery"
-                      },
-                      "blade": {
-                        "index": 12,
-                        "text": "Blade"
-                      },
-                      "cpu": {
-                        "index": 0,
-                        "text": "CPU"
-                      },
-                      "disk_controller": {
-                        "index": 1,
-                        "text": "Disk Controller"
-                      },
-                      "enclosure": {
-                        "index": 10,
-                        "text": "Enclosure"
-                      },
-                      "fan": {
-                        "index": 2,
-                        "text": "Fan"
-                      },
-                      "gpu": {
-                        "index": 13,
-                        "text": "GPU"
-                      },
-                      "led": {
-                        "index": 14,
-                        "text": "LED"
-                      },
-                      "logical_disk": {
-                        "index": 15,
-                        "text": "Logical Disk"
-                      },
-                      "lun": {
-                        "index": 16,
-                        "text": "LUN"
-                      },
-                      "memory": {
-                        "index": 3,
-                        "text": "Memory Module"
-                      },
-                      "network": {
-                        "index": 4,
-                        "text": "Network Interface"
-                      },
-                      "other_device": {
-                        "index": 5,
-                        "text": "Other Device"
-                      },
-                      "physical_disk": {
-                        "index": 6,
-                        "text": "Physical Disk"
-                      },
-                      "power_supply": {
-                        "index": 7,
-                        "text": "Power Supply"
-                      },
-                      "robotics": {
-                        "index": 17,
-                        "text": "Robotics"
-                      },
-                      "tape_drive": {
-                        "index": 18,
-                        "text": "Tape Drive"
-                      },
-                      "temperature": {
-                        "index": 8,
-                        "text": "Temperature"
-                      },
-                      "vm": {
-                        "index": 19,
-                        "text": "Virtual Machine"
-                      },
-                      "voltage": {
-                        "index": 9,
-                        "text": "Voltage"
-                      }
-                    },
-                    "type": "value"
-                  }
-                ]
-              },
-              {
-                "id": "custom.width",
-                "value": 204
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Name"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 426
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 24,
-        "x": 0,
-        "y": 33
-      },
-      "id": 325,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "enablePagination": true,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "Type"
-          }
-        ]
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "label_join(hw_status{site=~\"$site\", host_name=~\"$host_name\", state=\"ok\"} > 0 or hw_status{site=~\"$site\", host_name=~\"$host_name\",  state=\"degraded\"} > 0 or hw_status{site=~\"$site\", host_name=~\"$host_name\", state=\"failed\"} > 0, \"device_id\", \"_\", \"hw_type\", \"id\")",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "label_join(hw_status{site=~\"$site\", host_name=~\"$host_name\", state=\"present\"}, \"device_id\", \"_\", \"hw_type\", \"id\")",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "label_join(hw_status{site=~\"$site\", host_name=~\"$host_name\", state=\"predicted_failure\"}, \"device_id\", \"_\", \"hw_type\", \"id\")",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "range": false,
-          "refId": "C"
-        }
-      ],
-      "title": "Monitored Devices",
-      "transformations": [
-        {
-          "id": "seriesToColumns",
-          "options": {
-            "byField": "device_id",
-            "mode": "outer"
-          }
-        },
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "byVariable": false,
-            "include": {
-              "pattern": "(name 1|name 2|info 1|info 2|Value #B|state 1|Value #C|hw_type 1|hw_type 2|id)"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Type",
-            "mode": "reduceRow",
-            "reduce": {
-              "include": [
-                "hw_type 2",
-                "hw_type 1"
-              ],
-              "reducer": "lastNotNull"
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Name",
-            "mode": "reduceRow",
-            "reduce": {
-              "include": [
-                "name 1",
-                "name 2"
-              ],
-              "reducer": "lastNotNull"
-            },
-            "replaceFields": false
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Information",
-            "mode": "reduceRow",
-            "reduce": {
-              "include": [
-                "info 1",
-                "info 2"
-              ],
-              "reducer": "lastNotNull"
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Time 3": true,
-              "Time 4": true,
-              "Value": false,
-              "Value #A": false,
-              "Value #B": false,
-              "__name__": true,
-              "__name__ 1": true,
-              "__name__ 2": false,
-              "__name__ 3": true,
-              "__name__ 4": true,
-              "agent_host_name": true,
-              "agent_host_name 1": true,
-              "agent_host_name 2": true,
-              "agent_host_name 3": true,
-              "agent_host_name 4": true,
-              "deviceId": true,
-              "device_id 1": true,
-              "device_id 2": true,
-              "device_id 3": true,
-              "device_id 4": true,
-              "fqdn 1": true,
-              "fqdn 2": true,
-              "fqdn 3": true,
-              "fqdn 4": true,
-              "host_id": true,
-              "host_id 1": true,
-              "host_id 2": true,
-              "host_id 3": true,
-              "host_id 4": true,
-              "host_name": true,
-              "host_name 1": true,
-              "host_name 2": true,
-              "host_name 3": true,
-              "host_name 4": true,
-              "host_type": true,
-              "host_type 1": true,
-              "host_type 2": true,
-              "host_type 3": true,
-              "host_type 4": true,
-              "hw_type": false,
-              "hw_type 1": true,
-              "hw_type 2": true,
-              "hw_type 3": true,
-              "id": false,
-              "identifying_information 2": true,
-              "identifying_information 3": true,
-              "info 1": true,
-              "info 2": true,
-              "info 3": true,
-              "info 4": true,
-              "instance 1": true,
-              "instance 2": true,
-              "instance 3": true,
-              "instance 4": true,
-              "job 1": true,
-              "job 2": true,
-              "job 3": true,
-              "job 4": true,
-              "label": false,
-              "label 2": true,
-              "label 3": true,
-              "label 4": true,
-              "limit_type": true,
-              "model 2": true,
-              "model 3": true,
-              "model 4": true,
-              "name 1": true,
-              "name 2": true,
-              "name 3": true,
-              "name 4": true,
-              "os_type": true,
-              "os_type 1": true,
-              "os_type 2": true,
-              "os_type 3": true,
-              "os_type 4": true,
-              "parent": true,
-              "parent 1": true,
-              "parent 2": true,
-              "parent 3": true,
-              "parent 4": true,
-              "site": true,
-              "site 1": true,
-              "site 2": true,
-              "site 3": true,
-              "site 4": true,
-              "state 1": false,
-              "state 2": true,
-              "state 3": true,
-              "vendor 2": true,
-              "vendor 3": true,
-              "vendor 4": true,
-              "zone 1": true,
-              "zone 2": true,
-              "zone 3": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Information": 2,
-              "Name": 1,
-              "Type": 0,
-              "Value #B": 3,
-              "hw_type 1": 6,
-              "hw_type 2": 5,
-              "info 1": 8,
-              "info 2": 10,
-              "name 1": 7,
-              "name 2": 9,
-              "state 1": 4
-            },
-            "renameByName": {
-              "Information": "Information",
-              "Name": "Name",
-              "Type": "Type",
-              "Value": "Present",
-              "Value #A": "Present",
-              "Value #B": "Present",
-              "Value #C": "Predicted Failure",
-              "Value #D": "Maximum Speed",
-              "__name__ 2": "Name 2",
-              "additionalInformation1": "Additional Information",
-              "device_id": "Device ID",
-              "device_id 1": "Device ID",
-              "host_type 2": "",
-              "hw_type": "Type",
-              "hw_type 1": "",
-              "hw_type 2": "Type2",
-              "identifying_information": "Identifying Information",
-              "identifying_information 1": "Identifying Information",
-              "info": "Information",
-              "info 1": "",
-              "info 2": "",
-              "label": "Name",
-              "label 1": "Label",
-              "maximumSpeed": "Maximum Speed",
-              "maximum_speed": "Maximum Speed",
-              "model": "Model",
-              "model 1": "Model",
-              "name": "Name",
-              "name 1": "",
-              "name 2": "",
-              "os_type 1": "",
-              "state": "",
-              "state 1": "Status",
-              "state 2": "",
-              "state 3": "",
-              "vendor": "Manufacturer",
-              "vendor 1": "Vendor"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Status"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 44
-      },
-      "id": 142,
-      "panels": [],
-      "title": "Temperatures and Fans",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The current estimated internal temperature of the host.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlYlRd"
-          },
-          "decimals": 1,
-          "links": [
-            {
-              "title": "",
-              "url": "/d/PwSWpSN7k/device-temperature?orgId=1&${host_name:queryparam}&${site:queryparam}"
-            }
-          ],
-          "mappings": [],
-          "max": 60,
-          "min": 25,
-          "noValue": "No sensors",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 45
-      },
-      "id": 112,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "hw_host_ambient_temperature_celsius{site=~\"$site\", host_name=~\"$host_name\"}",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Ambient Temperature",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Ambient ",
-      "transformations": [
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": []
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The reading of the host's temperature sensors (when available).",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 7,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 10,
-        "x": 3,
-        "y": 45
-      },
-      "id": 122,
-      "interval": "2m",
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [
-            "last",
-            "min",
-            "max"
-          ],
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "hw_temperature_celsius{site=~\"$site\", host_name=~\"$host_name\"}",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 5,
-          "legendFormat": "{{name}}",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "hw_host_ambient_temperature_celsius{site=~\"$site\", host_name=~\"$host_name\"}",
-          "hide": false,
-          "legendFormat": "Ambient",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Temperatures",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The reading of the host's fans speed (when available).",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "graph": false,
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "rotrpm"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 11,
-        "x": 13,
-        "y": 45
-      },
-      "id": 173,
-      "interval": "2m",
-      "options": {
-        "graph": {},
-        "legend": {
-          "calcs": [
-            "last",
-            "min",
-            "max"
-          ],
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "hw_fan_speed_rpm{site=~\"$site\", host_name=~\"$host_name\"}",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 5,
-          "legendFormat": "{{name}}",
-          "refId": "B"
-        }
-      ],
-      "title": "Fans Speed",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The number of degrees Celsius (°C) remaining before the temperature reaches the closest warning temperature threshold of the host.\n\nA value of 0 indicates a critical temperature.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 1,
-          "links": [
-            {
-              "title": "More information about temperature sensors",
-              "url": "/d/PwSWpSN7k/device-temperature?orgId=1&${host_name:queryparam}&${site:queryparam}"
-            }
-          ],
-          "mappings": [],
-          "max": 20,
-          "min": 0,
-          "noValue": "No sensors",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 0
-              },
-              {
-                "color": "orange",
-                "value": 5
-              },
-              {
-                "color": "green",
-                "value": 10
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 48
-      },
-      "id": 125,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "hw_host_heating_margin_celsius{site=~\"$site\", host_name=~\"$host_name\"}",
-          "format": "time_series",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Heating Margin",
-          "refId": "A"
-        }
-      ],
-      "title": "Heating Margin",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The average speed of all the host's fans.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 0,
-          "links": [],
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              }
-            ]
-          },
-          "unit": "rotrpm"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 2,
-        "w": 3,
-        "x": 0,
-        "y": 51
-      },
-      "id": 189,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "avg(hw_fan_speed_rpm{site=~\"$site\", host_name=~\"$host_name\"})",
-          "hide": false,
-          "legendFormat": "Average Fan Speed",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Avg Fan Speed",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 53
-      },
-      "id": 118,
-      "panels": [],
-      "title": " Network ",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Data transmitted and received by the host.\n\nPositive values correspond to transmitted data.\nNegative values correspond to received data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-YlBl"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 21,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "Bps"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Received"
-            },
-            "properties": [
-              {
-                "id": "custom.transform",
-                "value": "negative-Y"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 12,
-        "x": 0,
-        "y": 54
-      },
-      "id": 158,
-      "interval": "5m",
-      "options": {
-        "legend": {
-          "calcs": [
-            "last",
-            "min",
-            "max",
-            "mean"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(rate(hw_network_io_bytes_total{site=~\"$site\", host_name=~\"$host_name\", direction=\"transmit\"}[5m]))",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "Transmitted",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(hw_network_io_bytes_total{site=~\"$site\", host_name=~\"$host_name\", direction=\"receive\"}[5m]))",
-          "hide": false,
-          "legendFormat": "Received",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Total Traffic (bytes/s)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The network interfaces and their current link status (plugged or unplugged).",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "left",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Link Status"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "basic",
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "0": {
-                        "color": "orange",
-                        "index": 1,
-                        "text": "Unplugged"
-                      },
-                      "1": {
-                        "color": "transparent",
-                        "index": 0,
-                        "text": "Plugged"
-                      }
-                    },
-                    "type": "value"
-                  }
-                ]
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 54
-      },
-      "id": 175,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "Link Status"
-          }
-        ]
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "hw_status{site=~\"$site\", host_name=~\"$host_name\", hw_type=\"network\", state=\"present\"}",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "hw_network_up{site=~\"$site\", host_name=~\"$host_name\"}",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "C"
-        }
-      ],
-      "title": "Network Links",
-      "transformations": [
-        {
-          "id": "seriesToColumns",
-          "options": {
-            "byField": "id"
-          }
-        },
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "device_id",
-                "info",
-                "logical_address",
-                "model",
-                "name",
-                "physical_address",
-                "serial_number",
-                "vendor",
-                "Value #C"
-              ]
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Time 3": true,
-              "Time 4": true,
-              "Value #A": true,
-              "Value #B": true,
-              "__name__": true,
-              "__name__ 1": true,
-              "__name__ 2": true,
-              "__name__ 3": true,
-              "__name__ 4": true,
-              "agent_host_name": true,
-              "agent_host_name 1": true,
-              "agent_host_name 2": true,
-              "agent_host_name 3": true,
-              "agent_host_name 4": true,
-              "bandwidth 2": true,
-              "bandwidth 3": true,
-              "deviceId": true,
-              "device_id 1": true,
-              "device_id 2": true,
-              "device_id 3": true,
-              "device_id 4": true,
-              "fqdn 1": true,
-              "fqdn 2": true,
-              "fqdn 3": true,
-              "fqdn 4": true,
-              "host_id": true,
-              "host_id 1": true,
-              "host_id 2": true,
-              "host_id 3": true,
-              "host_id 4": true,
-              "host_name": true,
-              "host_name 1": true,
-              "host_name 2": true,
-              "host_name 3": true,
-              "host_name 4": true,
-              "host_type": true,
-              "host_type 1": true,
-              "host_type 2": true,
-              "host_type 3": true,
-              "host_type 4": true,
-              "hw_type": true,
-              "hw_type 1": true,
-              "hw_type 2": true,
-              "id": true,
-              "identifying_information 2": true,
-              "identifying_information 3": true,
-              "info 1": true,
-              "info 2": true,
-              "info 3": true,
-              "info 4": true,
-              "instance 1": true,
-              "instance 2": true,
-              "instance 3": true,
-              "instance 4": true,
-              "job 1": true,
-              "job 2": true,
-              "job 3": true,
-              "job 4": true,
-              "label": false,
-              "label 2": true,
-              "label 3": true,
-              "label 4": true,
-              "logical_address 1": true,
-              "logical_address 2": true,
-              "logical_address 3": true,
-              "logical_address 4": true,
-              "model 1": false,
-              "model 2": true,
-              "model 3": true,
-              "model 4": true,
-              "name 2": true,
-              "name 3": true,
-              "name 4": true,
-              "os_type": true,
-              "os_type 1": true,
-              "os_type 2": true,
-              "os_type 3": true,
-              "os_type 4": true,
-              "parent": true,
-              "parent 1": true,
-              "parent 2": true,
-              "parent 3": true,
-              "parent 4": true,
-              "physical_address 2": true,
-              "physical_address 3": true,
-              "physical_address 4": true,
-              "remote_physical_address 2": true,
-              "remote_physical_address 3": true,
-              "serial_number 1": true,
-              "serial_number 2": true,
-              "serial_number 3": true,
-              "serial_number 4": true,
-              "site": true,
-              "site 1": true,
-              "site 2": true,
-              "site 3": true,
-              "site 4": true,
-              "state": true,
-              "state 1": true,
-              "state 2": true,
-              "vendor 1": false,
-              "vendor 2": true,
-              "vendor 3": true,
-              "vendor 4": true,
-              "zone 1": true,
-              "zone 2": true,
-              "zone 3": true,
-              "zone 4": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Value #C": 4,
-              "model 1": 1,
-              "model 2": 7,
-              "name 1": 2,
-              "name 2": 5,
-              "physical_address 1": 3,
-              "physical_address 2": 6,
-              "vendor 1": 0,
-              "vendor 2": 8
-            },
-            "renameByName": {
-              "Value": "Present",
-              "Value #A": "",
-              "Value #B": "",
-              "Value #C": "Link Status",
-              "Value #D": "Duplex Mode",
-              "__name__ 1": "",
-              "additionalInformation1": "Additional Information",
-              "bandwidth": "Bandwith",
-              "bandwidth 1": "Bandwith",
-              "device_id": "Device ID",
-              "device_id 1": "",
-              "fqdn 3": "",
-              "hw_type 2": "",
-              "identifying_information": "Identifying Information",
-              "identifying_information 1": "Identifying Information",
-              "info": "Information",
-              "info 1": "Information",
-              "label": "Name",
-              "label 1": "Label",
-              "logical_address": "Logical Address",
-              "logical_address 1": "Logical Address",
-              "maximumSpeed": "Maximum Speed",
-              "maximum_speed": "Maximum Speed",
-              "model": "Model",
-              "model 1": "Model",
-              "name": "Name",
-              "name 1": "Name",
-              "physical_address": "Physical Address",
-              "physical_address 1": "Physical Address",
-              "physical_address 3": "",
-              "remote_physical_address": "Remote Physical Address",
-              "remote_physical_address 1": "Remote Physical Address",
-              "serial_number": "Serial Number",
-              "serial_number 1": "Serial Number",
-              "state": "",
-              "state 2": "",
-              "vendor": "Manufacturer",
-              "vendor 1": "Vendor"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Device ID"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The highest network interface error ratio (total traffic vs errors).\n\nThis value should be at 0% or as close to 0% as possible.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 2,
-          "mappings": [],
-          "min": -1,
-          "noValue": "-",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text"
-              },
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 0.01
-              },
-              {
-                "color": "red",
-                "value": 10
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 2,
-        "x": 12,
-        "y": 60
-      },
-      "id": 183,
-      "interval": "5m",
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(hw_errors_total{site=\"$site\", host_name=\"$host_name\", hw_type=\"network\"})\r\n/ \r\n(sum(hw_network_packets_total{site=\"$site\", host_name=\"$host_name\", direction=\"receive\"})\r\n+ sum(hw_network_packets_total{site=\"$site\", host_name=\"$host_name\", direction=\"transmit\"}) * 100)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Max Error Ratio",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The network interfaces bandwidth utilization.\n\nThe bandwidth utilization should stay under 90% at all times.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "area"
-            }
-          },
-          "decimals": 0,
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              },
-              {
-                "color": "#EAB839",
-                "value": 0.9
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 10,
-        "x": 14,
-        "y": 60
-      },
-      "id": 182,
-      "interval": "5m",
-      "options": {
-        "legend": {
-          "calcs": [
-            "last",
-            "min",
-            "max"
-          ],
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "hw_network_bandwidth_utilization_ratio{site=~\"$site\", host_name=~\"$host_name\"}",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{name}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Bandwidth Utilization",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 65
-      },
-      "id": 245,
-      "panels": [],
-      "title": "CPUs, Voltage and Batteries",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Speed"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "rothz"
-              },
-              {
-                "id": "custom.axisPlacement",
-                "value": "left"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": " Consumption"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "watt"
-              },
-              {
-                "id": "custom.axisPlacement",
-                "value": "right"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 66
-      },
-      "id": 231,
-      "options": {
-        "legend": {
-          "calcs": [
-            "last"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg(hw_cpu_speed_hertz{site=~\"$site\", host_name=~\"$host_name\"})",
-          "legendFormat": "Speed",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(hw_energy_joules_total{site=~\"$site\", host_name=~\"$host_name\", hw_type=\"cpu\"}[5m]))",
-          "hide": false,
-          "legendFormat": " Consumption",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "CPUs Speed and Power Consumption",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The reading of the host's voltage sensors (when available).",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "volt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 8,
-        "y": 66
-      },
-      "id": 259,
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "mean",
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "hw_voltage_volts{site=~\"$site\", host_name=~\"$host_name\"}",
-          "legendFormat": "{{name}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Voltages",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The percentage of battery charge (when available).",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 66
-      },
-      "id": 261,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "hw_battery_charge_ratio{site=~\"$site\", host_name=~\"$host_name\"}",
-          "legendFormat": "{{name}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Battery Charge",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 74
-      },
-      "id": 186,
-      "panels": [],
-      "title": "Disks",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "links": [],
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "text"
-              },
-              {
-                "color": "blue",
-                "value": 0.1
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Size"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 14,
-        "x": 0,
-        "y": 75
-      },
-      "id": 320,
-      "interval": "5m",
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "Name"
-          }
-        ]
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "hw_logical_disk_limit_bytes{site=~\"$site\", host_name=~\"$host_name\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{ name}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Logical Disks",
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "name",
-                "site",
-                "Value"
-              ]
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Value": false,
-              "__name__": true,
-              "agent_host_name": true,
-              "device_id": true,
-              "host_id": true,
-              "host_name": true,
-              "host_type": true,
-              "id": true,
-              "info": true,
-              "name": false,
-              "os_type": true,
-              "parent": true,
-              "raid_level": true,
-              "site": true
-            },
-            "indexByName": {},
-            "renameByName": {
-              "Value": "Size",
-              "name": "Name"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": true,
-                "field": "Name"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The disks remaining lifetime in percentage.\n\nA value lower than 3% indicates that the disk should be replaced.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "area"
-            }
-          },
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red"
-              },
-              {
-                "color": "#EAB839",
-                "value": 0.1
-              },
-              {
-                "color": "transparent",
-                "value": 0.3
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 10,
-        "x": 14,
-        "y": 75
-      },
-      "id": 196,
-      "options": {
-        "legend": {
-          "calcs": [
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "hw_physical_disk_endurance_utilization_ratio{site=~\"$site\", host_name=~\"$host_name\"}",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{name}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Endurance Remaining",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 83
-      },
-      "id": 86,
-      "panels": [],
-      "title": "Monitoring Information",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Status"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "degraded": {
-                        "color": "orange",
-                        "index": 1,
-                        "text": "Degraded"
-                      },
-                      "failed": {
-                        "color": "red",
-                        "index": 2,
-                        "text": "Failed"
-                      },
-                      "ok": {
-                        "index": 0,
-                        "text": "OK"
-                      },
-                      "present": {
-                        "color": "red",
-                        "index": 3,
-                        "text": "Missing"
-                      }
-                    },
-                    "type": "value"
-                  }
-                ]
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "color-background"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Description"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 920
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
-        "y": 84
-      },
-      "id": 154,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "enablePagination": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "metricshub_connector_status{site=~\"$site\", host_name=~\"$host_name\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Connectors",
-      "transformations": [
-        {
-          "id": "filterByValue",
-          "options": {
-            "filters": [
-              {
-                "config": {
-                  "id": "lower",
-                  "options": {
-                    "value": 1
-                  }
-                },
-                "fieldName": "Value"
-              }
-            ],
-            "match": "any",
-            "type": "exclude"
-          }
-        },
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "description",
-                "name",
-                "state"
-              ]
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Value": true,
-              "__name__": true,
-              "agent_host_name": true,
-              "applies_to_os": true,
-              "compiled_file_name": true,
-              "connector_id": true,
-              "description": false,
-              "device_id": true,
-              "display_name": true,
-              "fqdn": true,
-              "host_id": true,
-              "host_name": true,
-              "host_type": true,
-              "id": true,
-              "instance": true,
-              "job": true,
-              "os_type": true,
-              "parent": true,
-              "site": true,
-              "zone": true
-            },
-            "indexByName": {
-              "Value": 4,
-              "applies_to_os": 11,
-              "connector_id": 12,
-              "description": 1,
-              "host_id": 7,
-              "host_name": 8,
-              "host_type": 9,
-              "id": 3,
-              "name": 0,
-              "os_type": 10,
-              "parent": 5,
-              "site": 6,
-              "state": 2
-            },
-            "renameByName": {
-              "Status": "Status",
-              "Time": "",
-              "Value": "",
-              "__name__": "",
-              "compiled_file_name": "",
-              "description": "Description",
-              "id": "",
-              "identifying_information": "More Information",
-              "label": "Name",
-              "model": "Model",
-              "name": "Name",
-              "serial_number": "Serial Number",
-              "site": "",
-              "state": "Status",
-              "type": "Type",
-              "vendor": "Vendor"
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 89
-      },
-      "id": 324,
-      "panels": [],
-      "title": "Hardware Sentry Agent Status",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Time since the monitoring of this host by Hardware Sentry was started.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "text",
-            "mode": "fixed"
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "dateTimeFromNow"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value * 1000"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Collect Started"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 90
-      },
-      "id": 194,
-      "interval": "1h",
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "min_over_time(timestamp(metricshub_host_configured{site=~\"$site\", host_name=\"$host_name\"})[1y:1d])",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "__auto",
-          "refId": "A"
-        }
-      ],
-      "title": "Collect Started",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Collect Started",
-            "binary": {
-              "left": "Value",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "1000"
-            },
-            "mode": "binary",
-            "reduce": {
-              "include": [
-                "Last Seen"
-              ],
-              "reducer": "last"
-            },
-            "replaceFields": false
-          }
-        },
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "agent_host_name",
-                "site",
-                "Collect Started"
-              ]
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Value": true,
-              "Value #A": true,
-              "__name__": true,
-              "agent_host_name": false,
-              "build_number": true,
-              "build_number 2": true,
-              "hc_version 2": true,
-              "host_id": true,
-              "host_id 1": true,
-              "host_id 2": true,
-              "host_name": true,
-              "host_name 1": true,
-              "host_name 2": true,
-              "host_type": true,
-              "host_type 1": true,
-              "host_type 2": true,
-              "os_type": true,
-              "os_type 1": true,
-              "os_type 2": true,
-              "project_name": true,
-              "project_name 1": true,
-              "project_name 2": true,
-              "project_version 2": true,
-              "service_name": true,
-              "service_name 1": true,
-              "service_name 2": true,
-              "site 2": true,
-              "timestamp": true,
-              "timestamp 1": true,
-              "timestamp 2": true
-            },
-            "indexByName": {
-              "Last Seen": 15,
-              "Time": 6,
-              "Value": 14,
-              "agent_host_name": 1,
-              "build_date": 3,
-              "build_number": 4,
-              "hc_version": 5,
-              "host_id": 7,
-              "host_name": 8,
-              "host_type": 9,
-              "os_type": 10,
-              "project_name": 11,
-              "project_version": 2,
-              "service_name": 12,
-              "site": 0,
-              "timestamp": 13
-            },
-            "renameByName": {
-              "Time": "",
-              "Value": "",
-              "agent_host_name": "Hostname",
-              "build_date": "Agent Build Date",
-              "build_number": "",
-              "build_number 1": "Agent Build Number",
-              "hc_version": "Connectors Version",
-              "hc_version 1": "Connectors Version",
-              "project_version": "Agent Version",
-              "project_version 1": "Agent Version",
-              "site": "Site",
-              "site 1": "Site",
-              "timestamp": ""
-            }
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": false
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Last Seen"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "dateTimeFromNow"
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Hostname"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 18,
-        "x": 3,
-        "y": 90
-      },
-      "id": 138,
-      "interval": "1h",
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "Site"
-          }
-        ]
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "last_over_time(timestamp(metricshub_agent_info{site=~\"$site\", agent_host_name=\"$agent\"})[6h:])",
-          "format": "table",
-          "hide": true,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "last_over_time(timestamp(metricshub_agent_info{agent_host_name=\"$agent\"})[6h:])",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "B"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Last Seen",
-            "binary": {
-              "left": {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Value"
-                }
-              },
-              "operator": "*",
-              "right": {
-                "fixed": "1000"
-              }
-            },
-            "mode": "binary",
-            "reduce": {
-              "include": [
-                "Last Seen"
-              ],
-              "reducer": "last"
-            },
-            "replaceFields": false
-          }
-        },
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "agent_host_name",
-                "build_date",
-                "build_number",
-                "version",
-                "Last Seen",
-                "cc_version"
-              ]
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Value": true,
-              "Value #A": true,
-              "__name__": true,
-              "agent_host_name": false,
-              "build_number": false,
-              "build_number 2": true,
-              "hc_version 2": true,
-              "host_id": true,
-              "host_id 1": true,
-              "host_id 2": true,
-              "host_name": true,
-              "host_name 1": true,
-              "host_name 2": true,
-              "host_type": true,
-              "host_type 1": true,
-              "host_type 2": true,
-              "job": true,
-              "name": true,
-              "os_type": true,
-              "os_type 1": true,
-              "os_type 2": true,
-              "otel_version": true,
-              "project_name": true,
-              "project_name 1": true,
-              "project_name 2": true,
-              "project_version": true,
-              "project_version 2": true,
-              "service_name": true,
-              "service_name 1": true,
-              "service_name 2": true,
-              "site": true,
-              "site 2": true,
-              "timestamp": true,
-              "timestamp 1": true,
-              "timestamp 2": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Last Seen": 5,
-              "agent_host_name": 0,
-              "build_date": 2,
-              "build_number": 3,
-              "cc_version": 4,
-              "version": 1
-            },
-            "renameByName": {
-              "Time": "",
-              "Value": "",
-              "agent_host_name": "Hostname",
-              "build_date": "Build Date",
-              "build_number": "Build Number",
-              "build_number 1": "Agent Build Number",
-              "cc_version": "Connectors Version",
-              "hc_version": "Connectors Version",
-              "hc_version 1": "Connectors Version",
-              "project_version": "",
-              "project_version 1": "Agent Version",
-              "site": "",
-              "site 1": "Site",
-              "timestamp": "",
-              "version": "Version"
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "noValue": "2026.1",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-green"
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 21,
-        "y": 90
-      },
-      "id": 323,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.0+security-01",
-      "title": "Dashboard Version",
-      "type": "stat"
-    }
-  ],
-  "refresh": "",
-  "schemaVersion": 41,
-  "tags": [
-    "hw_host"
-  ],
-  "templating": {
-    "list": [
-      {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(hw_status{site=~\"$site\", host_name=~\"$host_name\"}, hw_type)",
-        "hide": 2,
-        "includeAll": true,
-        "name": "hw_type",
-        "options": [],
-        "query": {
-          "query": "label_values(hw_status{site=~\"$site\", host_name=~\"$host_name\"}, hw_type)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "sort": 5,
-        "type": "query"
+        "targetBlank": false,
+        "title": "",
+        "tooltip": "",
+        "type": "dashboards",
+        "url": ""
       },
       {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(metricshub_host_configured,site)",
-        "includeAll": false,
-        "label": "Site",
-        "name": "site",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(metricshub_host_configured,site)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "sort": 5,
-        "type": "query"
+        "asDropdown": false,
+        "icon": "external link",
+        "includeVars": true,
+        "keepTime": true,
+        "tags": [
+          "hw_site"
+        ],
+        "targetBlank": false,
+        "title": "Site Information",
+        "tooltip": "",
+        "type": "dashboards",
+        "url": ""
+      }
+    ],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "hw_host"
+    ],
+    "timeSettings": {
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-7d",
+      "hideTimepicker": false,
+      "timezone": "",
+      "to": "now"
+    },
+    "title": "Hardware Host (MetricsHub)",
+    "variables": [
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(metricshub_host_configured,site)",
+          "hide": "dontHide",
+          "includeAll": false,
+          "label": "Site",
+          "multi": false,
+          "name": "site",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(metricshub_host_configured,site)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
       },
       {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(metricshub_host_configured{site=~\"$site\"},host_name)",
-        "includeAll": false,
-        "label": "Host Name",
-        "name": "host_name",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(metricshub_host_configured{site=~\"$site\"},host_name)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "sort": 5,
-        "type": "query"
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(metricshub_host_configured{site=~\"$site\"},host_name)",
+          "hide": "dontHide",
+          "includeAll": false,
+          "label": "Host Name",
+          "multi": false,
+          "name": "host_name",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(metricshub_host_configured{site=~\"$site\"},host_name)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
       },
       {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(metricshub_host_configured{site=\"$site\", host_name=\"$host_name\"},agent_host_name)",
-        "hide": 2,
-        "includeAll": false,
-        "name": "agent",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(metricshub_host_configured{site=\"$site\", host_name=\"$host_name\"},agent_host_name)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "type": "query"
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(metricshub_host_configured{site=\"$site\", host_name=\"$host_name\"},agent_host_name)",
+          "hide": "hideVariable",
+          "includeAll": false,
+          "multi": false,
+          "name": "agent",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(metricshub_host_configured{site=\"$site\", host_name=\"$host_name\"},agent_host_name)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
       }
     ]
   },
-  "time": {
-    "from": "now-7d",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "",
-  "title": "Hardware Host (MetricsHub)",
-  "uid": "c2K8skm4k",
-  "version": 4,
-  "weekStart": ""
+  "status": {}
 }

--- a/src/dashboards/Hardware/Hardware Main (MetricsHub).json
+++ b/src/dashboards/Hardware/Hardware Main (MetricsHub).json
@@ -1,4356 +1,5486 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "barchart",
-      "name": "Bar chart",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "bargauge",
-      "name": "Bar gauge",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "12.0.2"
-    },
-    {
-      "type": "panel",
-      "id": "piechart",
-      "name": "Pie chart",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "text",
-      "name": "Text",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "datasource",
-          "uid": "grafana"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "adbdmkq",
+    "generation": 4,
+    "creationTimestamp": "2026-04-29T13:43:02Z",
+    "labels": {},
+    "annotations": {}
   },
-  "description": "Collect hardware health and performance metrics as well as sustainability KPIs with MetricsHub®; visualize the gathered telemetry data in the comprehensive Hardware Main (MetricsHub), Hardware Site (MetricsHub), and Hardware Host (MetricsHub) dashboards.\r\n\r\nMetricsHubs collects metrics from servers (Cisco, Dell, HPE, Huawei, IBM Lenovo, SuperMicro, etc.), storage systems (NetApp, Dell EMC, Hitachi, HPE, IBM, Pure, Huawei, etc.), network devices (Cisco, Aruba, Dell, HP, F5, Juniper, Oracle) and other equipment like PDUs, UPS from APC, Raritan, Eaton, etc.",
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "id": null,
-  "links": [
-    {
-      "asDropdown": false,
-      "icon": "external link",
-      "includeVars": false,
-      "keepTime": false,
-      "tags": [
-        "hw_site"
-      ],
-      "targetBlank": false,
-      "title": "Site",
-      "tooltip": "",
-      "type": "dashboards",
-      "url": ""
-    }
-  ],
-  "panels": [
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 358,
-      "panels": [],
-      "title": "Overall Information",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The number of hosts currently configured to be monitored.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-green"
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 0,
-        "y": 1
-      },
-      "id": 188,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(count by (host_name) (present_over_time(metricshub_host_configured[1h])))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Hosts",
-          "refId": "A"
-        }
-      ],
-      "title": "Hosts",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The percentage of monitored hosts.\n\nA monitored host is a host with at least one responding connector.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 0,
-          "mappings": [],
-          "noValue": "0%",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-red"
-              },
-              {
-                "color": "super-light-yellow",
-                "value": 0.5
-              },
-              {
-                "color": "super-light-green",
-                "value": 0.9
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 2,
-        "y": 1
-      },
-      "id": 359,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(max by (host_name, site) (metricshub_connector_status{state=\"ok\"} == 1)) / sum(max by (host_name, site) (present_over_time(metricshub_host_configured[1h])))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Coverage",
-          "refId": "A"
-        }
-      ],
-      "title": "Coverage",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 4,
-        "y": 1
-      },
-      "id": 301,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(ALERTS_FOR_STATE{severity=\"critical\", alertname=~\"MetricsHub-Hardware-.*\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Critical Alerts",
-          "refId": "A"
-        }
-      ],
-      "title": "Critical Alerts",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent"
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 6,
-        "y": 1
-      },
-      "id": 303,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(ALERTS_FOR_STATE{severity=\"warning\", alertname=~\"MetricsHub-Hardware-.*\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Warning Alerts",
-          "refId": "A"
-        }
-      ],
-      "title": "Warning Alerts",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
             },
-            "filterable": true,
-            "inspect": false
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "No alerts",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
+            "version": "v0"
           }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Severity"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 109
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "critical": {
-                        "color": "red",
-                        "index": 1,
-                        "text": "Critical"
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "description": "Collect hardware health and performance metrics as well as sustainability KPIs with MetricsHub®; visualize the gathered telemetry data in the comprehensive Hardware Main (MetricsHub), Hardware Site (MetricsHub), and Hardware Host (MetricsHub) dashboards.\r\n\r\nMetricsHubs collects metrics from servers (Cisco, Dell, HPE, Huawei, IBM Lenovo, SuperMicro, etc.), storage systems (NetApp, Dell EMC, Hitachi, HPE, IBM, Pure, Huawei, etc.), network devices (Cisco, Aruba, Dell, HP, F5, Juniper, Oracle) and other equipment like PDUs, UPS from APC, Raritan, Eaton, etc.",
+    "editable": true,
+    "elements": {
+      "panel-114": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(sum by (site) (hw_host_power_watts)[1y:1d]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1y:1d]) * avg_over_time(avg by (site) (hw_site_electricity_cost)[1y:1d]) * 365 * 24 / 1000",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "{{site}}"
                       },
-                      "warning": {
-                        "color": "orange",
-                        "index": 0,
-                        "text": "Warning"
-                      }
+                      "version": "v0"
                     },
-                    "type": "value"
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": [
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "site"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The sites' yearly cost.\n\nThese values are estimated according to the past data if less than a year of data has been collected.",
+          "id": 114,
+          "links": [],
+          "title": "Yearly Cost",
+          "vizConfig": {
+            "group": "barchart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "dark-green",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "axisSoftMin": 0,
+                    "fillOpacity": 80,
+                    "gradientMode": "hue",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "links": [
+                    {
+                      "title": "Site Information",
+                      "url": "/d/SHFBpSH7z/site-information?orgId=1&var-site=${__data.fields.site}"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "percentage",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "barRadius": 0,
+                "barWidth": 0.95,
+                "fullHighlight": false,
+                "groupWidth": 0.7,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "orientation": "vertical",
+                "showValue": "never",
+                "stacking": "none",
+                "text": {},
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "sort": "none"
+                },
+                "xTickLabelRotation": -45,
+                "xTickLabelSpacing": 0
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-115": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(sum by (site) (hw_host_power_watts)[1y:1d]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1y:1d]) * avg_over_time(avg by (site) (hw_site_carbon_intensity_grams)[1y:1d]) * 365 * 24 / 1000 / 1000 / 1000",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "{{site}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": [
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "site"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The sites' yearly CO₂ emissions. \n\nThese values are estimated according to the past data if less than a year of data has been collected.",
+          "id": 115,
+          "links": [],
+          "title": "Yearly CO₂",
+          "vizConfig": {
+            "group": "barchart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#414141",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "axisSoftMin": 0,
+                    "fillOpacity": 80,
+                    "gradientMode": "hue",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "links": [
+                    {
+                      "title": "Site Information",
+                      "url": "/d/SHFBpSH7z/site-information?orgId=1&var-site=${__data.fields.site}"
+                    }
+                  ],
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "#ccccdc",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masst"
+                },
+                "overrides": []
+              },
+              "options": {
+                "barRadius": 0,
+                "barWidth": 0.95,
+                "fullHighlight": false,
+                "groupWidth": 0.7,
+                "legend": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "orientation": "vertical",
+                "showValue": "never",
+                "stacking": "none",
+                "text": {},
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "sort": "none"
+                },
+                "xTickLabelRotation": -45,
+                "xTickLabelSpacing": 0
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-119": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(sum by (site) (hw_host_power_watts)[1y:1d]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1y:1d]) * 365 * 24",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "{{site}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": [
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "site"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The sites' yearly power consumption.\n\nThese values are estimated according to the past data if less than a year of data has been collected.",
+          "id": 119,
+          "links": [],
+          "title": "Yearly Consumption",
+          "vizConfig": {
+            "group": "barchart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "dark-blue",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "axisSoftMin": 0,
+                    "fillOpacity": 80,
+                    "gradientMode": "hue",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "links": [
+                    {
+                      "title": "Site Information",
+                      "url": "/d/SHFBpSH7z/site-information?orgId=1&var-site=${__data.fields.site}"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "barRadius": 0,
+                "barWidth": 0.95,
+                "fullHighlight": false,
+                "groupWidth": 0.7,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "orientation": "vertical",
+                "showValue": "never",
+                "stacking": "none",
+                "text": {},
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "sort": "none"
+                },
+                "xTickLabelRotation": -45,
+                "xTickLabelSpacing": 0
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-155": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(hw_host_power_watts) ",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Total Power"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Total current power usage of all hosts across all sites.",
+          "id": 155,
+          "links": [],
+          "title": "Total Power",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watt"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-162": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 162,
+          "links": [
+            {
+              "title": "Hardware Sentry OpenTelemetry Collector",
+              "url": "https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html"
+            }
+          ],
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<a href=\"https://metricshub.com/\" target=\"_blank\">\n  <div style=\"\n    display: block;\n    margin: 0 auto; \n    \n    background: transparent url(https://metricshub.com/images/logo-darkgrey.svg) no-repeat center center;\n    background-size: contain;\n    \n    width: 150px;   \n    height: 125px;\n    border-radius: 3px;\n  \">\n  </div>\n</a>",
+                "mode": "html"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-168": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (host_type) (metricshub_host_configured)",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "{{host_type}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The total number of hosts per type: compute (server), storage and network.",
+          "id": 168,
+          "links": [],
+          "title": "Hosts Type",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "displayLabels": [
+                  "name",
+                  "value",
+                  "percent"
+                ],
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": false,
+                  "values": []
+                },
+                "pieType": "pie",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": true
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-172": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "exemplar": false,
+                        "expr": "sum by (os_type) (hw_host_power_watts)",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "{{site}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The power consumption distribution across platform types: \nHP-UX, IBM AIX, Management (i.e management card), Microsoft Windows, Linux, \nOracle Solaris and Storage.",
+          "id": 172,
+          "links": [],
+          "title": "Power per Platform Type",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "linux": {
+                          "index": 0,
+                          "text": "Linux"
+                        },
+                        "management": {
+                          "index": 1,
+                          "text": "Out-of-band"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "unit": "watt"
+                },
+                "overrides": []
+              },
+              "options": {
+                "displayLabels": [
+                  "name",
+                  "percent"
+                ],
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": false,
+                  "values": []
+                },
+                "pieType": "pie",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": true
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-177": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "exemplar": false,
+                        "expr": "sum by (host_type) (hw_host_power_watts)",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "{{host_type}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The power consumption distribution by host types: compute (server), storage and network.",
+          "id": 177,
+          "links": [],
+          "title": "Power per Host Type",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  "unit": "watt"
+                },
+                "overrides": []
+              },
+              "options": {
+                "displayLabels": [
+                  "name",
+                  "value",
+                  "percent"
+                ],
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": false,
+                  "values": []
+                },
+                "pieType": "pie",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": true
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-179": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "exemplar": false,
+                        "expr": "topk(10, hw_host_power_watts)",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "{{site}}: {{host_name}} "
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The 10 hosts that currently consume the most energy across all sites.",
+          "id": 179,
+          "links": [],
+          "title": "Top Consumers",
+          "vizConfig": {
+            "group": "bargauge",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "thresholds"
+                  },
+                  "links": [
+                    {
+                      "title": "",
+                      "url": "d/c2K8skm4k/host?orgId=1&var-site=${__field.labels.site}&var-host_name=${__field.labels.host_name}"
+                    }
+                  ],
+                  "max": 2000,
+                  "min": 500,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "super-light-blue",
+                        "value": 0
+                      },
+                      {
+                        "color": "light-blue",
+                        "value": 500
+                      },
+                      {
+                        "color": "semi-dark-blue",
+                        "value": 1000
+                      },
+                      {
+                        "color": "dark-blue",
+                        "value": 2000
+                      }
+                    ]
+                  },
+                  "unit": "watt"
+                },
+                "overrides": []
+              },
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "auto",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-181": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(sum by (site) (hw_host_power_watts) * avg by (site) (hw_site_pue_ratio))",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Total Power * PUE"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Total current power usage across all sites, multiplied by the site's PUE.\n\nThis number represents the actual power usage of all sites. It takes into account the cooling and other overhead that supports the equipment.",
+          "id": 181,
+          "links": [],
+          "title": "Total Power * PUE",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watt"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-188": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(count by (host_name) (present_over_time(metricshub_host_configured[1h])))",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Hosts"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The number of hosts currently configured to be monitored.",
+          "id": 188,
+          "links": [],
+          "title": "Hosts",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-206": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "last_over_time(timestamp(metricshub_agent_info)[6h:])",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": [
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "agent_host_name",
+                          "build_date",
+                          "site",
+                          "version",
+                          "Value",
+                          "build_number"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Last Seen",
+                      "binary": {
+                        "left": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value"
+                          }
+                        },
+                        "operator": "*",
+                        "right": {
+                          "fixed": "1000"
+                        }
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "include": [
+                          "Last Seen"
+                        ],
+                        "reducer": "last"
+                      },
+                      "replaceFields": false
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Value": true,
+                        "Value #A": true,
+                        "__name__": true,
+                        "agent_host_name": false,
+                        "build_number": false,
+                        "build_number 2": true,
+                        "hc_version 2": true,
+                        "host_id": true,
+                        "host_id 1": true,
+                        "host_id 2": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "job": true,
+                        "name": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "otel_version": true,
+                        "project_name": true,
+                        "project_name 1": true,
+                        "project_name 2": true,
+                        "project_version": true,
+                        "project_version 2": true,
+                        "service_name": true,
+                        "service_name 1": true,
+                        "service_name 2": true,
+                        "site 2": true,
+                        "timestamp": true,
+                        "timestamp 1": true,
+                        "timestamp 2": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Last Seen": 5,
+                        "Value": 6,
+                        "agent_host_name": 0,
+                        "build_date": 2,
+                        "build_number": 3,
+                        "site": 4,
+                        "version": 1
+                      },
+                      "renameByName": {
+                        "Last Seen": "",
+                        "Time": "",
+                        "Value": "",
+                        "agent_host_name": "Hostname",
+                        "build_date": "Build Date",
+                        "build_number": "Build Number",
+                        "build_number 1": "Agent Build Number",
+                        "hc_version": "Connectors Version",
+                        "hc_version 1": "Connectors Version",
+                        "name": "",
+                        "project_version": "",
+                        "project_version 1": "Agent Version",
+                        "site": "Site",
+                        "site 1": "Site",
+                        "timestamp": "",
+                        "version": "Version"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 206,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Last Seen"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 316
+                      },
+                      {
+                        "id": "unit",
+                        "value": "dateTimeFromNow"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "right"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Hostname"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Site"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
                   }
                 ]
               },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "basic",
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Site"
+                  }
+                ]
               }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "protocol"
             },
-            "properties": [
-              {
-                "id": "noValue",
-                "value": "N/A"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Device Type"
-            },
-            "properties": [
-              {
-                "id": "noValue",
-                "value": "N/A"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 219
-              }
-            ]
+            "version": "12.3.2"
           }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 16,
-        "x": 8,
-        "y": 1
-      },
-      "id": 365,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "enablePagination": true,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "Time"
-          }
-        ]
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "ALERTS_FOR_STATE{site != \"\", host_name != \"\", alertname=~\"MetricsHub-Hardware-.*\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
         }
-      ],
-      "title": "Current Alerts",
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "Time",
-                "host_name",
-                "name",
-                "severity",
-                "site",
-                "hw_type",
-                "protocol",
-                "alertname"
+      },
+      "panel-277": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "topk(25, hw_host_ambient_temperature_celsius)",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m",
+                "maxDataPoints": 1
+              },
+              "transformations": [
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "host_name",
+                          "name",
+                          "site",
+                          "Value"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "Value"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Value": false,
+                        "__name__": true,
+                        "agent_host_name": true,
+                        "host_id": true,
+                        "host_name": false,
+                        "host_type": true,
+                        "id": true,
+                        "label": true,
+                        "location": true,
+                        "os_type": true,
+                        "site": false
+                      },
+                      "indexByName": {
+                        "Time": 2,
+                        "Value": 1,
+                        "__name__": 3,
+                        "agent_host_name": 4,
+                        "host_id": 5,
+                        "host_name": 6,
+                        "host_type": 7,
+                        "id": 8,
+                        "label": 9,
+                        "location": 10,
+                        "os_type": 11,
+                        "site": 0
+                      },
+                      "renameByName": {}
+                    }
+                  }
+                }
               ]
             }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": false,
-              "Value": true,
-              "Value #A": true,
-              "__name__": true,
-              "agent_host_name": true,
-              "alertstatus": true,
-              "alertstatus_code": true,
-              "applies_to_os": true,
-              "array_name": true,
-              "bandwidth": true,
-              "battery_state": true,
-              "blade_name": true,
-              "chemistry": true,
-              "compiled_file_name": true,
-              "connector_id": true,
-              "description": true,
-              "device_id": true,
-              "device_type": true,
-              "display_name": true,
-              "driver_version": true,
-              "firmware_version": true,
-              "fqdn": true,
-              "host_id": true,
-              "host_name": false,
-              "host_type": true,
-              "hw_type": false,
-              "id": true,
-              "identifying_information": true,
-              "info": true,
-              "instance": true,
-              "ip_address": true,
-              "job": true,
-              "local_device_name": true,
-              "location": true,
-              "logical_address": true,
-              "model": true,
-              "name": false,
-              "os_type": true,
-              "parent": true,
-              "physical_address": true,
-              "power_supply_type": true,
-              "raid_level": true,
-              "robotic_type": true,
-              "sensor_location": true,
-              "serial_number": true,
-              "severity": false,
-              "site": false,
-              "state": true,
-              "type": true,
-              "vendor": true,
-              "wwn": true,
-              "zone": true
-            },
-            "indexByName": {
-              "Time": 0,
-              "Value": 16,
-              "__name__": 10,
-              "agent_host_name": 11,
-              "alertname": 2,
-              "applies_to_os": 23,
-              "bandwidth": 27,
-              "blade_name": 34,
-              "connector_id": 24,
-              "description": 25,
-              "device_id": 17,
-              "device_type": 26,
-              "firmware_version": 32,
-              "host_id": 12,
-              "host_name": 4,
-              "host_type": 13,
-              "hw_type": 5,
-              "id": 8,
-              "info": 18,
-              "ip_address": 36,
-              "location": 22,
-              "logical_address": 31,
-              "model": 19,
-              "name": 6,
-              "os_type": 14,
-              "parent": 9,
-              "physical_address": 28,
-              "power_supply_type": 33,
-              "protocol": 7,
-              "raid_level": 35,
-              "sensor_location": 30,
-              "serial_number": 29,
-              "severity": 1,
-              "site": 3,
-              "state": 15,
-              "type": 20,
-              "vendor": 21
-            },
-            "renameByName": {
-              "Time": "Time",
-              "alertname": "Alert Name",
-              "fqdn": "",
-              "host_name": "Hostname",
-              "hw_type": "Device Type",
-              "id": "",
-              "label": "Label",
-              "name": "Device Name",
-              "os_type": "",
-              "protocol": "Protocol",
-              "severity": "Severity",
-              "site": "Site"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Time"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 0,
-        "y": 5
-      },
-      "id": 162,
-      "links": [
-        {
-          "title": "Hardware Sentry OpenTelemetry Collector",
-          "url": "https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html"
-        }
-      ],
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<a href=\"https://metricshub.com/\" target=\"_blank\">\n  <div style=\"\n    display: block;\n    margin: 0 auto; \n    \n    background: transparent url(https://metricshub.com/images/logo-darkgrey.svg) no-repeat center center;\n    background-size: contain;\n    \n    width: 150px;   \n    height: 125px;\n    border-radius: 3px;\n  \">\n  </div>\n</a>",
-        "mode": "html"
-      },
-      "pluginVersion": "12.0.2",
-      "type": "text"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 9
-      },
-      "id": 356,
-      "panels": [],
-      "title": "Power, Cost and CO₂ Emissions",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Total current power usage across all sites, multiplied by the site's PUE.\n\nThis number represents the actual power usage of all sites. It takes into account the cooling and other overhead that supports the equipment.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
           },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 0,
-        "y": 10
-      },
-      "id": 181,
-      "interval": "1h",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(sum by (site) (hw_host_power_watts) * avg by (site) (hw_site_pue_ratio))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Total Power * PUE",
-          "refId": "A"
-        }
-      ],
-      "title": "Total Power * PUE",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Total current power usage across all sites, multiplied by the site's PUE, displayed as a graph.\n\nThis number represents the actual power usage of all sites. It takes into account the cooling and other overhead that supports the equipment.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMin": 0,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 51,
-            "gradientMode": "hue",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 2,
-            "pointSize": 6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue"
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 8,
-        "x": 4,
-        "y": 10
-      },
-      "id": 366,
-      "interval": "5m",
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "last"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(sum by (site) (hw_host_power_watts) * avg by (site) (avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[2h])))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Total Power * PUE",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Total Power * PUE",
-      "type": "timeseries"
-    },
-    {
-      "description": "",
-      "gridPos": {
-        "h": 2,
-        "w": 3,
-        "x": 12,
-        "y": 10
-      },
-      "id": 351,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<h3 style=\"background-color:DimGray\"><center>Live Data</center></h3>",
-        "mode": "html"
-      },
-      "pluginVersion": "12.0.2",
-      "type": "text"
-    },
-    {
-      "description": "",
-      "gridPos": {
-        "h": 2,
-        "w": 9,
-        "x": 15,
-        "y": 10
-      },
-      "id": 352,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<h3 style=\"background-color:DimGray\"><center>Cumulative Data</center></h3>",
-        "mode": "html"
-      },
-      "pluginVersion": "12.0.2",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Today's total power consumption for all sites.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 12,
-        "y": 12
-      },
-      "hideTimeOverride": true,
-      "id": 367,
-      "interval": "5m",
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(sum by (site) (increase(hw_host_energy_joules_total{site !=\"\"}[$__range])) * avg_over_time(avg by (site) (hw_site_pue_ratio)[$__range:5m])) / 3600",
-          "hide": false,
-          "legendFormat": "Today's Live Consumption ",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "timeFrom": "now/d",
-      "title": "Today's Live Consumption ",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall power consumption reported for all sites in the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "green",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 15,
-        "y": 12
-      },
-      "id": 328,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1d:5m]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1d:5m])) * 24",
-          "format": "time_series",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Daily Consumption",
-          "refId": "A"
-        }
-      ],
-      "title": "Daily Consumption",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall energy cost of all sites for the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 18,
-        "y": 12
-      },
-      "id": 99,
-      "interval": "5m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1d:5m]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1d:5m]) * avg_over_time(avg by (site) (hw_site_electricity_cost)[1d:5m])) * 24 / 1000",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Daily Cost",
-          "refId": "A"
-        }
-      ],
-      "title": "Daily Cost",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall volume of CO₂ emitted by all the sites for the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#808080",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-green"
-              }
-            ]
-          },
-          "unit": "masst"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 21,
-        "y": 12
-      },
-      "id": 331,
-      "interval": "5m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1d:5m]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1d:5m]) * avg_over_time(avg by (site) (hw_site_carbon_intensity_grams)[1d:5m])) * 24 / 1000 / 1000 / 1000",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Daily CO₂ Emissions",
-          "refId": "A"
-        }
-      ],
-      "title": "Daily CO₂ Emissions",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Total current power usage of all hosts across all sites.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 0,
-        "y": 14
-      },
-      "id": 155,
-      "interval": "1h",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(hw_host_power_watts) ",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Total Power",
-          "refId": "A"
-        }
-      ],
-      "title": "Total Power",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Today's total power cost for all sites.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 12,
-        "y": 15
-      },
-      "hideTimeOverride": true,
-      "id": 330,
-      "interval": "5m",
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(sum by (site) (increase(hw_host_energy_joules_total[$__range])) * avg_over_time(avg by (site) (hw_site_pue_ratio)[$__range:5m]) * avg_over_time(avg by (site) (hw_site_electricity_cost)[$__range:5m])) / 3600 / 1000",
-          "hide": false,
-          "legendFormat": "Today's Live Cost",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "timeFrom": "now/d",
-      "title": "Today's Live Cost",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall power consumption reported for all sites during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "semi-dark-blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "green",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 15,
-        "y": 15
-      },
-      "id": 320,
-      "interval": "5m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[30d:1h]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[30d:1h])) * 30.437 * 24",
-          "format": "time_series",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Monthly Consumption",
-          "refId": "A"
-        }
-      ],
-      "title": "Monthly Consumption",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall energy cost of all sites for the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "semi-dark-green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 18,
-        "y": 15
-      },
-      "id": 321,
-      "interval": "5m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[30d:1h]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[30d:1h]) * avg_over_time(avg by (site) (hw_site_electricity_cost)[30d:1h])) * 30.437 * 24 / 1000",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Monthly Cost",
-          "refId": "A"
-        }
-      ],
-      "title": "Monthly Cost",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall volume of CO₂ emitted by all the sites for the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on the past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#525252",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-green"
-              }
-            ]
-          },
-          "unit": "masst"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 21,
-        "y": 15
-      },
-      "id": 319,
-      "interval": "5m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[30d:1h]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[30d:1h]) * avg_over_time(avg by (site) (hw_site_carbon_intensity_grams)[30d:1h])) * 30.467 * 24 / 1000 / 1000 / 1000",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Monthly CO₂ Emissions",
-          "refId": "A"
-        }
-      ],
-      "title": "Monthly CO₂ Emissions",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The power consumption's margin of error.\n\nThis value is based on the number of hosts that report measured power consumptions and the number of hosts whose power consumption is estimated.\n\nWhen the power consumed by a host cannot be read, Hardware Sentry estimates this value based on the host's components (CPUs, disks, network interfaces, etc.) and their usage.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 0,
+          "description": "The 25 hosts reporting the hottest ambient temperature.\n\nClick on a host for details.",
+          "id": 277,
           "links": [],
-          "mappings": [],
-          "noValue": "25%",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-yellow"
+          "title": "Hosts Ambient Temperature",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-BlYlRd"
+                  },
+                  "decimals": 1,
+                  "links": [
+                    {
+                      "title": "",
+                      "url": "d/c2K8skm4k/host?orgId=1&var-site=${__data.fields.site}&var-host_name=${__data.fields.host_name}"
+                    }
+                  ],
+                  "max": 30,
+                  "min": 18,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "celsius"
+                },
+                "overrides": []
               },
-              {
-                "color": "super-light-green",
-                "value": 10
-              },
-              {
-                "color": "super-light-yellow",
-                "value": 11
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [],
+                  "fields": "",
+                  "values": true
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
               }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 18
-      },
-      "id": 363,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(sum(hw_host_power_watts{quality=\"estimated\"} * 15) + sum(hw_host_power_watts{quality=\"measured\"} * 5) + 10000 * (sum(present_over_time(metricshub_host_configured[1h])) - (count(max by (host_name) (metricshub_connector_status{state=\"ok\"} == 1))))) / (sum(hw_host_power_watts) + 100 * (sum(present_over_time(metricshub_host_configured[1h])) - (count(max by (host_name) (metricshub_connector_status{state=\"ok\"} == 1)))))",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Margin of Error",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Margin of Error",
-      "transformations": [
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": []
+            },
+            "version": "12.3.2"
           }
         }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
       },
-      "description": "Today's volume of CO₂ emissions for all sites.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#808080",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-green"
-              }
-            ]
-          },
-          "unit": "masst"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 12,
-        "y": 18
-      },
-      "hideTimeOverride": true,
-      "id": 368,
-      "interval": "5m",
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(sum by (site) (increase(hw_host_energy_joules_total[$__range])) * avg_over_time(avg by (site) (hw_site_pue_ratio)[$__range:5m]) * avg_over_time(avg by (site) (hw_site_carbon_intensity_grams)[$__range:5m])) / 3600 / 1000 / 1000 / 1000",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Today's Live CO₂ Emissions",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "timeFrom": "now/d",
-      "title": "Today's Live CO₂ Emissions",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall power consumption reported for all sites during the last year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "dark-blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
+      "panel-299": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "topk(25, max by (site, host_name) (hw_temperature_celsius))",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m",
+                "maxDataPoints": 1
               },
-              {
-                "color": "green",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 15,
-        "y": 18
-      },
-      "id": 317,
-      "interval": "5m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1y:1d]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1y:1d])) * 365 * 24",
-          "format": "time_series",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Yearly Consumption",
-          "refId": "A"
-        }
-      ],
-      "title": "Yearly Consumption",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall energy cost of all sites for the past year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "dark-green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 18,
-        "y": 18
-      },
-      "id": 318,
-      "interval": "5m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1y:1d]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1y:1d]) * avg_over_time(avg by (site) (hw_site_electricity_cost)[1y:1d])) * 365 * 24 / 1000",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Yearly Cost",
-          "refId": "A"
-        }
-      ],
-      "title": "Yearly Cost",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall volume of CO₂ emitted by all the sites for the past year.\n\nIf less than 365 days of data is available, this value is estimated based on the past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#414141",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "dark-green"
-              }
-            ]
-          },
-          "unit": "masst"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 21,
-        "y": 18
-      },
-      "id": 322,
-      "interval": "5m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1y:1d]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1y:1d]) * avg_over_time(avg by (site) (hw_site_carbon_intensity_grams)[1y:1d])) * 365 * 24 / 1000 / 1000 / 1000",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Yearly CO₂ Emissions",
-          "refId": "A"
-        }
-      ],
-      "title": "Yearly CO₂ Emissions",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 21
-      },
-      "id": 354,
-      "panels": [],
-      "title": "Sites",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "left",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": false
-          },
-          "links": [
-            {
-              "title": "",
-              "url": "/d/SHFBpSH7z/site-information?orgId=1&var-site=${__data.fields.site}"
+              "transformations": [
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "host_name",
+                          "site",
+                          "Value"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Value": false,
+                        "host_name": false
+                      },
+                      "indexByName": {
+                        "Time": 2,
+                        "Value": 3,
+                        "host_name": 1,
+                        "site": 0
+                      },
+                      "renameByName": {}
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "Value"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
             }
-          ],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
+          },
+          "description": "The temperature sensors reporting the highest temperatures at the moment.\n\nClick on a temperature for details.",
+          "id": 299,
+          "links": [],
+          "title": "Hosts Highest Temperature Sensor ",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-BlYlRd"
+                  },
+                  "decimals": 1,
+                  "links": [
+                    {
+                      "title": "",
+                      "url": "d/c2K8skm4k/host?orgId=1&var-site=${__data.fields.site}&var-host_name=${__data.fields.host_name}"
+                    }
+                  ],
+                  "max": 60,
+                  "min": 18,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "celsius"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [],
+                  "fields": "",
+                  "values": true
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
               }
-            ]
+            },
+            "version": "12.3.2"
           }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Electricity Cost (per kWh)"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
+        }
+      },
+      "panel-301": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(ALERTS_FOR_STATE{severity=\"critical\", alertname=~\"MetricsHub-Hardware-.*\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Critical Alerts"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
                 }
-              },
-              {
-                "id": "unit",
-                "value": "currencyUSD"
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 0.4
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
           },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "CO₂ Intensity"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "massg"
+          "description": "",
+          "id": 301,
+          "links": [],
+          "title": "Critical Alerts",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
               },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 500
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
               }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "site"
             },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-303": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(ALERTS_FOR_STATE{severity=\"warning\", alertname=~\"MetricsHub-Hardware-.*\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Warning Alerts"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 303,
+          "links": [],
+          "title": "Warning Alerts",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
               }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "PUE"
             },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Total Power"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "watt"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-308": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "exemplar": false,
+                        "expr": "count by (vendor) (label_replace(hw_status{hw_type=\"enclosure\", state=\"present\"}, \"vendor\", \"Unknown\", \"vendor\", \"^$\"))",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "{{vendor}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
                 }
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "semi-dark-blue",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
           },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Hosts Sites Distribution"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "percentunit"
+          "description": "The hosts distribution per manufacturer.",
+          "id": 308,
+          "links": [],
+          "title": "Hosts Vendor",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  }
+                },
+                "overrides": []
               },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "PUE"
-            },
-            "properties": [
-              {
-                "id": "min",
-                "value": 1
-              },
-              {
-                "id": "max",
-                "value": 2.5
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-text"
+              "options": {
+                "displayLabels": [
+                  "name",
+                  "percent"
+                ],
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": false,
+                  "values": []
+                },
+                "pieType": "pie",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": true
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
                 }
               }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Ambient Temperature"
             },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "celsius"
-              },
-              {
-                "id": "min",
-                "value": 18
-              },
-              {
-                "id": "max",
-                "value": 30
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-BlYlRd"
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-314": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg by (site) (avg_over_time(hw_site_electricity_cost{site != \"\"}[1d])) ",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg by (site) (avg_over_time(hw_site_carbon_intensity_grams{site != \"\"}[1d]))",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg by (site) (avg_over_time(hw_site_pue_ratio{site != \"\"}[1d]))",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (site) (avg_over_time(hw_host_power_watts{site != \"\"}[1d]))",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(count by (host_name, site) (present_over_time(metricshub_host_configured[1h]))) by (site)",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "E"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(count by (host_name, site) (avg_over_time(metricshub_host_configured[1h]))) by (site)\r\n/\r\nscalar(sum(count by (host_name, site) (avg_over_time(metricshub_host_configured[1h]))))",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "F"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg by (site) (avg_over_time(hw_host_ambient_temperature_celsius{site != \"\"}[1d]))",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "G"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "min by (site) (min_over_time(hw_host_heating_margin_celsius{site != \"\"}[1d]))",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "H"
+                  }
                 }
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "basic",
-                  "type": "color-background"
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "merge",
+                  "spec": {
+                    "id": "merge",
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "site": false
+                      },
+                      "indexByName": {
+                        "Time": 0,
+                        "Value #A": 6,
+                        "Value #B": 7,
+                        "Value #C": 5,
+                        "Value #D": 4,
+                        "Value #E": 2,
+                        "Value #F": 3,
+                        "site": 1
+                      },
+                      "renameByName": {
+                        "Time": "",
+                        "Value #A": "Electricity Cost",
+                        "Value #B": "CO₂ Intensity",
+                        "Value #C": "PUE",
+                        "Value #D": "Total Power",
+                        "Value #E": "Hosts Count",
+                        "Value #F": "Hosts Sites Distribution",
+                        "Value #G": "Ambient Temperature",
+                        "Value #H": "Heating Margin",
+                        "site": "Site",
+                        "{site=\"Boston\"}": "Hosts Count"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "site"
+                        }
+                      ]
+                    }
+                  }
                 }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "noValue",
-                "value": "No Temperatures"
-              }
-            ]
+              ]
+            }
           },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Heating Margin"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "celsius"
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "thresholds"
-                }
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "applyToRow": false,
-                  "mode": "basic",
-                  "type": "color-background",
-                  "wrapText": false
-                }
-              },
-              {
-                "id": "noValue",
-                "value": "No Temperatures"
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
+          "description": "",
+          "id": 314,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "left",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "links": [
                     {
-                      "color": "red"
+                      "title": "",
+                      "url": "/d/SHFBpSH7z/site-information?orgId=1&var-site=${__data.fields.site}"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Electricity Cost (per kWh)"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "currencyUSD"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 0.4
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-GrYlRd"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "CO₂ Intensity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "massg"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 500
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-GrYlRd"
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "site"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "PUE"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Total Power"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "watt"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "semi-dark-blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Hosts Sites Distribution"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "PUE"
+                    },
+                    "properties": [
+                      {
+                        "id": "min",
+                        "value": 1
+                      },
+                      {
+                        "id": "max",
+                        "value": 2.5
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-GrYlRd"
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Ambient Temperature"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "celsius"
+                      },
+                      {
+                        "id": "min",
+                        "value": 18
+                      },
+                      {
+                        "id": "max",
+                        "value": 30
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-BlYlRd"
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "No Temperatures"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Heating Margin"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "celsius"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "thresholds"
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "applyToRow": false,
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.wrapText",
+                        "value": false
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "No Temperatures"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 5
+                            },
+                            {
+                              "color": "orange",
+                              "value": 10
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Hosts Count"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "CO₂ Intensity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "grams/kWh"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Electricity Cost"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "$/kWh"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Electricity Cost (per kWh)"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-317": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1y:1d]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1y:1d])) * 365 * 24",
+                        "format": "time_series",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Yearly Consumption"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The overall power consumption reported for all sites during the last year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
+          "id": 317,
+          "links": [],
+          "title": "Yearly Consumption",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "dark-blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "green",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-318": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1y:1d]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1y:1d]) * avg_over_time(avg by (site) (hw_site_electricity_cost)[1y:1d])) * 365 * 24 / 1000",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Yearly Cost"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The overall energy cost of all sites for the past year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
+          "id": 318,
+          "links": [],
+          "title": "Yearly Cost",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "dark-green",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-319": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[30d:1h]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[30d:1h]) * avg_over_time(avg by (site) (hw_site_carbon_intensity_grams)[30d:1h])) * 30.467 * 24 / 1000 / 1000 / 1000",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Monthly CO₂ Emissions"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The overall volume of CO₂ emitted by all the sites for the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on the past collected data.",
+          "id": 319,
+          "links": [],
+          "title": "Monthly CO₂ Emissions",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#525252",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masst"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-320": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[30d:1h]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[30d:1h])) * 30.437 * 24",
+                        "format": "time_series",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Monthly Consumption"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The overall power consumption reported for all sites during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on past collected data.",
+          "id": 320,
+          "links": [],
+          "title": "Monthly Consumption",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "semi-dark-blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "green",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-321": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[30d:1h]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[30d:1h]) * avg_over_time(avg by (site) (hw_site_electricity_cost)[30d:1h])) * 30.437 * 24 / 1000",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Monthly Cost"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The overall energy cost of all sites for the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on past collected data.",
+          "id": 321,
+          "links": [],
+          "title": "Monthly Cost",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "semi-dark-green",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-322": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1y:1d]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1y:1d]) * avg_over_time(avg by (site) (hw_site_carbon_intensity_grams)[1y:1d])) * 365 * 24 / 1000 / 1000 / 1000",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Yearly CO₂ Emissions"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The overall volume of CO₂ emitted by all the sites for the past year.\n\nIf less than 365 days of data is available, this value is estimated based on the past collected data.",
+          "id": 322,
+          "links": [],
+          "title": "Yearly CO₂ Emissions",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#414141",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masst"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-328": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1d:5m]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1d:5m])) * 24",
+                        "format": "time_series",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Daily Consumption"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall power consumption reported for all sites in the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
+          "id": 328,
+          "links": [],
+          "title": "Daily Consumption",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "green",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-330": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sum by (site) (increase(hw_host_energy_joules_total[$__range])) * avg_over_time(avg by (site) (hw_site_pue_ratio)[$__range:5m]) * avg_over_time(avg by (site) (hw_site_electricity_cost)[$__range:5m])) / 3600 / 1000",
+                        "legendFormat": "Today's Live Cost",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "hideTimeOverride": true,
+                "interval": "5m",
+                "timeFrom": "now/d"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Today's total power cost for all sites.",
+          "id": 330,
+          "links": [],
+          "title": "Today's Live Cost",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-331": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1d:5m]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1d:5m]) * avg_over_time(avg by (site) (hw_site_carbon_intensity_grams)[1d:5m])) * 24 / 1000 / 1000 / 1000",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Daily CO₂ Emissions"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The overall volume of CO₂ emitted by all the sites for the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
+          "id": 331,
+          "links": [],
+          "title": "Daily CO₂ Emissions",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#808080",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masst"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-333": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": true,
+                        "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1d:5m]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1d:5m])) * 24 + ignoring(year, month, day) group_right\r\n  count_values without() (\"year\", year(timestamp(\r\n    count_values without() (\"month\", month(timestamp(\r\n\t\t\tcount_values without() (\"day\", day_of_month(timestamp(\r\n        sum((sum by (site) (increase(hw_host_energy_joules_total{site != \"\"} [1d]))) / avg by (site) (increase(timestamp(hw_host_energy_joules_total{site != \"\"})[1d:1d])) * 24 * avg by (site) (hw_site_pue_ratio{site != \"\"}))\r\n\t\t\t\t)))\r\n    )))\r\n  ))) * 0",
+                        "format": "table",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "{{unit}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "hideTimeOverride": true,
+                "timeFrom": "now-30d",
+                "timeShift": "1d"
+              },
+              "transformations": [
+                {
+                  "kind": "filterByValue",
+                  "spec": {
+                    "id": "filterByValue",
+                    "options": {
+                      "filters": [
+                        {
+                          "config": {
+                            "id": "regex",
+                            "options": {
+                              "value": "NaN"
+                            }
+                          },
+                          "fieldName": "Value"
+                        }
+                      ],
+                      "match": "any",
+                      "type": "exclude"
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "Time",
+                          "Value"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "desc": false,
+                          "field": "Time"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": false,
+                        "Value": false,
+                        "day": true,
+                        "month": true,
+                        "year": true
+                      },
+                      "indexByName": {},
+                      "renameByName": {
+                        "Time": "",
+                        "day": ""
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The overall daily energy consumption for the past 30 days, as reported.",
+          "id": 333,
+          "links": [],
+          "title": "Daily Energy Consumption (last 30 days)",
+          "vizConfig": {
+            "group": "barchart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "axisSoftMin": 0,
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "displayName": "Daily Energy Consumption (last 30 days)",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Time"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "time:dddd DD/MM"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "barRadius": 0,
+                "barWidth": 0.95,
+                "fullHighlight": false,
+                "groupWidth": 0.7,
+                "legend": {
+                  "calcs": [
+                    "min",
+                    "max",
+                    "last"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "orientation": "auto",
+                "showValue": "always",
+                "stacking": "none",
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "sort": "none"
+                },
+                "xTickLabelRotation": -45,
+                "xTickLabelSpacing": 0
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-348": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "min_over_time(timestamp(metricshub_host_configured)[1y:1w])",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "__auto"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": [
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "",
+                      "binary": {
+                        "left": "Value",
+                        "operator": "*",
+                        "reducer": "sum",
+                        "right": "1000"
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "include": [
+                          "Last Seen"
+                        ],
+                        "reducer": "last"
+                      },
+                      "replaceFields": false
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Value": true,
+                        "Value #A": true,
+                        "__name__": true,
+                        "agent_host_name": false,
+                        "build_number": true,
+                        "build_number 2": true,
+                        "hc_version 2": true,
+                        "host_id": true,
+                        "host_id 1": true,
+                        "host_id 2": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "project_name": true,
+                        "project_name 1": true,
+                        "project_name 2": true,
+                        "project_version 2": true,
+                        "service_name": true,
+                        "service_name 1": true,
+                        "service_name 2": true,
+                        "site 2": true,
+                        "timestamp": true,
+                        "timestamp 1": true,
+                        "timestamp 2": true
+                      },
+                      "indexByName": {
+                        "Last Seen": 15,
+                        "Time": 6,
+                        "Value": 14,
+                        "agent_host_name": 1,
+                        "build_date": 3,
+                        "build_number": 4,
+                        "hc_version": 5,
+                        "host_id": 7,
+                        "host_name": 8,
+                        "host_type": 9,
+                        "os_type": 10,
+                        "project_name": 11,
+                        "project_version": 2,
+                        "service_name": 12,
+                        "site": 0,
+                        "timestamp": 13
+                      },
+                      "renameByName": {
+                        "Time": "",
+                        "Value": "",
+                        "agent_host_name": "Hostname",
+                        "build_date": "Agent Build Date",
+                        "build_number": "",
+                        "build_number 1": "Agent Build Number",
+                        "hc_version": "Connectors Version",
+                        "hc_version 1": "Connectors Version",
+                        "project_version": "Agent Version",
+                        "project_version 1": "Agent Version",
+                        "site": "Site",
+                        "site 1": "Site",
+                        "timestamp": ""
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Time since the collect of data by Hardware Sentry was first started.",
+          "id": 348,
+          "links": [],
+          "title": "Collect Started",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "text",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "dateTimeFromNow"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value * 1000"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Collect Started"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-351": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 351,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<h3 style=\"background-color:DimGray\"><center>Live Data</center></h3>",
+                "mode": "html"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-352": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 352,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<h3 style=\"background-color:DimGray\"><center>Cumulative Data</center></h3>",
+                "mode": "html"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-359": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(max by (host_name, site) (metricshub_connector_status{state=\"ok\"} == 1)) / sum(max by (host_name, site) (present_over_time(metricshub_host_configured[1h])))",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Coverage"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The percentage of monitored hosts.\n\nA monitored host is a host with at least one responding connector.",
+          "id": 359,
+          "links": [],
+          "title": "Coverage",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "noValue": "0%",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "super-light-red",
+                        "value": 0
+                      },
+                      {
+                        "color": "super-light-yellow",
+                        "value": 0.5
+                      },
+                      {
+                        "color": "super-light-green",
+                        "value": 0.9
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-363": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(sum(hw_host_power_watts{quality=\"estimated\"} * 15) + sum(hw_host_power_watts{quality=\"measured\"} * 5) + 10000 * (sum(present_over_time(metricshub_host_configured[1h])) - (count(max by (host_name) (metricshub_connector_status{state=\"ok\"} == 1))))) / (sum(hw_host_power_watts) + 100 * (sum(present_over_time(metricshub_host_configured[1h])) - (count(max by (host_name) (metricshub_connector_status{state=\"ok\"} == 1)))))",
+                        "instant": true,
+                        "legendFormat": "Margin of Error",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": [
+                {
+                  "kind": "reduce",
+                  "spec": {
+                    "id": "reduce",
+                    "options": {
+                      "reducers": []
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The power consumption's margin of error.\n\nThis value is based on the number of hosts that report measured power consumptions and the number of hosts whose power consumption is estimated.\n\nWhen the power consumed by a host cannot be read, Hardware Sentry estimates this value based on the host's components (CPUs, disks, network interfaces, etc.) and their usage.",
+          "id": 363,
+          "links": [],
+          "title": "Margin of Error",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "noValue": "25%",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "super-light-yellow",
+                        "value": 0
+                      },
+                      {
+                        "color": "super-light-green",
+                        "value": 10
+                      },
+                      {
+                        "color": "super-light-yellow",
+                        "value": 11
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-365": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_replace(\r\n  ALERTS_FOR_STATE{site != \"\", host_name != \"\", alertname=~\"MetricsHub-Hardware-.*\"},\r\n  \"alertname\",\r\n  \"$1\",\r\n  \"alertname\",\r\n  \"MetricsHub-Hardware-(.*)\" # To remove the MetricsHub prefix from the alert name\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "Time",
+                          "host_name",
+                          "name",
+                          "severity",
+                          "site",
+                          "hw_type",
+                          "protocol",
+                          "alertname"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": false,
+                        "Value": true,
+                        "Value #A": true,
+                        "__name__": true,
+                        "agent_host_name": true,
+                        "alertstatus": true,
+                        "alertstatus_code": true,
+                        "applies_to_os": true,
+                        "array_name": true,
+                        "bandwidth": true,
+                        "battery_state": true,
+                        "blade_name": true,
+                        "chemistry": true,
+                        "compiled_file_name": true,
+                        "connector_id": true,
+                        "description": true,
+                        "device_id": true,
+                        "device_type": true,
+                        "display_name": true,
+                        "driver_version": true,
+                        "firmware_version": true,
+                        "fqdn": true,
+                        "host_id": true,
+                        "host_name": false,
+                        "host_type": true,
+                        "hw_type": false,
+                        "id": true,
+                        "identifying_information": true,
+                        "info": true,
+                        "instance": true,
+                        "ip_address": true,
+                        "job": true,
+                        "local_device_name": true,
+                        "location": true,
+                        "logical_address": true,
+                        "model": true,
+                        "name": false,
+                        "os_type": true,
+                        "parent": true,
+                        "physical_address": true,
+                        "power_supply_type": true,
+                        "raid_level": true,
+                        "robotic_type": true,
+                        "sensor_location": true,
+                        "serial_number": true,
+                        "severity": false,
+                        "site": false,
+                        "state": true,
+                        "type": true,
+                        "vendor": true,
+                        "wwn": true,
+                        "zone": true
+                      },
+                      "indexByName": {
+                        "Time": 0,
+                        "Value": 16,
+                        "__name__": 10,
+                        "agent_host_name": 11,
+                        "alertname": 2,
+                        "applies_to_os": 23,
+                        "bandwidth": 27,
+                        "blade_name": 34,
+                        "connector_id": 24,
+                        "description": 25,
+                        "device_id": 17,
+                        "device_type": 26,
+                        "firmware_version": 32,
+                        "host_id": 12,
+                        "host_name": 4,
+                        "host_type": 13,
+                        "hw_type": 5,
+                        "id": 8,
+                        "info": 18,
+                        "ip_address": 36,
+                        "location": 22,
+                        "logical_address": 31,
+                        "model": 19,
+                        "name": 6,
+                        "os_type": 14,
+                        "parent": 9,
+                        "physical_address": 28,
+                        "power_supply_type": 33,
+                        "protocol": 7,
+                        "raid_level": 35,
+                        "sensor_location": 30,
+                        "serial_number": 29,
+                        "severity": 1,
+                        "site": 3,
+                        "state": 15,
+                        "type": 20,
+                        "vendor": 21
+                      },
+                      "renameByName": {
+                        "Time": "Time",
+                        "alertname": "Alert Name",
+                        "fqdn": "",
+                        "host_name": "Hostname",
+                        "hw_type": "Device Type",
+                        "id": "",
+                        "label": "Label",
+                        "name": "Device Name",
+                        "os_type": "",
+                        "protocol": "Protocol",
+                        "severity": "Severity",
+                        "site": "Site"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "Time"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 365,
+          "links": [],
+          "title": "Current Alerts",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "links": [
+                    {
+                      "title": "Host",
+                      "url": "d/c2K8skm4k/host?orgId=1&var-host_name=${__data.fields.Hostname}&var-site=${__data.fields.Site}"
+                    }
+                  ],
+                  "noValue": "No alerts",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Severity"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 109
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "critical": {
+                                "color": "red",
+                                "index": 1,
+                                "text": "Critical"
+                              },
+                              "warning": {
+                                "color": "orange",
+                                "index": 0,
+                                "text": "Warning"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "protocol"
+                    },
+                    "properties": [
+                      {
+                        "id": "noValue",
+                        "value": "N/A"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Device Type"
+                    },
+                    "properties": [
+                      {
+                        "id": "noValue",
+                        "value": "N/A"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Time"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 219
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Alert Name"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 221
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Time"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-366": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sum by (site) (hw_host_power_watts) * avg by (site) (avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[2h])))",
+                        "instant": false,
+                        "legendFormat": "Total Power * PUE",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Total current power usage across all sites, multiplied by the site's PUE, displayed as a graph.\n\nThis number represents the actual power usage of all sites. It takes into account the cooling and other overhead that supports the equipment.",
+          "id": 366,
+          "links": [],
+          "title": "Total Power * PUE",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "axisSoftMin": 0,
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 51,
+                    "gradientMode": "hue",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 2,
+                    "pointSize": 6,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watt"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "min",
+                    "max",
+                    "last"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-367": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(sum by (site) (increase(hw_host_energy_joules_total{site !=\"\"}[$__range])) * avg_over_time(avg by (site) (hw_site_pue_ratio)[$__range:5m])) / 3600",
+                        "legendFormat": "Today's Live Consumption ",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "hideTimeOverride": true,
+                "interval": "5m",
+                "timeFrom": "now/d"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Today's total power consumption for all sites.",
+          "id": 367,
+          "links": [],
+          "title": "Today's Live Consumption ",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-368": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(sum by (site) (increase(hw_host_energy_joules_total[$__range])) * avg_over_time(avg by (site) (hw_site_pue_ratio)[$__range:5m]) * avg_over_time(avg by (site) (hw_site_carbon_intensity_grams)[$__range:5m])) / 3600 / 1000 / 1000 / 1000",
+                        "instant": true,
+                        "legendFormat": "Today's Live CO₂ Emissions",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "hideTimeOverride": true,
+                "interval": "5m",
+                "timeFrom": "now/d"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Today's volume of CO₂ emissions for all sites.",
+          "id": 368,
+          "links": [],
+          "title": "Today's Live CO₂ Emissions",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#808080",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "dark-green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masst"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-369": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "",
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 369,
+          "links": [],
+          "title": "Dashboard Version",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "2026.2",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "light-green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-99": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1d:5m]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1d:5m]) * avg_over_time(avg by (site) (hw_site_electricity_cost)[1d:5m])) * 24 / 1000",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Daily Cost"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The overall energy cost of all sites for the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on past collected data.",
+          "id": 99,
+          "links": [],
+          "title": "Daily Cost",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-188"
+                        },
+                        "height": 4,
+                        "width": 2,
+                        "x": 0,
+                        "y": 0
+                      }
                     },
                     {
-                      "color": "green",
-                      "value": 5
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-359"
+                        },
+                        "height": 4,
+                        "width": 2,
+                        "x": 2,
+                        "y": 0
+                      }
                     },
                     {
-                      "color": "orange",
-                      "value": 10
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-301"
+                        },
+                        "height": 4,
+                        "width": 2,
+                        "x": 4,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-303"
+                        },
+                        "height": 4,
+                        "width": 2,
+                        "x": 6,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-365"
+                        },
+                        "height": 8,
+                        "width": 16,
+                        "x": 8,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-162"
+                        },
+                        "height": 4,
+                        "width": 8,
+                        "x": 0,
+                        "y": 4
+                      }
                     }
                   ]
                 }
               },
-              {
-                "id": "decimals",
-                "value": 0
-              }
-            ]
+              "title": "Overall Information"
+            }
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "Hosts Count"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "CO₂ Intensity"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "grams/kWh"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Electricity Cost"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "$/kWh"
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 22
-      },
-      "id": 314,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "enablePagination": true,
-          "fields": [
-            "Value #D"
-          ],
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "Electricity Cost (per kWh)"
-          }
-        ]
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg by (site) (avg_over_time(hw_site_electricity_cost{site != \"\"}[1d])) ",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg by (site) (avg_over_time(hw_site_carbon_intensity_grams{site != \"\"}[1d]))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg by (site) (avg_over_time(hw_site_pue_ratio{site != \"\"}[1d]))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum by (site) (avg_over_time(hw_host_power_watts{site != \"\"}[1d]))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(count by (host_name, site) (present_over_time(metricshub_host_configured[1h]))) by (site)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "E"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(count by (host_name, site) (avg_over_time(metricshub_host_configured[1h]))) by (site)\r\n/\r\nscalar(sum(count by (host_name, site) (avg_over_time(metricshub_host_configured[1h]))))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "F"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg by (site) (avg_over_time(hw_host_ambient_temperature_celsius{site != \"\"}[1d]))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "G"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "min by (site) (min_over_time(hw_host_heating_margin_celsius{site != \"\"}[1d]))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "H"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "merge",
-          "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "site": false
-            },
-            "indexByName": {
-              "Time": 0,
-              "Value #A": 6,
-              "Value #B": 7,
-              "Value #C": 5,
-              "Value #D": 4,
-              "Value #E": 2,
-              "Value #F": 3,
-              "site": 1
-            },
-            "renameByName": {
-              "Time": "",
-              "Value #A": "Electricity Cost",
-              "Value #B": "CO₂ Intensity",
-              "Value #C": "PUE",
-              "Value #D": "Total Power",
-              "Value #E": "Hosts Count",
-              "Value #F": "Hosts Sites Distribution",
-              "Value #G": "Ambient Temperature",
-              "Value #H": "Heating Margin",
-              "site": "Site",
-              "{site=\"Boston\"}": "Hosts Count"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "site"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The sites' yearly power consumption.\n\nThese values are estimated according to the past data if less than a year of data has been collected.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "dark-blue",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMin": 0,
-            "fillOpacity": 80,
-            "gradientMode": "hue",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineWidth": 1,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [
-            {
-              "title": "Site Information",
-              "url": "/d/SHFBpSH7z/site-information?orgId=1&var-site=${__data.fields.site}"
-            }
-          ],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 0,
-        "y": 29
-      },
-      "id": 119,
-      "interval": "5m",
-      "options": {
-        "barRadius": 0,
-        "barWidth": 0.95,
-        "fullHighlight": false,
-        "groupWidth": 0.7,
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "orientation": "vertical",
-        "showValue": "never",
-        "stacking": "none",
-        "text": {},
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        },
-        "xTickLabelRotation": -45,
-        "xTickLabelSpacing": 0
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(sum by (site) (hw_host_power_watts)[1y:1d]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1y:1d]) * 365 * 24",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{site}}",
-          "refId": "B"
-        }
-      ],
-      "title": "Yearly Consumption",
-      "transformations": [
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "site"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "barchart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The sites' yearly cost.\n\nThese values are estimated according to the past data if less than a year of data has been collected.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "dark-green",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMin": 0,
-            "fillOpacity": 80,
-            "gradientMode": "hue",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineWidth": 1,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [
-            {
-              "title": "Site Information",
-              "url": "/d/SHFBpSH7z/site-information?orgId=1&var-site=${__data.fields.site}"
-            }
-          ],
-          "mappings": [],
-          "thresholds": {
-            "mode": "percentage",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 8,
-        "y": 29
-      },
-      "id": 114,
-      "interval": "5m",
-      "options": {
-        "barRadius": 0,
-        "barWidth": 0.95,
-        "fullHighlight": false,
-        "groupWidth": 0.7,
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "orientation": "vertical",
-        "showValue": "never",
-        "stacking": "none",
-        "text": {},
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        },
-        "xTickLabelRotation": -45,
-        "xTickLabelSpacing": 0
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(sum by (site) (hw_host_power_watts)[1y:1d]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1y:1d]) * avg_over_time(avg by (site) (hw_site_electricity_cost)[1y:1d]) * 365 * 24 / 1000",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{site}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Yearly Cost",
-      "transformations": [
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "site"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "barchart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The sites' yearly CO₂ emissions. \n\nThese values are estimated according to the past data if less than a year of data has been collected.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#414141",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMin": 0,
-            "fillOpacity": 80,
-            "gradientMode": "hue",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineWidth": 1,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [
-            {
-              "title": "Site Information",
-              "url": "/d/SHFBpSH7z/site-information?orgId=1&var-site=${__data.fields.site}"
-            }
-          ],
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "#ccccdc"
-              }
-            ]
-          },
-          "unit": "masst"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 8,
-        "x": 16,
-        "y": 29
-      },
-      "id": 115,
-      "interval": "5m",
-      "options": {
-        "barRadius": 0,
-        "barWidth": 0.95,
-        "fullHighlight": false,
-        "groupWidth": 0.7,
-        "legend": {
-          "calcs": [
-            "last"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "orientation": "vertical",
-        "showValue": "never",
-        "stacking": "none",
-        "text": {},
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        },
-        "xTickLabelRotation": -45,
-        "xTickLabelSpacing": 0
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(sum by (site) (hw_host_power_watts)[1y:1d]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1y:1d]) * avg_over_time(avg by (site) (hw_site_carbon_intensity_grams)[1y:1d]) * 365 * 24 / 1000 / 1000 / 1000",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{site}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Yearly CO₂",
-      "transformations": [
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "site"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "barchart"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 38
-      },
-      "id": 316,
-      "panels": [],
-      "title": "Power and Host Information",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The 10 hosts that currently consume the most energy across all sites.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "thresholds"
-          },
-          "links": [
-            {
-              "title": "",
-              "url": "d/c2K8skm4k/host?orgId=1&var-site=${__field.labels.site}&var-host_name=${__field.labels.host_name}"
-            }
-          ],
-          "mappings": [],
-          "max": 2000,
-          "min": 500,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-blue"
-              },
-              {
-                "color": "light-blue",
-                "value": 500
-              },
-              {
-                "color": "semi-dark-blue",
-                "value": 1000
-              },
-              {
-                "color": "dark-blue",
-                "value": 2000
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 5,
-        "x": 0,
-        "y": 39
-      },
-      "id": 179,
-      "options": {
-        "displayMode": "gradient",
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "maxVizHeight": 300,
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "namePlacement": "auto",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "sizing": "auto",
-        "valueMode": "color"
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "topk(10, hw_host_power_watts)",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{site}}: {{host_name}} ",
-          "refId": "A"
-        }
-      ],
-      "title": "Top Consumers",
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The power consumption distribution by host types: compute (server), storage and network.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 4,
-        "x": 5,
-        "y": 39
-      },
-      "id": 177,
-      "options": {
-        "displayLabels": [
-          "name",
-          "value",
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": false,
-          "values": []
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "sum by (host_type) (hw_host_power_watts)",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{host_type}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Power per Host Type",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The power consumption distribution across platform types: \nHP-UX, IBM AIX, Management (i.e management card), Microsoft Windows, Linux, \nOracle Solaris and Storage.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "links": [],
-          "mappings": [
-            {
-              "options": {
-                "linux": {
-                  "index": 0,
-                  "text": "Linux"
-                },
-                "management": {
-                  "index": 1,
-                  "text": "Out-of-band"
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-181"
+                        },
+                        "height": 4,
+                        "width": 4,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-366"
+                        },
+                        "height": 11,
+                        "width": 8,
+                        "x": 4,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-351"
+                        },
+                        "height": 2,
+                        "width": 3,
+                        "x": 12,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-352"
+                        },
+                        "height": 2,
+                        "width": 9,
+                        "x": 15,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-367"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 12,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-328"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 15,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-99"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 18,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-331"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 21,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-155"
+                        },
+                        "height": 4,
+                        "width": 4,
+                        "x": 0,
+                        "y": 4
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-330"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 12,
+                        "y": 5
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-320"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 15,
+                        "y": 5
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-321"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 18,
+                        "y": 5
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-319"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 21,
+                        "y": 5
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-363"
+                        },
+                        "height": 3,
+                        "width": 4,
+                        "x": 0,
+                        "y": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-368"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 12,
+                        "y": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-317"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 15,
+                        "y": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-318"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 18,
+                        "y": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-322"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 21,
+                        "y": 8
+                      }
+                    }
+                  ]
                 }
               },
-              "type": "value"
+              "title": "Power, Cost and CO₂ Emissions"
             }
-          ],
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 5,
-        "x": 9,
-        "y": 39
-      },
-      "id": 172,
-      "options": {
-        "displayLabels": [
-          "name",
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": false,
-          "values": []
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "sum by (os_type) (hw_host_power_watts)",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{site}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Power per Platform Type",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The total number of hosts per type: compute (server), storage and network.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": []
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 5,
-        "x": 14,
-        "y": 39
-      },
-      "id": 168,
-      "options": {
-        "displayLabels": [
-          "name",
-          "value",
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": false,
-          "values": []
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum by (host_type) (metricshub_host_configured)",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{host_type}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Hosts Type",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The hosts distribution per manufacturer.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": []
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 5,
-        "x": 19,
-        "y": 39
-      },
-      "id": 308,
-      "options": {
-        "displayLabels": [
-          "name",
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": false,
-          "values": []
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "count by (vendor) (label_replace(hw_status{hw_type=\"enclosure\", state=\"present\"}, \"vendor\", \"Unknown\", \"vendor\", \"^$\"))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{vendor}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Hosts Vendor",
-      "type": "piechart"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 48
-      },
-      "id": 306,
-      "panels": [],
-      "title": "Hosts Temperatures",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The 25 hosts reporting the hottest ambient temperature.\n\nClick on a host for details.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlYlRd"
-          },
-          "decimals": 1,
-          "links": [
-            {
-              "title": "",
-              "url": "d/c2K8skm4k/host?orgId=1&var-site=${__data.fields.site}&var-host_name=${__data.fields.host_name}"
-            }
-          ],
-          "mappings": [],
-          "max": 30,
-          "min": 18,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 24,
-        "x": 0,
-        "y": 49
-      },
-      "id": 277,
-      "interval": "2m",
-      "maxDataPoints": 1,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": true
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(25, hw_host_ambient_temperature_celsius)",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Hosts Ambient Temperature",
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "host_name",
-                "name",
-                "site",
-                "Value"
-              ]
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Value"
-              }
-            ]
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Value": false,
-              "__name__": true,
-              "agent_host_name": true,
-              "host_id": true,
-              "host_name": false,
-              "host_type": true,
-              "id": true,
-              "label": true,
-              "location": true,
-              "os_type": true,
-              "site": false
-            },
-            "indexByName": {
-              "Time": 2,
-              "Value": 1,
-              "__name__": 3,
-              "agent_host_name": 4,
-              "host_id": 5,
-              "host_name": 6,
-              "host_type": 7,
-              "id": 8,
-              "label": 9,
-              "location": 10,
-              "os_type": 11,
-              "site": 0
-            },
-            "renameByName": {}
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The temperature sensors reporting the highest temperatures at the moment.\n\nClick on a temperature for details.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlYlRd"
-          },
-          "decimals": 1,
-          "links": [
-            {
-              "title": "",
-              "url": "d/c2K8skm4k/host?orgId=1&var-site=${__data.fields.site}&var-host_name=${__data.fields.host_name}"
-            }
-          ],
-          "mappings": [],
-          "max": 60,
-          "min": 18,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 24,
-        "x": 0,
-        "y": 53
-      },
-      "id": 299,
-      "interval": "2m",
-      "maxDataPoints": 1,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [],
-          "fields": "",
-          "values": true
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(25, max by (site, host_name) (hw_temperature_celsius))",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Hosts Highest Temperature Sensor ",
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "host_name",
-                "site",
-                "Value"
-              ]
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Value": false,
-              "host_name": false
-            },
-            "indexByName": {
-              "Time": 2,
-              "Value": 3,
-              "host_name": 1,
-              "site": 0
-            },
-            "renameByName": {}
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Value"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 57
-      },
-      "id": 194,
-      "panels": [],
-      "title": "History",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall daily energy consumption for the past 30 days, as reported.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMin": 0,
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineWidth": 1,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "displayName": "Daily Energy Consumption (last 30 days)",
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue"
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "time:dddd DD/MM"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 12,
-        "w": 24,
-        "x": 0,
-        "y": 58
-      },
-      "hideTimeOverride": true,
-      "id": 333,
-      "options": {
-        "barRadius": 0,
-        "barWidth": 0.95,
-        "fullHighlight": false,
-        "groupWidth": 0.7,
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "last"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "orientation": "auto",
-        "showValue": "always",
-        "stacking": "none",
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        },
-        "xTickLabelRotation": -45,
-        "xTickLabelSpacing": 0
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(avg_over_time(sum by (site) (hw_host_power_watts)[1d:5m]) * avg_over_time(avg by (site) (hw_site_pue_ratio)[1d:5m])) * 24 + ignoring(year, month, day) group_right\r\n  count_values without() (\"year\", year(timestamp(\r\n    count_values without() (\"month\", month(timestamp(\r\n\t\t\tcount_values without() (\"day\", day_of_month(timestamp(\r\n        sum((sum by (site) (increase(hw_host_energy_joules_total{site != \"\"} [1d]))) / avg by (site) (increase(timestamp(hw_host_energy_joules_total{site != \"\"})[1d:1d])) * 24 * avg by (site) (hw_site_pue_ratio{site != \"\"}))\r\n\t\t\t\t)))\r\n    )))\r\n  ))) * 0",
-          "format": "table",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{unit}}",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": "now-30d",
-      "timeShift": "1d",
-      "title": "Daily Energy Consumption (last 30 days)",
-      "transformations": [
-        {
-          "id": "filterByValue",
-          "options": {
-            "filters": [
-              {
-                "config": {
-                  "id": "regex",
-                  "options": {
-                    "value": "NaN"
-                  }
-                },
-                "fieldName": "Value"
-              }
-            ],
-            "match": "any",
-            "type": "exclude"
-          }
-        },
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "Time",
-                "Value"
-              ]
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "Time"
-              }
-            ]
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": false,
-              "Value": false,
-              "day": true,
-              "month": true,
-              "year": true
-            },
-            "indexByName": {},
-            "renameByName": {
-              "Time": "",
-              "day": ""
-            }
-          }
-        }
-      ],
-      "type": "barchart"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 70
-      },
-      "id": 107,
-      "panels": [],
-      "title": "Hardware Sentry Agents Status",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Time since the collect of data by Hardware Sentry was first started.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "text",
-            "mode": "fixed"
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          },
-          "unit": "dateTimeFromNow"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value * 1000"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Collect Started"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 0,
-        "y": 71
-      },
-      "id": 348,
-      "interval": "1h",
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "min_over_time(timestamp(metricshub_host_configured)[1y:1w])",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "__auto",
-          "refId": "A"
-        }
-      ],
-      "title": "Collect Started",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "",
-            "binary": {
-              "left": "Value",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "1000"
-            },
-            "mode": "binary",
-            "reduce": {
-              "include": [
-                "Last Seen"
-              ],
-              "reducer": "last"
-            },
-            "replaceFields": false
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Value": true,
-              "Value #A": true,
-              "__name__": true,
-              "agent_host_name": false,
-              "build_number": true,
-              "build_number 2": true,
-              "hc_version 2": true,
-              "host_id": true,
-              "host_id 1": true,
-              "host_id 2": true,
-              "host_name": true,
-              "host_name 1": true,
-              "host_name 2": true,
-              "host_type": true,
-              "host_type 1": true,
-              "host_type 2": true,
-              "os_type": true,
-              "os_type 1": true,
-              "os_type 2": true,
-              "project_name": true,
-              "project_name 1": true,
-              "project_name 2": true,
-              "project_version 2": true,
-              "service_name": true,
-              "service_name 1": true,
-              "service_name 2": true,
-              "site 2": true,
-              "timestamp": true,
-              "timestamp 1": true,
-              "timestamp 2": true
-            },
-            "indexByName": {
-              "Last Seen": 15,
-              "Time": 6,
-              "Value": 14,
-              "agent_host_name": 1,
-              "build_date": 3,
-              "build_number": 4,
-              "hc_version": 5,
-              "host_id": 7,
-              "host_name": 8,
-              "host_type": 9,
-              "os_type": 10,
-              "project_name": 11,
-              "project_version": 2,
-              "service_name": 12,
-              "site": 0,
-              "timestamp": 13
-            },
-            "renameByName": {
-              "Time": "",
-              "Value": "",
-              "agent_host_name": "Hostname",
-              "build_date": "Agent Build Date",
-              "build_number": "",
-              "build_number 1": "Agent Build Number",
-              "hc_version": "Connectors Version",
-              "hc_version 1": "Connectors Version",
-              "project_version": "Agent Version",
-              "project_version 1": "Agent Version",
-              "site": "Site",
-              "site 1": "Site",
-              "timestamp": ""
-            }
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "inspect": false
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Last Seen"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 316
-              },
-              {
-                "id": "unit",
-                "value": "dateTimeFromNow"
-              },
-              {
-                "id": "custom.align",
-                "value": "right"
-              }
-            ]
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "Hostname"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Site"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 18,
-        "x": 3,
-        "y": 71
-      },
-      "id": 206,
-      "interval": "1h",
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "Site"
-          }
-        ]
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "last_over_time(timestamp(metricshub_agent_info)[6h:])",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "agent_host_name",
-                "build_date",
-                "site",
-                "version",
-                "Value",
-                "build_number"
-              ]
-            }
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Last Seen",
-            "binary": {
-              "left": {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Value"
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-314"
+                        },
+                        "height": 5,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-119"
+                        },
+                        "height": 9,
+                        "width": 8,
+                        "x": 0,
+                        "y": 5
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-114"
+                        },
+                        "height": 9,
+                        "width": 8,
+                        "x": 8,
+                        "y": 5
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-115"
+                        },
+                        "height": 9,
+                        "width": 8,
+                        "x": 16,
+                        "y": 5
+                      }
+                    }
+                  ]
                 }
               },
-              "operator": "*",
-              "right": {
-                "fixed": "1000"
-              }
-            },
-            "mode": "binary",
-            "reduce": {
-              "include": [
-                "Last Seen"
-              ],
-              "reducer": "last"
-            },
-            "replaceFields": false
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Value": true,
-              "Value #A": true,
-              "__name__": true,
-              "agent_host_name": false,
-              "build_number": false,
-              "build_number 2": true,
-              "hc_version 2": true,
-              "host_id": true,
-              "host_id 1": true,
-              "host_id 2": true,
-              "host_name": true,
-              "host_name 1": true,
-              "host_name 2": true,
-              "host_type": true,
-              "host_type 1": true,
-              "host_type 2": true,
-              "job": true,
-              "name": true,
-              "os_type": true,
-              "os_type 1": true,
-              "os_type 2": true,
-              "otel_version": true,
-              "project_name": true,
-              "project_name 1": true,
-              "project_name 2": true,
-              "project_version": true,
-              "project_version 2": true,
-              "service_name": true,
-              "service_name 1": true,
-              "service_name 2": true,
-              "site 2": true,
-              "timestamp": true,
-              "timestamp 1": true,
-              "timestamp 2": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Last Seen": 5,
-              "Value": 6,
-              "agent_host_name": 0,
-              "build_date": 2,
-              "build_number": 3,
-              "site": 4,
-              "version": 1
-            },
-            "renameByName": {
-              "Last Seen": "",
-              "Time": "",
-              "Value": "",
-              "agent_host_name": "Hostname",
-              "build_date": "Build Date",
-              "build_number": "Build Number",
-              "build_number 1": "Agent Build Number",
-              "hc_version": "Connectors Version",
-              "hc_version 1": "Connectors Version",
-              "name": "",
-              "project_version": "",
-              "project_version 1": "Agent Version",
-              "site": "Site",
-              "site 1": "Site",
-              "timestamp": "",
-              "version": "Version"
+              "title": "Sites"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-179"
+                        },
+                        "height": 9,
+                        "width": 5,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-177"
+                        },
+                        "height": 9,
+                        "width": 4,
+                        "x": 5,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-172"
+                        },
+                        "height": 9,
+                        "width": 5,
+                        "x": 9,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-168"
+                        },
+                        "height": 9,
+                        "width": 5,
+                        "x": 14,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-308"
+                        },
+                        "height": 9,
+                        "width": 5,
+                        "x": 19,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Power and Host Information"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-277"
+                        },
+                        "height": 4,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-299"
+                        },
+                        "height": 4,
+                        "width": 24,
+                        "x": 0,
+                        "y": 4
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Hosts Temperatures"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-333"
+                        },
+                        "height": 12,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "History"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-348"
+                        },
+                        "height": 4,
+                        "width": 3,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-206"
+                        },
+                        "height": 4,
+                        "width": 18,
+                        "x": 3,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-369"
+                        },
+                        "height": 4,
+                        "width": 3,
+                        "x": 21,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Hardware Sentry Agents Status"
             }
           }
-        }
-      ],
-      "type": "table"
+        ]
+      }
     },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "noValue": "2026.1",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-green"
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 21,
-        "y": 71
-      },
-      "id": 369,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Dashboard Version",
-      "type": "stat"
-    }
-  ],
-  "refresh": "30s",
-  "schemaVersion": 41,
-  "tags": [
-    "hw_main"
-  ],
-  "templating": {
-    "list": [
+    "links": [
       {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(site)",
-        "hide": 2,
-        "includeAll": true,
-        "label": "site",
-        "multi": true,
-        "name": "site",
-        "options": [],
-        "query": {
-          "query": "label_values(site)",
-          "refId": "StandardVariableQuery"
-        },
-        "refresh": 2,
-        "regex": "",
-        "sort": 2,
-        "type": "query"
+        "asDropdown": false,
+        "icon": "external link",
+        "includeVars": false,
+        "keepTime": false,
+        "tags": [
+          "hw_site"
+        ],
+        "targetBlank": false,
+        "title": "Site",
+        "tooltip": "",
+        "type": "dashboards",
+        "url": ""
+      }
+    ],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "hw_main"
+    ],
+    "timeSettings": {
+      "autoRefresh": "30s",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-7d",
+      "hideTimepicker": false,
+      "timezone": "Europe/Paris",
+      "to": "now"
+    },
+    "title": "Hardware Main (MetricsHub)",
+    "variables": [
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(metricshub_host_configured,site)",
+          "hide": "hideVariable",
+          "includeAll": true,
+          "label": "site",
+          "multi": true,
+          "name": "site",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(metricshub_host_configured,site)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "alphabeticalDesc"
+        }
       }
     ]
   },
-  "time": {
-    "from": "now-7d",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "Europe/Paris",
-  "title": "Hardware Main (MetricsHub)",
-  "uid": "-GV2ChOnz",
-  "version": 11,
-  "weekStart": ""
+  "status": {}
 }

--- a/src/dashboards/Hardware/Hardware Site (MetricsHub).json
+++ b/src/dashboards/Hardware/Hardware Site (MetricsHub).json
@@ -1,4916 +1,6207 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "barchart",
-      "name": "Bar chart",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "12.3.2"
-    },
-    {
-      "type": "panel",
-      "id": "histogram",
-      "name": "Histogram",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "piechart",
-      "name": "Pie chart",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "text",
-      "name": "Text",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "datasource",
-          "uid": "grafana"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "adz9bvt",
+    "generation": 6,
+    "creationTimestamp": "2026-04-29T13:45:08Z",
+    "labels": {},
+    "annotations": {}
   },
-  "description": "Gain insight into the energy usage and costs as well as the carbon emissions of your data center (a site) and its monitored hosts with MetricsHub. Optimize the ambient temperature of your data center based on data-driven recommendations and reduce your cooling costs.\r\n\r\nMetricsHubs collects metrics from servers (Cisco, Dell, HPE, Huawei, IBM Lenovo, SuperMicro, etc.), storage systems (NetApp, Dell EMC, Hitachi, HPE, IBM, Pure, Huawei, etc.), network devices (Cisco, Aruba, Dell, HP, F5, Juniper, Oracle) and other equipment like PDUs, UPS from APC, Raritan, Eaton, etc.",
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 0,
-  "links": [
-    {
-      "asDropdown": false,
-      "icon": "external link",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [
-        "hw_main"
-      ],
-      "targetBlank": false,
-      "title": "",
-      "tooltip": "",
-      "type": "dashboards",
-      "url": ""
-    },
-    {
-      "asDropdown": false,
-      "icon": "external link",
-      "includeVars": true,
-      "keepTime": false,
-      "tags": [
-        "hw_host"
-      ],
-      "targetBlank": false,
-      "title": "Host",
-      "tooltip": "",
-      "type": "dashboards",
-      "url": ""
-    }
-  ],
-  "panels": [
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 120,
-      "panels": [],
-      "title": "Overall Information",
-      "type": "row"
-    },
-    {
-      "description": "",
-      "gridPos": {
-        "h": 2,
-        "w": 24,
-        "x": 0,
-        "y": 1
-      },
-      "id": 44,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<h1 style=\"\">\r\n  <center>$site</center>\r\n</h1>",
-        "mode": "html"
-      },
-      "pluginVersion": "12.3.2",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The number of hosts currently configured to be monitored.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 0,
-        "y": 3
-      },
-      "id": 36,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(count by (host_name) (present_over_time(metricshub_host_configured{site=~\"$site\"}[1h])))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Hosts",
-          "refId": "A"
-        }
-      ],
-      "title": "Hosts",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The percentage of monitored hosts.\n\nA monitored host is a host with at least one responding connector.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 0,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-red",
-                "value": 0
-              },
-              {
-                "color": "super-light-yellow",
-                "value": 0.5
-              },
-              {
-                "color": "super-light-green",
-                "value": 0.9
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 2,
-        "y": 3
-      },
-      "id": 127,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(max by (host_name, site) (metricshub_connector_status{state=\"ok\", site=~\"$site\"} == 1)) / sum(max by (host_name, site) (present_over_time(metricshub_host_configured{site=~\"$site\"}[1h])))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Coverage",
-          "refId": "A"
-        }
-      ],
-      "title": "Coverage",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 4,
-        "y": 3
-      },
-      "id": 61,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(ALERTS_FOR_STATE{severity=\"critical\", site=~\"$site\", alertname=~\"MetricsHub-Hardware-.*\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Critical Alerts",
-          "refId": "A"
-        }
-      ],
-      "title": "Critical Alerts",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 6,
-        "y": 3
-      },
-      "id": 37,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(ALERTS_FOR_STATE{severity=\"warning\", site=~\"$site\", alertname=~\"MetricsHub-Hardware-.*\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Warning Alerts",
-          "refId": "A"
-        }
-      ],
-      "title": "Warning Alerts",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The total number of hosts per type: compute (server), storage and network.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": []
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 8,
-        "y": 3
-      },
-      "id": 59,
-      "options": {
-        "displayLabels": [
-          "name",
-          "value",
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": false,
-          "values": []
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": true
-        },
-        "sort": "desc",
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum by (host_type) (metricshub_host_configured{site=~\"$site\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{host_type}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Host Types",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The hosts distribution per manufacturer.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": []
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 4,
-        "x": 12,
-        "y": 3
-      },
-      "id": 87,
-      "options": {
-        "displayLabels": [
-          "name",
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": false,
-          "values": []
-        },
-        "pieType": "pie",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": true
-        },
-        "sort": "desc",
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "exemplar": false,
-          "expr": "count by (vendor) (label_replace(hw_status{hw_type=\"enclosure\", site=~\"$site\", state=\"present\"}, \"vendor\", \"Unknown\", \"vendor\", \"^$\"))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{vendor}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Hosts Vendors",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The average of the Power Usage Effectiveness over 2 hours.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
             },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "dashed+area"
-            }
-          },
-          "mappings": [],
-          "min": 1,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 1
-              },
-              {
-                "color": "#EAB839",
-                "value": 1.4
-              },
-              {
-                "color": "orange",
-                "value": 1.8
-              },
-              {
-                "color": "red",
-                "value": 2
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 5,
-        "x": 16,
-        "y": 3
-      },
-      "id": 129,
-      "interval": "1h",
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg(avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[2h]))",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "PUE",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "PUE",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The average of the Power Usage Effectiveness over 24 hours.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "continuous-GrYlRd"
-          },
-          "mappings": [],
-          "max": 2.5,
-          "min": 1,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 3,
-        "x": 21,
-        "y": 3
-      },
-      "id": 132,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg(avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[1d]))",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "PUE (24 hrs)",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "PUE (24 hrs)",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The total number of CPUs currently monitored.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "transparent",
-            "mode": "fixed"
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 0,
-        "y": 7
-      },
-      "id": 68,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(hw_status{site=~\"$site\", hw_type=\"cpu\", state=\"present\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "CPUs",
-          "refId": "A"
-        }
-      ],
-      "title": "CPUs",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The total number of connected network cards.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "transparent",
-            "mode": "fixed"
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 2,
-        "y": 7
-      },
-      "id": 70,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(hw_network_up{site=~\"$site\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Connected NICs",
-          "refId": "A"
-        }
-      ],
-      "title": "Connected NICs",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The total disk space in the site.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "transparent",
-            "mode": "fixed"
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 4,
-        "y": 7
-      },
-      "id": 69,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(hw_physical_disk_size_bytes{site=~\"$site\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Disk Space",
-          "refId": "A"
-        }
-      ],
-      "title": "Disk Space",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The total volume of network transfers in the site.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "transparent",
-            "mode": "fixed"
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 6,
-        "y": 7
-      },
-      "id": 71,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(hw_network_io_bytes_total{site=~\"$site\", direction=\"transmit\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Network Transfers",
-          "refId": "A"
-        }
-      ],
-      "title": "Network Tx",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The CO₂ electricity emissions, as provided in the configuration file.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-GrYlRd"
-          },
-          "mappings": [],
-          "max": 500,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "massg"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 16,
-        "y": 7
-      },
-      "id": 56,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg(hw_site_carbon_intensity_grams{site=~\"$site\"})",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "CO₂ Intensity",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "CO₂ Intensity",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Electricity cost, as provided in the configuration file.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-GrYlRd"
-          },
-          "mappings": [],
-          "max": 0.4,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 7
-      },
-      "id": 55,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg(hw_site_electricity_cost{site=~\"$site\"})",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "Electricity Cost",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Electricity Cost",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 10
-      },
-      "id": 118,
-      "panels": [],
-      "title": "Power, Costs and CO₂ Emissions",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The site's current power usage multiplied by the site's PUE.\n\nThis number represents the site's actual power usage. It takes into account the cooling and other overhead that supports the equipment.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 0,
-        "y": 11
-      },
-      "id": 38,
-      "interval": "1h",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(hw_host_power_watts{site=~\"$site\"}) * scalar(avg(hw_site_pue_ratio{site=~\"$site\"}))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Total Power * PUE",
-          "refId": "A"
-        }
-      ],
-      "title": "Total Power * PUE",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The site's current power usage multiplied by the site's PUE, displayed as a graph.\n\nThis number represents the actual power usage of a data center. It takes into account the cooling and other overhead that supports the equipment.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMin": 0,
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 51,
-            "gradientMode": "hue",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 2,
-            "pointSize": 6,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 8,
-        "x": 4,
-        "y": 11
-      },
-      "id": 130,
-      "interval": "5m",
-      "options": {
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "last"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(hw_host_power_watts{site=~\"$site\"}) * scalar(avg(avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[2h])))",
-          "hide": false,
-          "legendFormat": "Total Power * PUE",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Total Power * PUE",
-      "type": "timeseries"
-    },
-    {
-      "description": "",
-      "gridPos": {
-        "h": 2,
-        "w": 3,
-        "x": 12,
-        "y": 11
-      },
-      "id": 112,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<h3 style=\"background-color:Grey\"><center>Live Data</center></h3>",
-        "mode": "html"
-      },
-      "pluginVersion": "12.3.2",
-      "type": "text"
-    },
-    {
-      "description": "",
-      "gridPos": {
-        "h": 2,
-        "w": 9,
-        "x": 15,
-        "y": 11
-      },
-      "id": 114,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<h3 style=\"background-color:Grey\"><center>Cumulative Data</center></h3>",
-        "mode": "html"
-      },
-      "pluginVersion": "12.3.2",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Today's power consumption for the site.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 12,
-        "y": 13
-      },
-      "hideTimeOverride": true,
-      "id": 91,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(increase(hw_host_energy_joules_total{site=~\"$site\"}[$__range])) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[$__range:5m]) / 3600 ",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Today's Live Consumption",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "timeFrom": "now/d",
-      "title": "Today's Live Consumption",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall power consumption reported for the site in the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 15,
-        "y": 13
-      },
-      "id": 154,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1d:5m]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m])) * 24",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Daily Consumption",
-          "refId": "A"
-        }
-      ],
-      "title": "Daily Consumption",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall energy cost reported for the site during the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 18,
-        "y": 13
-      },
-      "id": 151,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1d:5m]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m]) * avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[1d:5m])) * 24 / 1000",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Daily Cost",
-          "range": false,
-          "refId": "B"
-        }
-      ],
-      "title": "Daily Cost",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall volume of CO₂ emitted by the site during the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "masskg"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 21,
-        "y": 13
-      },
-      "id": 152,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1d:5m]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m]) * avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[1d:5m])) * 24 / 1000 / 1000",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Daily CO₂ Emissions",
-          "range": false,
-          "refId": "B"
-        }
-      ],
-      "title": "Daily CO₂ Emissions",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The total current power consumption of all the hosts in the site.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "watt"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 0,
-        "y": 15
-      },
-      "id": 19,
-      "interval": "1h",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(hw_host_power_watts{site=~\"$site\"})",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Total Power",
-          "refId": "A"
-        }
-      ],
-      "title": "Total Power",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Today's power cost for the site.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 12,
-        "y": 16
-      },
-      "hideTimeOverride": true,
-      "id": 92,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(increase(hw_host_energy_joules_total{site=~\"$site\"}[$__range])) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[$__range:5m]) * avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[$__range:5m]) / 3600 / 1000",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Today's Live Cost",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "timeFrom": "now/d",
-      "title": "Today's Live Cost",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall power consumption reported for the site during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "semi-dark-blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 15,
-        "y": 16
-      },
-      "id": 155,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[30d:1h]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[30d:1h])) * 30.437 * 24",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Monthly Consumption",
-          "refId": "A"
-        }
-      ],
-      "title": "Monthly Consumption",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall energy cost reported for the site during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "semi-dark-green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 18,
-        "y": 16
-      },
-      "id": 148,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[30d:1h]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[30d:1h]) * avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[30d:1h])) * 30.437 * 24 /1000",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Monthly Cost",
-          "range": false,
-          "refId": "B"
-        }
-      ],
-      "title": "Monthly Cost",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall volume of CO₂ emitted by the site during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on the past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#525252",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "masst"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 21,
-        "y": 16
-      },
-      "id": 149,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[30d:1h]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[30d:1h]) * avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[30d:1h])) * 30.437 * 24 / 1000 / 1000 / 1000",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Monthly CO₂ Emissions",
-          "range": false,
-          "refId": "B"
-        }
-      ],
-      "title": "Monthly CO₂ Emissions",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The percentage of possible deviation from an exact power consumption value.\n\nThis value is based on the collected data of monitored hosts reporting power consumption and estimated values for hosts not reporting their power consumption.\n\nWhen the power consumed by a host cannot be read, Hardware Sentry estimates this value based on the typical consumption of a host's components (CPUs, disks, network interfaces, etc.).",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 0,
-          "links": [],
-          "mappings": [],
-          "noValue": "25%",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-yellow",
-                "value": 0
-              },
-              {
-                "color": "super-light-green",
-                "value": 10
-              },
-              {
-                "color": "super-light-yellow",
-                "value": 11
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 19
-      },
-      "id": 125,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(sum(hw_host_power_watts{quality=\"estimated\", site=\"$site\"} * 15) + sum(hw_host_power_watts{quality=\"measured\", site=\"$site\"} * 5) + 10000 * (sum(present_over_time(metricshub_host_configured{site=\"$site\"}[1h])) - (count(max by (host_name) (metricshub_connector_status{state=\"ok\", site=\"$site\"} == 1))))) / (sum(hw_host_power_watts{site=\"$site\"}) + 100 * (sum(present_over_time(metricshub_host_configured{site=\"$site\"}[1h])) - (count(max by (host_name) (metricshub_connector_status{state=\"ok\", site=\"$site\"} == 1)))))",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Margin of Error",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Margin of Error",
-      "transformations": [
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": []
+            "version": "v0"
           }
         }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Today's volume of CO₂ emissions for the site.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "decimals": 2,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "masskg"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 12,
-        "y": 19
-      },
-      "hideTimeOverride": true,
-      "id": 48,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(increase(hw_host_energy_joules_total{site=~\"$site\"}[$__range])) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[$__range:5m]) * avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[$__range:5m]) / 3600 / 1000 / 1000",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Today's Live CO₂ Emissions",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "timeFrom": "now/d",
-      "title": "Today's Live CO₂ Emissions",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall power consumption reported for the site during the last year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "dark-blue",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 15,
-        "y": 19
-      },
-      "id": 153,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1y:1d]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1y:1d])) * 365 * 24",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Yearly Consumption",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Yearly Consumption",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall energy cost reported for the site in the past year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "dark-green",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "purple",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 18,
-        "y": 19
-      },
-      "id": 145,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1y:1d]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1y:1d]) * avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[1y:1d])) * 365 * 24 / 1000",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Yearly Cost",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Yearly Cost",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The overall volume of CO₂ emitted by the site during the past year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "#414141",
-            "mode": "fixed"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "purple",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "masst"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 21,
-        "y": 19
-      },
-      "id": 146,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1y:1d]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1y:1d]) * avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[1y:1d])) * 365 * 24 / 1000 / 1000 / 1000",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Yearly CO₂ Emissions",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Yearly CO₂ Emissions",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 22
-      },
-      "id": 67,
-      "panels": [],
-      "title": "Site Temperature Optimization",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The number of degrees Celsius (°C) remaining before the temperature of a host in the site reaches its closest warning temperature threshold.\n\nIt is advised to keep the heating margin above 5°C.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 0,
-          "links": [],
-          "mappings": [],
-          "max": 20,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 5
-              },
-              {
-                "color": "orange",
-                "value": 10
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 0,
-        "y": 23
-      },
-      "id": 2,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "min(min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d]))",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Heating Margin",
-          "refId": "A"
-        }
-      ],
-      "title": "Heating Margin",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The percentage of hosts for which temperature readings are reported.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 0,
-          "links": [
-            {
-              "title": "",
-              "url": "/d/F_gu_3d7z/site_temperatures?orgId=1&${site:queryparam} "
-            }
-          ],
-          "mappings": [],
-          "max": -1,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 50
-              },
-              {
-                "color": "green",
-                "value": 75
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 4,
-        "y": 23
-      },
-      "id": 74,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(hw_host_ambient_temperature_celsius{site=~\"$site\"}) / sum(present_over_time(metricshub_host_configured{site=~\"$site\"}[1h])) * 100",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Monitoring Confidence",
-          "refId": "A"
-        }
-      ],
-      "title": "Monitoring Confidence",
-      "transformations": [
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": []
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The lowest host's heating margin of all hosts in the site.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": true,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 3,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "area"
-            }
-          },
-          "mappings": [],
-          "max": 15,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 5
-              },
-              {
-                "color": "light-yellow",
-                "value": 10
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 9,
-        "x": 7,
-        "y": 23
-      },
-      "id": 76,
-      "interval": "1h",
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "min(hw_host_heating_margin_celsius{site=\"$site\"})",
-          "interval": "",
-          "legendFormat": "Heating Margin",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Site Heating Margin",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The estimation of the site's temperature based on the ambient temperature of all hosts in the site.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlYlRd"
-          },
-          "decimals": 1,
-          "links": [],
-          "mappings": [],
-          "max": 30,
-          "min": 18,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 18
-              },
-              {
-                "color": "yellow",
-                "value": 26
-              },
-              {
-                "color": "dark-red",
-                "value": 30
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 4,
-        "x": 16,
-        "y": 23
-      },
-      "id": 4,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg(hw_host_ambient_temperature_celsius{site=~\"$site\"})",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "Site Temperature",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Current Site Temperature",
-      "transformations": [
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": []
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The estimated energy consumption cuts based on the current power consumption, heating margin, site temperature and recommended site temperature.\n\nIf the recommended site temperature is lower than the current site temperature, this number may be negative.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 1,
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-red",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 23
-      },
-      "id": 82,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(avg_over_time(hw_host_power_watts{site=~\"$site\"}[1d])) * (avg(avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[1d])) - 1.15) * 24 * 365 * (clamp_max(avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])) + min(min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d])) - 5 - ((avg(max_over_time(avg(hw_host_ambient_temperature_celsius{site=~\"$site\"})[1d:])) - avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])))), 29) - avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d]))) * 0.05",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Potential Yearly Energy Savings",
-      "transformations": [
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": []
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The number of hosts according to their heating margin.\n\nThe abscissa shows the heating margin.\nThe ordinate represents the number of hosts  for a given heating margin.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "red",
-            "mode": "fixed"
-          },
-          "custom": {
-            "fillOpacity": 80,
-            "gradientMode": "hue",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineWidth": 1,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            }
-          },
-          "decimals": 0,
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 7,
-        "x": 0,
-        "y": 26
-      },
-      "id": 157,
-      "maxDataPoints": 1,
-      "options": {
-        "bucketOffset": 0,
-        "bucketSize": 1,
-        "combine": true,
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "min by (host_name) (min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d]))",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "B"
-        }
-      ],
-      "title": "Heating Margin Host Distribution",
-      "type": "histogram"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The estimated yearly savings based on the current power consumption, heating margin, site temperature and recommended site temperature.\n\nIf the recommended site temperature is lower than the current site temperature, this number may be negative.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 1,
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-red",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "currencyUSD"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 26
-      },
-      "id": 83,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(avg_over_time(hw_host_power_watts{site=~\"$site\"}[1d])) * (avg(avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[1d])) - 1.15) * 24 * 365 * (clamp_max(avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])) + min(min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d])) - 5 - ((max_over_time(avg(hw_host_ambient_temperature_celsius{site=~\"$site\"})[1d:]) - avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])))), 29) - avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d]))) * 0.05 * avg(avg_over_time(hw_site_electricity_cost{site=~\"$site\"}[1d])) / 1000",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Potential Yearly Savings",
-      "transformations": [
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": []
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The recommended site temperature based on the site's current heating margin, as well as the current and past site temperatures.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "transparent",
-            "mode": "fixed"
-          },
-          "decimals": 0,
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "celsius"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 4,
-        "x": 16,
-        "y": 28
-      },
-      "id": 81,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "clamp_min(clamp_max(avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])) * 2 + min(min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d])) - max_over_time(avg(hw_host_ambient_temperature_celsius{site=~\"$site\"})[1d:]) - 5, 29), 15)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Recommended Max Site Temperature",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The estimated CO₂ emissions reduction based on the current power consumption, heating margin, site temperature and recommended site temperature.\n\nIf the recommended site temperature is lower than the current site temperature, this number may be negative.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 1,
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "super-light-red",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "masst"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 4,
-        "x": 20,
-        "y": 29
-      },
-      "id": 84,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(avg_over_time(hw_host_power_watts{site=~\"$site\"}[1d])) * (avg(avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[1d])) - 1.15) * 24 * 365 * (clamp_max(avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])) + min(min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d])) - 5 - ((max_over_time(avg(hw_host_ambient_temperature_celsius{site=~\"$site\"})[1d:]) - avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])))), 29) - avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d]))) * 0.05 * avg(avg_over_time(hw_site_carbon_intensity_grams{site=~\"$site\"}[1d])) / 1000 / 1000000",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Potential Yearly CO₂ Reduction",
-      "transformations": [
-        {
-          "id": "reduce",
-          "options": {
-            "reducers": []
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 32
-      },
-      "id": 63,
-      "panels": [],
-      "title": "Hosts",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "links": [
-            {
-              "title": "d/c2K8skm4k/host?orgId=1",
-              "url": "d/c2K8skm4k/host?orgId=1&${site:queryparam}&var-host_name=${__data.fields.Host}"
-            }
-          ],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Power Consumption"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "unit",
-                "value": "watt"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Power Consumption"
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 3000
-              },
-              {
-                "id": "custom.align",
-                "value": "left"
-              },
-              {
-                "id": "custom.filterable"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Heating Margin"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "basic",
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "unit",
-                "value": "celsius"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
+      }
+    ],
+    "cursorSync": "Off",
+    "description": "Gain insight into the energy usage and costs as well as the carbon emissions of your data center (a site) and its monitored hosts with MetricsHub. Optimize the ambient temperature of your data center based on data-driven recommendations and reduce your cooling costs.\r\n\r\nMetricsHubs collects metrics from servers (Cisco, Dell, HPE, Huawei, IBM Lenovo, SuperMicro, etc.), storage systems (NetApp, Dell EMC, Hitachi, HPE, IBM, Pure, Huawei, etc.), network devices (Cisco, Aruba, Dell, HP, F5, Juniper, Oracle) and other equipment like PDUs, UPS from APC, Raritan, Eaton, etc.",
+    "editable": true,
+    "elements": {
+      "panel-107": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "min_over_time(timestamp(metricshub_host_configured{site=~\"$site\"})[1y:1d])",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
                     },
-                    {
-                      "color": "red",
-                      "value": 0
-                    },
-                    {
-                      "color": "green",
-                      "value": 5
-                    },
-                    {
-                      "color": "orange",
-                      "value": 10
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "thresholds"
-                }
-              },
-              {
-                "id": "custom.filterable",
-                "value": false
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "custom.filterable"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Operating System"
-            },
-            "properties": [
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "aix": {
-                        "index": 1,
-                        "text": "IBM AIX"
-                      },
-                      "hpux": {
-                        "index": 4,
-                        "text": "HP-UX"
-                      },
-                      "linux": {
-                        "index": 0,
-                        "text": "Linux"
-                      },
-                      "management": {
-                        "index": 6,
-                        "text": "Management"
-                      },
-                      "solaris": {
-                        "index": 2,
-                        "text": "Oracle Solaris"
-                      },
-                      "storage": {
-                        "index": 5,
-                        "text": "Storage"
-                      },
-                      "windows": {
-                        "index": 3,
-                        "text": "Microsoft Windows"
-                      }
-                    },
-                    "type": "value"
+                    "refId": "A"
                   }
-                ]
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Last Seen"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "dateTimeFromNow"
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
               },
-              {
-                "id": "mappings",
-                "value": [
-                  {
+              "transformations": [
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
                     "options": {
-                      "match": "null+nan",
-                      "result": {
-                        "color": "red",
-                        "index": 0,
-                        "text": "Unknown"
-                      }
-                    },
-                    "type": "special"
-                  }
-                ]
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "transparent",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.filterable"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Host Temperature"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "celsius"
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "thresholds"
-                }
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "light-blue",
-                      "value": 0
-                    },
-                    {
-                      "color": "green",
-                      "value": 20
-                    },
-                    {
-                      "color": "#EAB839",
-                      "value": 28
-                    },
-                    {
-                      "color": "red",
-                      "value": 30
+                      "alias": "",
+                      "binary": {
+                        "left": "Value",
+                        "operator": "*",
+                        "reducer": "sum",
+                        "right": "1000"
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "include": [
+                          "Last Seen"
+                        ],
+                        "reducer": "last"
+                      },
+                      "replaceFields": false
                     }
-                  ]
-                }
-              },
-              {
-                "id": "custom.filterable"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Matching Connectors"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "color"
-              },
-              {
-                "id": "noValue",
-                "value": "0"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "red",
-                      "value": 0
-                    },
-                    {
-                      "color": "transparent",
-                      "value": 1
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "custom.filterable"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Critical Alerts"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "color"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 1
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "custom.filterable",
-                "value": false
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Warnings"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "color"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "orange",
-                      "value": 1
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "custom.filterable"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Failed Protocols"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "color"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 1
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "custom.filterable"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Failed Connectors"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "color"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 1
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "custom.filterable"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 13,
-        "w": 24,
-        "x": 0,
-        "y": 33
-      },
-      "id": 6,
-      "interval": "1h",
-      "options": {
-        "cellHeight": "sm",
-        "enablePagination": false,
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Failed Connectors"
-          }
-        ]
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "round(rate(hw_host_energy_joules_total{site=~\"$site\"}[1d]))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d])",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "last_over_time(timestamp(metricshub_host_up{site=~\"$site\"})[6h:])",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "range": false,
-          "refId": "D"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "metricshub_host_configured{site=~\"$site\"}",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "E"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum by (host_name) (metricshub_connector_status{site=~\"$site\"})",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "TotalConnectors"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(\r\n  count(ALERTS_FOR_STATE{severity=\"critical\", site=~\"$site\", alertname=~\"MetricsHub-Hardware-.*\"}) by (host_name)\r\n  or \r\n  (0 * count by (host_name) (hw_host_power_watts{site=~\"$site\"})) # This is used to make sure a column is always created\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "CriticalAlerts"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "(\r\n  count(ALERTS_FOR_STATE{severity=\"warning\", site=~\"$site\", alertname=~\"MetricsHub-Hardware-.*\"}) by (host_name)\r\n  or \r\n  (0 * count by (host_name) (hw_host_power_watts{site=~\"$site\"})) # This is used to make sure a column is always created\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "Warnings"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "(count by (host_name) (metricshub_host_up{site=~\"$site\"} == 0)) \r\nor \r\n(count by (host_name) (metricshub_host_up{site=~\"$site\"}) * 0)",
-          "format": "table",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "ProtocolErrors"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (host_name) (metricshub_connector_status{site=~\"$site\", state=\"failed\"}) \r\nor \r\n(0 * count by (host_name) (hw_host_power_watts{site=~\"$site\"}))",
-          "format": "table",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "FailedConnectors"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "seriesToColumns",
-          "options": {
-            "byField": "host_name"
-          }
-        },
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Last Seen",
-            "binary": {
-              "left": {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Value #C"
-                }
-              },
-              "operator": "*",
-              "right": {
-                "fixed": "1000"
-              }
-            },
-            "mode": "binary",
-            "reduce": {
-              "reducer": "sum"
-            },
-            "window": {
-              "reducer": "mean",
-              "windowAlignment": "trailing",
-              "windowSize": 0.1,
-              "windowSizeMode": "percentage"
-            }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Time 3": true,
-              "Time 6": true,
-              "Value #A": false,
-              "Value #C": true,
-              "Value #E": true,
-              "__name__": true,
-              "__name__ 1": true,
-              "__name__ 2": true,
-              "agent_host_name 1": true,
-              "agent_host_name 2": true,
-              "agent_host_name 3": true,
-              "agent_host_name 4": true,
-              "agent_host_name 5": true,
-              "fqdn": true,
-              "host_id": true,
-              "host_id 1": true,
-              "host_id 2": true,
-              "host_id 3": true,
-              "host_id 4": true,
-              "host_id 5": true,
-              "host_name 1": false,
-              "host_name 2": true,
-              "host_name 3": true,
-              "host_type": true,
-              "host_type 1": true,
-              "host_type 2": true,
-              "host_type 3": true,
-              "host_type 4": true,
-              "host_type 5": true,
-              "id": true,
-              "id 1": true,
-              "id 2": true,
-              "id 3": true,
-              "id 4": true,
-              "id 5": true,
-              "instance 1": true,
-              "instance 2": true,
-              "instance 3": true,
-              "is_endpoint 1": true,
-              "is_endpoint 2": true,
-              "is_endpoint 3": true,
-              "is_endpoint 4": true,
-              "is_endpoint 5": true,
-              "job 1": true,
-              "job 2": true,
-              "job 3": true,
-              "label": true,
-              "label 1": true,
-              "label 2": true,
-              "label 3": true,
-              "location": true,
-              "location 1": true,
-              "location 2": true,
-              "location 3": true,
-              "location 4": true,
-              "location 5": true,
-              "name 1": true,
-              "name 2": true,
-              "name 3": true,
-              "name 4": true,
-              "name 5": true,
-              "os_type 1": false,
-              "os_type 2": true,
-              "os_type 3": true,
-              "os_type 4": true,
-              "os_type 5": true,
-              "power_meter": true,
-              "power_meter 1": true,
-              "power_meter 2": true,
-              "power_meter 3": true,
-              "protocol": true,
-              "quality": true,
-              "site": true,
-              "site 1": true,
-              "site 2": true,
-              "site 3": true,
-              "site 4": true,
-              "site 5": true,
-              "zone": true,
-              "zone 1": true,
-              "zone 2": true,
-              "zone 3": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Last Seen": 10,
-              "Time 1": 14,
-              "Time 10": 44,
-              "Time 2": 17,
-              "Time 3": 20,
-              "Time 4": 28,
-              "Time 5": 33,
-              "Time 6": 40,
-              "Time 7": 41,
-              "Time 8": 42,
-              "Time 9": 43,
-              "Value #A": 2,
-              "Value #B": 6,
-              "Value #C": 25,
-              "Value #CriticalAlerts": 3,
-              "Value #D": 7,
-              "Value #E": 39,
-              "Value #FailedConnectors": 8,
-              "Value #ProtocolErrors": 5,
-              "Value #TotalConnectors": 9,
-              "Value #Warnings": 4,
-              "__name__": 34,
-              "agent_host_name 1": 11,
-              "agent_host_name 2": 12,
-              "agent_host_name 3": 21,
-              "agent_host_name 4": 29,
-              "agent_host_name 5": 35,
-              "host_name": 0,
-              "host_type 1": 15,
-              "host_type 2": 18,
-              "host_type 3": 22,
-              "host_type 4": 30,
-              "host_type 5": 36,
-              "os_type 1": 1,
-              "os_type 2": 13,
-              "os_type 3": 23,
-              "os_type 4": 31,
-              "os_type 5": 37,
-              "protocol": 27,
-              "quality": 26,
-              "site 1": 16,
-              "site 2": 19,
-              "site 3": 24,
-              "site 4": 32,
-              "site 5": 38
-            },
-            "renameByName": {
-              "Time 1": "",
-              "Time 10": "",
-              "Value #A": "Power Consumption",
-              "Value #B": "Heating Margin",
-              "Value #C": "",
-              "Value #C * 1000": "Last Seen",
-              "Value #CriticalAlerts": "Critical Alerts",
-              "Value #D": "Host Temperature",
-              "Value #F": "",
-              "Value #FailedConnectors": "Failed Connectors",
-              "Value #ProtocolErrors": "Failed Protocols",
-              "Value #TotalConnectors": "Matching Connectors",
-              "Value #Warnings": "Warnings",
-              "agent_host_name 1": "",
-              "host_name": "Host",
-              "host_name 1": "Host",
-              "host_type 1": "",
-              "job 2": "",
-              "location 1": "",
-              "os_type 1": "Operating System",
-              "os_type 3": ""
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 46
-      },
-      "id": 42,
-      "panels": [],
-      "title": "History",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "The site's daily energy consumption for the past 30 days, as reported.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "axisSoftMin": 0,
-            "fillOpacity": 80,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineWidth": 1,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "displayName": "Daily Energy Consumption (last 30 days)",
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "watth"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "time:dddd DD/MM"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 14,
-        "w": 24,
-        "x": 0,
-        "y": 47
-      },
-      "hideTimeOverride": true,
-      "id": 156,
-      "options": {
-        "barRadius": 0,
-        "barWidth": 0.95,
-        "fullHighlight": false,
-        "groupWidth": 0.7,
-        "legend": {
-          "calcs": [
-            "min",
-            "max",
-            "last"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "orientation": "auto",
-        "showValue": "always",
-        "stacking": "none",
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        },
-        "xTickLabelRotation": -45,
-        "xTickLabelSpacing": 0
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1d:5m]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m])) * 24 + ignoring(year, month, day) group_right\r\n  count_values without() (\"year\", year(timestamp(\r\n    count_values without() (\"month\", month(timestamp(\r\n\t\t\tcount_values without() (\"day\", day_of_month(timestamp(\r\n        sum(increase(hw_host_energy_joules_total{site=~\"$site\"} [1d])) / avg(increase(timestamp(hw_host_energy_joules_total{site=~\"$site\"})[1d:1d])) * 24 * avg(hw_site_pue_ratio{site=~\"$site\"})\r\n\t\t\t\t)))\r\n    )))\r\n  ))) * 0",
-          "format": "table",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{unit}}",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": "now-30d",
-      "timeShift": "1d",
-      "title": "Daily Energy Consumption (last 30 days)",
-      "transformations": [
-        {
-          "id": "filterByValue",
-          "options": {
-            "filters": [
-              {
-                "config": {
-                  "id": "regex",
-                  "options": {
-                    "value": "NaN"
                   }
                 },
-                "fieldName": "Value"
-              }
-            ],
-            "match": "any",
-            "type": "exclude"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "Time"
-              }
-            ]
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": false,
-              "Value": false,
-              "day": true,
-              "month": true,
-              "year": true
-            },
-            "indexByName": {},
-            "renameByName": {
-              "Time": "",
-              "day": ""
-            }
-          }
-        }
-      ],
-      "type": "barchart"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 61
-      },
-      "id": 40,
-      "panels": [],
-      "title": "Hardware Sentry Agent Status",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Time since the collect of data by Hardware Sentry was first started for the site.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "text",
-            "mode": "fixed"
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "dateTimeFromNow"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value * 1000"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Collect Started"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 62
-      },
-      "id": 107,
-      "interval": "1h",
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "valueSize": 32
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "min_over_time(timestamp(metricshub_host_configured{site=~\"$site\"})[1y:1d])",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "Collect Started",
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "",
-            "binary": {
-              "left": "Value",
-              "operator": "*",
-              "reducer": "sum",
-              "right": "1000"
-            },
-            "mode": "binary",
-            "reduce": {
-              "include": [
-                "Last Seen"
-              ],
-              "reducer": "last"
-            },
-            "replaceFields": false
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Value": true,
-              "Value #A": true,
-              "__name__": true,
-              "agent_host_name": false,
-              "build_number": true,
-              "build_number 2": true,
-              "hc_version 2": true,
-              "host_id": true,
-              "host_id 1": true,
-              "host_id 2": true,
-              "host_name": true,
-              "host_name 1": true,
-              "host_name 2": true,
-              "host_type": true,
-              "host_type 1": true,
-              "host_type 2": true,
-              "os_type": true,
-              "os_type 1": true,
-              "os_type 2": true,
-              "project_name": true,
-              "project_name 1": true,
-              "project_name 2": true,
-              "project_version 2": true,
-              "service_name": true,
-              "service_name 1": true,
-              "service_name 2": true,
-              "site 2": true,
-              "timestamp": true,
-              "timestamp 1": true,
-              "timestamp 2": true
-            },
-            "indexByName": {
-              "Last Seen": 15,
-              "Time": 6,
-              "Value": 14,
-              "agent_host_name": 1,
-              "build_date": 3,
-              "build_number": 4,
-              "hc_version": 5,
-              "host_id": 7,
-              "host_name": 8,
-              "host_type": 9,
-              "os_type": 10,
-              "project_name": 11,
-              "project_version": 2,
-              "service_name": 12,
-              "site": 0,
-              "timestamp": 13
-            },
-            "renameByName": {
-              "Time": "",
-              "Value": "",
-              "agent_host_name": "Hostname",
-              "build_date": "Agent Build Date",
-              "build_number": "",
-              "build_number 1": "Agent Build Number",
-              "hc_version": "Connectors Version",
-              "hc_version 1": "Connectors Version",
-              "project_version": "Agent Version",
-              "project_version 1": "Agent Version",
-              "site": "Site",
-              "site 1": "Site",
-              "timestamp": ""
-            }
-          }
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Last Seen"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "dateTimeFromNow"
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Hostname"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 18,
-        "x": 3,
-        "y": 62
-      },
-      "id": 89,
-      "interval": "1h",
-      "options": {
-        "cellHeight": "sm",
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "Site"
-          }
-        ]
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "last_over_time(timestamp(metricshub_agent_info{agent_host_name=\"$agent\"})[6h:])",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Last Seen",
-            "binary": {
-              "left": {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Value"
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Value": true,
+                        "Value #A": true,
+                        "__name__": true,
+                        "agent_host_name": false,
+                        "build_number": true,
+                        "build_number 2": true,
+                        "hc_version 2": true,
+                        "host_id": true,
+                        "host_id 1": true,
+                        "host_id 2": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "project_name": true,
+                        "project_name 1": true,
+                        "project_name 2": true,
+                        "project_version 2": true,
+                        "service_name": true,
+                        "service_name 1": true,
+                        "service_name 2": true,
+                        "site 2": true,
+                        "timestamp": true,
+                        "timestamp 1": true,
+                        "timestamp 2": true
+                      },
+                      "indexByName": {
+                        "Last Seen": 15,
+                        "Time": 6,
+                        "Value": 14,
+                        "agent_host_name": 1,
+                        "build_date": 3,
+                        "build_number": 4,
+                        "hc_version": 5,
+                        "host_id": 7,
+                        "host_name": 8,
+                        "host_type": 9,
+                        "os_type": 10,
+                        "project_name": 11,
+                        "project_version": 2,
+                        "service_name": 12,
+                        "site": 0,
+                        "timestamp": 13
+                      },
+                      "renameByName": {
+                        "Time": "",
+                        "Value": "",
+                        "agent_host_name": "Hostname",
+                        "build_date": "Agent Build Date",
+                        "build_number": "",
+                        "build_number 1": "Agent Build Number",
+                        "hc_version": "Connectors Version",
+                        "hc_version 1": "Connectors Version",
+                        "project_version": "Agent Version",
+                        "project_version 1": "Agent Version",
+                        "site": "Site",
+                        "site 1": "Site",
+                        "timestamp": ""
+                      }
+                    }
+                  }
                 }
-              },
-              "operator": "*",
-              "right": {
-                "fixed": "1000"
-              }
-            },
-            "mode": "binary",
-            "reduce": {
-              "include": [
-                "Last Seen"
-              ],
-              "reducer": "last"
-            },
-            "replaceFields": false
-          }
-        },
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "agent_host_name",
-                "build_date",
-                "build_number",
-                "version",
-                "Last Seen",
-                "cc_version"
               ]
             }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Value": true,
-              "Value #A": true,
-              "__name__": true,
-              "agent_host_name": false,
-              "build_number": false,
-              "build_number 2": true,
-              "hc_version 2": true,
-              "host_id": true,
-              "host_id 1": true,
-              "host_id 2": true,
-              "host_name": true,
-              "host_name 1": true,
-              "host_name 2": true,
-              "host_type": true,
-              "host_type 1": true,
-              "host_type 2": true,
-              "job": true,
-              "name": true,
-              "os_type": true,
-              "os_type 1": true,
-              "os_type 2": true,
-              "otel_version": true,
-              "project_name": true,
-              "project_name 1": true,
-              "project_name 2": true,
-              "project_version": true,
-              "project_version 2": true,
-              "service_name": true,
-              "service_name 1": true,
-              "service_name 2": true,
-              "site": true,
-              "site 2": true,
-              "timestamp": true,
-              "timestamp 1": true,
-              "timestamp 2": true
+          },
+          "description": "Time since the collect of data by Hardware Sentry was first started for the site.",
+          "id": 107,
+          "links": [],
+          "title": "Collect Started",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "text",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "dateTimeFromNow"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value * 1000"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Collect Started"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "auto",
+                "wideLayout": true
+              }
             },
-            "includeByName": {},
-            "indexByName": {
-              "Last Seen": 5,
-              "agent_host_name": 0,
-              "build_date": 3,
-              "build_number": 4,
-              "cc_version": 2,
-              "version": 1
-            },
-            "renameByName": {
-              "Time": "",
-              "Value": "",
-              "agent_host_name": "Hostname",
-              "build_date": "Build Date",
-              "build_number": "Build Number",
-              "build_number 1": "Agent Build Number",
-              "cc_version": "Connectors Version",
-              "hc_version": "Connectors Version",
-              "hc_version 1": "Connectors Version",
-              "name": "",
-              "otel_version": "",
-              "project_version": "",
-              "project_version 1": "Agent Version",
-              "site": "",
-              "site 1": "Site",
-              "timestamp": "",
-              "version": "Version"
-            }
+            "version": "12.3.2"
           }
         }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
       },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
+      "panel-112": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
           },
-          "mappings": [],
-          "noValue": "2026.2",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-green",
-                "value": 0
+          "description": "",
+          "id": 112,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<h3 style=\"background-color:Grey\"><center>Live Data</center></h3>",
+                "mode": "html"
               }
-            ]
+            },
+            "version": "12.3.2"
           }
-        },
-        "overrides": []
+        }
       },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 21,
-        "y": 62
+      "panel-114": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 114,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<h3 style=\"background-color:Grey\"><center>Cumulative Data</center></h3>",
+                "mode": "html"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
       },
-      "id": 159,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
+      "panel-125": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(sum(hw_host_power_watts{quality=\"estimated\", site=\"$site\"} * 15) + sum(hw_host_power_watts{quality=\"measured\", site=\"$site\"} * 5) + 10000 * (sum(present_over_time(metricshub_host_configured{site=\"$site\"}[1h])) - (count(max by (host_name) (metricshub_connector_status{state=\"ok\", site=\"$site\"} == 1))))) / (sum(hw_host_power_watts{site=\"$site\"}) + 100 * (sum(present_over_time(metricshub_host_configured{site=\"$site\"}[1h])) - (count(max by (host_name) (metricshub_connector_status{state=\"ok\", site=\"$site\"} == 1)))))",
+                        "instant": true,
+                        "legendFormat": "Margin of Error",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": [
+                {
+                  "kind": "reduce",
+                  "spec": {
+                    "id": "reduce",
+                    "options": {
+                      "reducers": []
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The percentage of possible deviation from an exact power consumption value.\n\nThis value is based on the collected data of monitored hosts reporting power consumption and estimated values for hosts not reporting their power consumption.\n\nWhen the power consumed by a host cannot be read, Hardware Sentry estimates this value based on the typical consumption of a host's components (CPUs, disks, network interfaces, etc.).",
+          "id": 125,
+          "links": [],
+          "title": "Margin of Error",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "noValue": "25%",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "super-light-yellow",
+                        "value": 0
+                      },
+                      {
+                        "color": "super-light-green",
+                        "value": 10
+                      },
+                      {
+                        "color": "super-light-yellow",
+                        "value": 11
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
       },
-      "pluginVersion": "12.3.2",
-      "title": "Dashboard Version",
-      "type": "stat"
-    }
-  ],
-  "preload": false,
-  "refresh": "30s",
-  "schemaVersion": 42,
-  "tags": [
-    "hw_site"
-  ],
-  "templating": {
-    "list": [
+      "panel-127": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(max by (host_name, site) (metricshub_connector_status{state=\"ok\", site=~\"$site\"} == 1)) / sum(max by (host_name, site) (present_over_time(metricshub_host_configured{site=~\"$site\"}[1h])))",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Coverage"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The percentage of monitored hosts.\n\nA monitored host is a host with at least one responding connector.",
+          "id": 127,
+          "links": [],
+          "title": "Coverage",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "super-light-red",
+                        "value": 0
+                      },
+                      {
+                        "color": "super-light-yellow",
+                        "value": 0.5
+                      },
+                      {
+                        "color": "super-light-green",
+                        "value": 0.9
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-129": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg(avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[2h]))",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "PUE",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The average of the Power Usage Effectiveness over 2 hours.",
+          "id": 129,
+          "links": [],
+          "title": "PUE",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "dashed+area"
+                    }
+                  },
+                  "min": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "green",
+                        "value": 1
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 1.4
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1.8
+                      },
+                      {
+                        "color": "red",
+                        "value": 2
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-130": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(hw_host_power_watts{site=~\"$site\"}) * scalar(avg(avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[2h])))",
+                        "legendFormat": "Total Power * PUE",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The site's current power usage multiplied by the site's PUE, displayed as a graph.\n\nThis number represents the actual power usage of a data center. It takes into account the cooling and other overhead that supports the equipment.",
+          "id": 130,
+          "links": [],
+          "title": "Total Power * PUE",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "axisSoftMin": 0,
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 51,
+                    "gradientMode": "hue",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 2,
+                    "pointSize": 6,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watt"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "min",
+                    "max",
+                    "last"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-132": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg(avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[1d]))",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "PUE (24 hrs)",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The average of the Power Usage Effectiveness over 24 hours.",
+          "id": 132,
+          "links": [],
+          "title": "PUE (24 hrs)",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "continuous-GrYlRd"
+                  },
+                  "max": 2.5,
+                  "min": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-145": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1y:1d]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1y:1d]) * avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[1y:1d])) * 365 * 24 / 1000",
+                        "instant": true,
+                        "legendFormat": "Yearly Cost",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall energy cost reported for the site in the past year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
+          "id": 145,
+          "links": [],
+          "title": "Yearly Cost",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "dark-green",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "purple",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-146": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1y:1d]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1y:1d]) * avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[1y:1d])) * 365 * 24 / 1000 / 1000 / 1000",
+                        "instant": true,
+                        "legendFormat": "Yearly CO₂ Emissions",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall volume of CO₂ emitted by the site during the past year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
+          "id": 146,
+          "links": [],
+          "title": "Yearly CO₂ Emissions",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#414141",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "purple",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masst"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-148": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[30d:1h]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[30d:1h]) * avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[30d:1h])) * 30.437 * 24 /1000",
+                        "instant": true,
+                        "legendFormat": "Monthly Cost",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall energy cost reported for the site during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on past collected data.",
+          "id": 148,
+          "links": [],
+          "title": "Monthly Cost",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "semi-dark-green",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-149": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[30d:1h]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[30d:1h]) * avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[30d:1h])) * 30.437 * 24 / 1000 / 1000 / 1000",
+                        "instant": true,
+                        "legendFormat": "Monthly CO₂ Emissions",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall volume of CO₂ emitted by the site during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on the past collected data.",
+          "id": 149,
+          "links": [],
+          "title": "Monthly CO₂ Emissions",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#525252",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masst"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-151": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1d:5m]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m]) * avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[1d:5m])) * 24 / 1000",
+                        "instant": true,
+                        "legendFormat": "Daily Cost",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall energy cost reported for the site during the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
+          "id": 151,
+          "links": [],
+          "title": "Daily Cost",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-152": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1d:5m]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m]) * avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[1d:5m])) * 24 / 1000 / 1000",
+                        "instant": true,
+                        "legendFormat": "Daily CO₂ Emissions",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall volume of CO₂ emitted by the site during the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
+          "id": 152,
+          "links": [],
+          "title": "Daily CO₂ Emissions",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masskg"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-153": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1y:1d]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1y:1d])) * 365 * 24",
+                        "instant": true,
+                        "legendFormat": "Yearly Consumption",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall power consumption reported for the site during the last year.\n\nIf less than 365 days of data is available, this value is estimated based on past collected data.",
+          "id": 153,
+          "links": [],
+          "title": "Yearly Consumption",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "dark-blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-154": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1d:5m]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m])) * 24",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Daily Consumption"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall power consumption reported for the site in the last 24 hours.\n\nIf less than 24 hours of data is available, this value is estimated based on the past collected data.",
+          "id": 154,
+          "links": [],
+          "title": "Daily Consumption",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-155": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[30d:1h]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[30d:1h])) * 30.437 * 24",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Monthly Consumption"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The overall power consumption reported for the site during the last 30 days.\n\nIf less than 30 days of data is available, this value is estimated based on past collected data.",
+          "id": 155,
+          "links": [],
+          "title": "Monthly Consumption",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "semi-dark-blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-156": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": true,
+                        "expr": "sum(avg_over_time(sum(hw_host_power_watts{site=~\"$site\"})[1d:5m]) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[1d:5m])) * 24 + ignoring(year, month, day) group_right\r\n  count_values without() (\"year\", year(timestamp(\r\n    count_values without() (\"month\", month(timestamp(\r\n\t\t\tcount_values without() (\"day\", day_of_month(timestamp(\r\n        sum(increase(hw_host_energy_joules_total{site=~\"$site\"} [1d])) / avg(increase(timestamp(hw_host_energy_joules_total{site=~\"$site\"})[1d:1d])) * 24 * avg(hw_site_pue_ratio{site=~\"$site\"})\r\n\t\t\t\t)))\r\n    )))\r\n  ))) * 0",
+                        "format": "table",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "{{unit}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "hideTimeOverride": true,
+                "timeFrom": "now-30d",
+                "timeShift": "1d"
+              },
+              "transformations": [
+                {
+                  "kind": "filterByValue",
+                  "spec": {
+                    "id": "filterByValue",
+                    "options": {
+                      "filters": [
+                        {
+                          "config": {
+                            "id": "regex",
+                            "options": {
+                              "value": "NaN"
+                            }
+                          },
+                          "fieldName": "Value"
+                        }
+                      ],
+                      "match": "any",
+                      "type": "exclude"
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "desc": false,
+                          "field": "Time"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": false,
+                        "Value": false,
+                        "day": true,
+                        "month": true,
+                        "year": true
+                      },
+                      "indexByName": {},
+                      "renameByName": {
+                        "Time": "",
+                        "day": ""
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The site's daily energy consumption for the past 30 days, as reported.",
+          "id": 156,
+          "links": [],
+          "title": "Daily Energy Consumption (last 30 days)",
+          "vizConfig": {
+            "group": "barchart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "axisSoftMin": 0,
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "displayName": "Daily Energy Consumption (last 30 days)",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Time"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "time:dddd DD/MM"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "barRadius": 0,
+                "barWidth": 0.95,
+                "fullHighlight": false,
+                "groupWidth": 0.7,
+                "legend": {
+                  "calcs": [
+                    "min",
+                    "max",
+                    "last"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "orientation": "auto",
+                "showValue": "always",
+                "stacking": "none",
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                },
+                "xTickLabelRotation": -45,
+                "xTickLabelSpacing": 0
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-157": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "min by (host_name) (min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d]))",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 1
+              },
+              "transformations": []
+            }
+          },
+          "description": "The number of hosts according to their heating margin.\n\nThe abscissa shows the heating margin.\nThe ordinate represents the number of hosts  for a given heating margin.",
+          "id": 157,
+          "links": [],
+          "title": "Heating Margin Host Distribution",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "red",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "hue",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "decimals": 0,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "celsius"
+                },
+                "overrides": []
+              },
+              "options": {
+                "bucketOffset": 0,
+                "bucketSize": 1,
+                "combine": true,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-159": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {},
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 159,
+          "links": [],
+          "title": "Dashboard Version",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "2026.2",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "light-green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-19": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(hw_host_power_watts{site=~\"$site\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Total Power"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The total current power consumption of all the hosts in the site.",
+          "id": 19,
+          "links": [],
+          "title": "Total Power",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watt"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "min(min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d]))",
+                        "instant": true,
+                        "interval": "",
+                        "intervalFactor": 1,
+                        "legendFormat": "Heating Margin"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The number of degrees Celsius (°C) remaining before the temperature of a host in the site reaches its closest warning temperature threshold.\n\nIt is advised to keep the heating margin above 5°C.",
+          "id": 2,
+          "links": [],
+          "title": "Heating Margin",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "max": 20,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 0
+                      },
+                      {
+                        "color": "green",
+                        "value": 5
+                      },
+                      {
+                        "color": "orange",
+                        "value": 10
+                      }
+                    ]
+                  },
+                  "unit": "celsius"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-36": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(count by (host_name) (present_over_time(metricshub_host_configured{site=~\"$site\"}[1h])))",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Hosts"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The number of hosts currently configured to be monitored.",
+          "id": 36,
+          "links": [],
+          "title": "Hosts",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "fixed"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-37": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(ALERTS_FOR_STATE{severity=\"warning\", site=~\"$site\", alertname=~\"MetricsHub-Hardware-.*\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Warning Alerts"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 37,
+          "links": [],
+          "title": "Warning Alerts",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-38": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(hw_host_power_watts{site=~\"$site\"}) * scalar(avg(hw_site_pue_ratio{site=~\"$site\"}))",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Total Power * PUE"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The site's current power usage multiplied by the site's PUE.\n\nThis number represents the site's actual power usage. It takes into account the cooling and other overhead that supports the equipment.",
+          "id": 38,
+          "links": [],
+          "title": "Total Power * PUE",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watt"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg(hw_host_ambient_temperature_celsius{site=~\"$site\"})",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "Site Temperature",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": [
+                {
+                  "kind": "reduce",
+                  "spec": {
+                    "id": "reduce",
+                    "options": {
+                      "reducers": []
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The estimation of the site's temperature based on the ambient temperature of all hosts in the site.",
+          "id": 4,
+          "links": [],
+          "title": "Current Site Temperature",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-BlYlRd"
+                  },
+                  "decimals": 1,
+                  "max": 30,
+                  "min": 18,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      },
+                      {
+                        "color": "green",
+                        "value": 18
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 26
+                      },
+                      {
+                        "color": "dark-red",
+                        "value": 30
+                      }
+                    ]
+                  },
+                  "unit": "celsius"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-44": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 44,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<h1 style=\"\">\r\n  <center>$site</center>\r\n</h1>",
+                "mode": "html"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-48": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(increase(hw_host_energy_joules_total{site=~\"$site\"}[$__range])) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[$__range:5m]) * avg_over_time(avg(hw_site_carbon_intensity_grams{site=~\"$site\"})[$__range:5m]) / 3600 / 1000 / 1000",
+                        "instant": true,
+                        "legendFormat": "Today's Live CO₂ Emissions",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "hideTimeOverride": true,
+                "timeFrom": "now/d"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Today's volume of CO₂ emissions for the site.",
+          "id": 48,
+          "links": [],
+          "title": "Today's Live CO₂ Emissions",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "fixed"
+                  },
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masskg"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-55": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg(hw_site_electricity_cost{site=~\"$site\"})",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "Electricity Cost",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Electricity cost, as provided in the configuration file.",
+          "id": 55,
+          "links": [],
+          "title": "Electricity Cost",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-GrYlRd"
+                  },
+                  "max": 0.4,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-56": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg(hw_site_carbon_intensity_grams{site=~\"$site\"})",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "CO₂ Intensity",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The CO₂ electricity emissions, as provided in the configuration file.",
+          "id": 56,
+          "links": [],
+          "title": "CO₂ Intensity",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-GrYlRd"
+                  },
+                  "max": 500,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "massg"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-59": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (host_type) (metricshub_host_configured{site=~\"$site\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "{{host_type}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The total number of hosts per type: compute (server), storage and network.",
+          "id": 59,
+          "links": [],
+          "title": "Host Types",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "displayLabels": [
+                  "name",
+                  "value",
+                  "percent"
+                ],
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": false,
+                  "values": []
+                },
+                "pieType": "pie",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": true
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-6": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "round(rate(hw_host_energy_joules_total{site=~\"$site\"}[1d]))",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d])",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "last_over_time(timestamp(metricshub_host_up{site=~\"$site\"})[6h:])",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])",
+                        "format": "table",
+                        "instant": true,
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "D"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "metricshub_host_configured{site=~\"$site\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "E"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (host_name) (metricshub_connector_status{site=~\"$site\"})",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "TotalConnectors"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  count(ALERTS_FOR_STATE{severity=\"critical\", site=~\"$site\", alertname=~\"MetricsHub-Hardware-.*\"}) by (host_name)\r\n  or \r\n  (0 * count by (host_name) (hw_host_power_watts{site=~\"$site\"})) # This is used to make sure a column is always created\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "CriticalAlerts"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "(\r\n  count(ALERTS_FOR_STATE{severity=\"warning\", site=~\"$site\", alertname=~\"MetricsHub-Hardware-.*\"}) by (host_name)\r\n  or \r\n  (0 * count by (host_name) (hw_host_power_watts{site=~\"$site\"})) # This is used to make sure a column is always created\r\n)",
+                        "format": "table",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Warnings"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "(count by (host_name) (metricshub_host_up{site=~\"$site\"} == 0)) \r\nor \r\n(count by (host_name) (metricshub_host_up{site=~\"$site\"}) * 0)",
+                        "format": "table",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "ProtocolErrors"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (host_name) (metricshub_connector_status{site=~\"$site\", state=\"failed\"}) \r\nor \r\n(0 * count by (host_name) (hw_host_power_watts{site=~\"$site\"}))",
+                        "format": "table",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "FailedConnectors"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": [
+                {
+                  "kind": "seriesToColumns",
+                  "spec": {
+                    "id": "seriesToColumns",
+                    "options": {
+                      "byField": "host_name"
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Last Seen",
+                      "binary": {
+                        "left": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value #C"
+                          }
+                        },
+                        "operator": "*",
+                        "right": {
+                          "fixed": "1000"
+                        }
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "reducer": "sum"
+                      },
+                      "window": {
+                        "reducer": "mean",
+                        "windowAlignment": "trailing",
+                        "windowSize": 0.1,
+                        "windowSizeMode": "percentage"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 10": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Time 5": true,
+                        "Time 6": true,
+                        "Time 7": true,
+                        "Time 8": true,
+                        "Time 9": true,
+                        "Value #A": false,
+                        "Value #C": true,
+                        "Value #E": true,
+                        "__name__": true,
+                        "__name__ 1": true,
+                        "__name__ 2": true,
+                        "agent_host_name 1": true,
+                        "agent_host_name 2": true,
+                        "agent_host_name 3": true,
+                        "agent_host_name 4": true,
+                        "agent_host_name 5": true,
+                        "entityName 1": true,
+                        "entityName 2": true,
+                        "entityName 3": true,
+                        "entityName 4": true,
+                        "entityName 5": true,
+                        "entityTypeId 1": true,
+                        "entityTypeId 2": true,
+                        "entityTypeId 3": true,
+                        "entityTypeId 4": true,
+                        "entityTypeId 5": true,
+                        "fqdn": true,
+                        "host_id": true,
+                        "host_id 1": true,
+                        "host_id 2": true,
+                        "host_id 3": true,
+                        "host_id 4": true,
+                        "host_id 5": true,
+                        "host_name 1": false,
+                        "host_name 2": true,
+                        "host_name 3": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "host_type 3": true,
+                        "host_type 4": true,
+                        "host_type 5": true,
+                        "id": true,
+                        "id 1": true,
+                        "id 2": true,
+                        "id 3": true,
+                        "id 4": true,
+                        "id 5": true,
+                        "instance 1": true,
+                        "instance 2": true,
+                        "instance 3": true,
+                        "instanceName 1": true,
+                        "instanceName 2": true,
+                        "instanceName 3": true,
+                        "instanceName 4": true,
+                        "instanceName 5": true,
+                        "is_endpoint 1": true,
+                        "is_endpoint 2": true,
+                        "is_endpoint 3": true,
+                        "is_endpoint 4": true,
+                        "is_endpoint 5": true,
+                        "job 1": true,
+                        "job 2": true,
+                        "job 3": true,
+                        "label": true,
+                        "label 1": true,
+                        "label 2": true,
+                        "label 3": true,
+                        "location": true,
+                        "location 1": true,
+                        "location 2": true,
+                        "location 3": true,
+                        "location 4": true,
+                        "location 5": true,
+                        "name 1": true,
+                        "name 2": true,
+                        "name 3": true,
+                        "name 4": true,
+                        "name 5": true,
+                        "os_type 1": false,
+                        "os_type 2": true,
+                        "os_type 3": true,
+                        "os_type 4": true,
+                        "os_type 5": true,
+                        "otel_scope_name 1": true,
+                        "otel_scope_name 2": true,
+                        "otel_scope_name 3": true,
+                        "otel_scope_name 4": true,
+                        "otel_scope_name 5": true,
+                        "power_meter": true,
+                        "power_meter 1": true,
+                        "power_meter 2": true,
+                        "power_meter 3": true,
+                        "protocol": true,
+                        "quality": true,
+                        "site": true,
+                        "site 1": true,
+                        "site 2": true,
+                        "site 3": true,
+                        "site 4": true,
+                        "site 5": true,
+                        "zone": true,
+                        "zone 1": true,
+                        "zone 2": true,
+                        "zone 3": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Last Seen": 10,
+                        "Time 1": 14,
+                        "Time 10": 44,
+                        "Time 2": 17,
+                        "Time 3": 20,
+                        "Time 4": 28,
+                        "Time 5": 33,
+                        "Time 6": 40,
+                        "Time 7": 41,
+                        "Time 8": 42,
+                        "Time 9": 43,
+                        "Value #A": 2,
+                        "Value #B": 6,
+                        "Value #C": 25,
+                        "Value #CriticalAlerts": 3,
+                        "Value #D": 7,
+                        "Value #E": 39,
+                        "Value #FailedConnectors": 8,
+                        "Value #ProtocolErrors": 5,
+                        "Value #TotalConnectors": 9,
+                        "Value #Warnings": 4,
+                        "__name__": 34,
+                        "agent_host_name 1": 11,
+                        "agent_host_name 2": 12,
+                        "agent_host_name 3": 21,
+                        "agent_host_name 4": 29,
+                        "agent_host_name 5": 35,
+                        "host_name": 0,
+                        "host_type 1": 15,
+                        "host_type 2": 18,
+                        "host_type 3": 22,
+                        "host_type 4": 30,
+                        "host_type 5": 36,
+                        "os_type 1": 1,
+                        "os_type 2": 13,
+                        "os_type 3": 23,
+                        "os_type 4": 31,
+                        "os_type 5": 37,
+                        "protocol": 27,
+                        "quality": 26,
+                        "site 1": 16,
+                        "site 2": 19,
+                        "site 3": 24,
+                        "site 4": 32,
+                        "site 5": 38
+                      },
+                      "renameByName": {
+                        "Time 1": "",
+                        "Time 10": "",
+                        "Value #A": "Power Consumption",
+                        "Value #B": "Heating Margin",
+                        "Value #C": "",
+                        "Value #C * 1000": "Last Seen",
+                        "Value #CriticalAlerts": "Critical Alerts",
+                        "Value #D": "Host Temperature",
+                        "Value #F": "",
+                        "Value #FailedConnectors": "Failed Connectors",
+                        "Value #ProtocolErrors": "Failed Protocols",
+                        "Value #TotalConnectors": "Matching Connectors",
+                        "Value #Warnings": "Warnings",
+                        "agent_host_name 1": "",
+                        "host_name": "Host",
+                        "host_name 1": "Host",
+                        "host_type 1": "",
+                        "job 2": "",
+                        "location 1": "",
+                        "os_type 1": "Operating System",
+                        "os_type 3": ""
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 6,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "links": [
+                    {
+                      "title": "d/c2K8skm4k/host?orgId=1",
+                      "url": "d/c2K8skm4k/host?orgId=1&${site:queryparam}&var-host_name=${__data.fields.Host}"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Power Consumption"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "watt"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-GrYlRd"
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Power Consumption"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 3000
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      },
+                      {
+                        "id": "custom.filterable"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Heating Margin"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "celsius"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 5
+                            },
+                            {
+                              "color": "orange",
+                              "value": 10
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "thresholds"
+                        }
+                      },
+                      {
+                        "id": "custom.filterable",
+                        "value": false
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.filterable"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Operating System"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "aix": {
+                                "index": 1,
+                                "text": "IBM AIX"
+                              },
+                              "hpux": {
+                                "index": 4,
+                                "text": "HP-UX"
+                              },
+                              "linux": {
+                                "index": 0,
+                                "text": "Linux"
+                              },
+                              "management": {
+                                "index": 6,
+                                "text": "Management"
+                              },
+                              "solaris": {
+                                "index": 2,
+                                "text": "Oracle Solaris"
+                              },
+                              "storage": {
+                                "index": 5,
+                                "text": "Storage"
+                              },
+                              "windows": {
+                                "index": 3,
+                                "text": "Microsoft Windows"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Last Seen"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dateTimeFromNow"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "match": "null+nan",
+                              "result": {
+                                "color": "red",
+                                "index": 0,
+                                "text": "Unknown"
+                              }
+                            },
+                            "type": "special"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "transparent",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.filterable"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Host Temperature"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "celsius"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "thresholds"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "light-blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 20
+                            },
+                            {
+                              "color": "#EAB839",
+                              "value": 28
+                            },
+                            {
+                              "color": "red",
+                              "value": 30
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.filterable"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Matching Connectors"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "transparent",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.filterable"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Critical Alerts"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.filterable",
+                        "value": false
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Warnings"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.filterable"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Failed Protocols"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.filterable"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Failed Connectors"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.filterable"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Failed Connectors"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-61": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(ALERTS_FOR_STATE{severity=\"critical\", site=~\"$site\", alertname=~\"MetricsHub-Hardware-.*\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Critical Alerts"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 61,
+          "links": [],
+          "title": "Critical Alerts",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-68": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(hw_status{site=~\"$site\", hw_type=\"cpu\", state=\"present\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "CPUs"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The total number of CPUs currently monitored.",
+          "id": 68,
+          "links": [],
+          "title": "CPUs",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "transparent",
+                    "mode": "fixed"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-69": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(hw_physical_disk_size_bytes{site=~\"$site\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Disk Space"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The total disk space in the site.",
+          "id": 69,
+          "links": [],
+          "title": "Disk Space",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "transparent",
+                    "mode": "fixed"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "decbytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-70": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(hw_network_up{site=~\"$site\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Connected NICs"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The total number of connected network cards.",
+          "id": 70,
+          "links": [],
+          "title": "Connected NICs",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "transparent",
+                    "mode": "fixed"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-71": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(hw_network_io_bytes_total{site=~\"$site\", direction=\"transmit\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Network Transfers"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The total volume of network transfers in the site.",
+          "id": 71,
+          "links": [],
+          "title": "Network Tx",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "transparent",
+                    "mode": "fixed"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "decbytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-74": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(hw_host_ambient_temperature_celsius{site=~\"$site\"}) / sum(present_over_time(metricshub_host_configured{site=~\"$site\"}[1h])) * 100",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Monitoring Confidence"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": [
+                {
+                  "kind": "reduce",
+                  "spec": {
+                    "id": "reduce",
+                    "options": {
+                      "reducers": []
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The percentage of hosts for which temperature readings are reported.",
+          "id": 74,
+          "links": [],
+          "title": "Monitoring Confidence",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "links": [
+                    {
+                      "title": "",
+                      "url": "/d/F_gu_3d7z/site_temperatures?orgId=1&${site:queryparam} "
+                    }
+                  ],
+                  "max": -1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": 0
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 50
+                      },
+                      {
+                        "color": "green",
+                        "value": 75
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-76": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": true,
+                        "expr": "min(hw_host_heating_margin_celsius{site=\"$site\"})",
+                        "interval": "",
+                        "legendFormat": "Heating Margin",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The lowest host's heating margin of all hosts in the site.",
+          "id": 76,
+          "links": [],
+          "title": "Site Heating Margin",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": true,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 3,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "area"
+                    }
+                  },
+                  "max": 15,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "red",
+                        "value": 0
+                      },
+                      {
+                        "color": "green",
+                        "value": 5
+                      },
+                      {
+                        "color": "light-yellow",
+                        "value": 10
+                      }
+                    ]
+                  },
+                  "unit": "celsius"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-81": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "clamp_min(clamp_max(avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])) * 2 + min(min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d])) - max_over_time(avg(hw_host_ambient_temperature_celsius{site=~\"$site\"})[1d:]) - 5, 29), 15)",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "The recommended site temperature based on the site's current heating margin, as well as the current and past site temperatures.",
+          "id": 81,
+          "links": [],
+          "title": "Recommended Max Site Temperature",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "transparent",
+                    "mode": "fixed"
+                  },
+                  "decimals": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "celsius"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-82": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(avg_over_time(hw_host_power_watts{site=~\"$site\"}[1d])) * (avg(avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[1d])) - 1.15) * 24 * 365 * (clamp_max(avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])) + min(min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d])) - 5 - ((avg(max_over_time(avg(hw_host_ambient_temperature_celsius{site=~\"$site\"})[1d:])) - avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])))), 29) - avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d]))) * 0.05",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": [
+                {
+                  "kind": "reduce",
+                  "spec": {
+                    "id": "reduce",
+                    "options": {
+                      "reducers": []
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The estimated energy consumption cuts based on the current power consumption, heating margin, site temperature and recommended site temperature.\n\nIf the recommended site temperature is lower than the current site temperature, this number may be negative.",
+          "id": 82,
+          "links": [],
+          "title": "Potential Yearly Energy Savings",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "super-light-red",
+                        "value": 0
+                      },
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-83": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(avg_over_time(hw_host_power_watts{site=~\"$site\"}[1d])) * (avg(avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[1d])) - 1.15) * 24 * 365 * (clamp_max(avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])) + min(min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d])) - 5 - ((max_over_time(avg(hw_host_ambient_temperature_celsius{site=~\"$site\"})[1d:]) - avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])))), 29) - avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d]))) * 0.05 * avg(avg_over_time(hw_site_electricity_cost{site=~\"$site\"}[1d])) / 1000",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": [
+                {
+                  "kind": "reduce",
+                  "spec": {
+                    "id": "reduce",
+                    "options": {
+                      "reducers": []
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The estimated yearly savings based on the current power consumption, heating margin, site temperature and recommended site temperature.\n\nIf the recommended site temperature is lower than the current site temperature, this number may be negative.",
+          "id": 83,
+          "links": [],
+          "title": "Potential Yearly Savings",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "super-light-red",
+                        "value": 0
+                      },
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-84": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(avg_over_time(hw_host_power_watts{site=~\"$site\"}[1d])) * (avg(avg_over_time(hw_site_pue_ratio{site=~\"$site\"}[1d])) - 1.15) * 24 * 365 * (clamp_max(avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])) + min(min_over_time(hw_host_heating_margin_celsius{site=~\"$site\"}[1d])) - 5 - ((max_over_time(avg(hw_host_ambient_temperature_celsius{site=~\"$site\"})[1d:]) - avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d])))), 29) - avg(avg_over_time(hw_host_ambient_temperature_celsius{site=~\"$site\"}[1d]))) * 0.05 * avg(avg_over_time(hw_site_carbon_intensity_grams{site=~\"$site\"}[1d])) / 1000 / 1000000",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": [
+                {
+                  "kind": "reduce",
+                  "spec": {
+                    "id": "reduce",
+                    "options": {
+                      "reducers": []
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The estimated CO₂ emissions reduction based on the current power consumption, heating margin, site temperature and recommended site temperature.\n\nIf the recommended site temperature is lower than the current site temperature, this number may be negative.",
+          "id": 84,
+          "links": [],
+          "title": "Potential Yearly CO₂ Reduction",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "super-light-red",
+                        "value": 0
+                      },
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "masst"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-87": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "exemplar": false,
+                        "expr": "count by (vendor) (label_replace(hw_status{hw_type=\"enclosure\", site=~\"$site\", state=\"present\"}, \"vendor\", \"Unknown\", \"vendor\", \"^$\"))",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "{{vendor}}"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The hosts distribution per manufacturer.",
+          "id": 87,
+          "links": [],
+          "title": "Hosts Vendors",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "displayLabels": [
+                  "name",
+                  "percent"
+                ],
+                "legend": {
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": false,
+                  "values": []
+                },
+                "pieType": "pie",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": true
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-89": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "last_over_time(timestamp(metricshub_agent_info{agent_host_name=\"$agent\"})[6h:])",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": [
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Last Seen",
+                      "binary": {
+                        "left": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value"
+                          }
+                        },
+                        "operator": "*",
+                        "right": {
+                          "fixed": "1000"
+                        }
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "include": [
+                          "Last Seen"
+                        ],
+                        "reducer": "last"
+                      },
+                      "replaceFields": false
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "agent_host_name",
+                          "build_date",
+                          "build_number",
+                          "version",
+                          "Last Seen",
+                          "cc_version"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Value": true,
+                        "Value #A": true,
+                        "__name__": true,
+                        "agent_host_name": false,
+                        "build_number": false,
+                        "build_number 2": true,
+                        "hc_version 2": true,
+                        "host_id": true,
+                        "host_id 1": true,
+                        "host_id 2": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "job": true,
+                        "name": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "otel_version": true,
+                        "project_name": true,
+                        "project_name 1": true,
+                        "project_name 2": true,
+                        "project_version": true,
+                        "project_version 2": true,
+                        "service_name": true,
+                        "service_name 1": true,
+                        "service_name 2": true,
+                        "site": true,
+                        "site 2": true,
+                        "timestamp": true,
+                        "timestamp 1": true,
+                        "timestamp 2": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Last Seen": 5,
+                        "agent_host_name": 0,
+                        "build_date": 3,
+                        "build_number": 4,
+                        "cc_version": 2,
+                        "version": 1
+                      },
+                      "renameByName": {
+                        "Time": "",
+                        "Value": "",
+                        "agent_host_name": "Hostname",
+                        "build_date": "Build Date",
+                        "build_number": "Build Number",
+                        "build_number 1": "Agent Build Number",
+                        "cc_version": "Connectors Version",
+                        "hc_version": "Connectors Version",
+                        "hc_version 1": "Connectors Version",
+                        "name": "",
+                        "otel_version": "",
+                        "project_version": "",
+                        "project_version 1": "Agent Version",
+                        "site": "",
+                        "site 1": "Site",
+                        "timestamp": "",
+                        "version": "Version"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 89,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Last Seen"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dateTimeFromNow"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Hostname"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Site"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-91": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(increase(hw_host_energy_joules_total{site=~\"$site\"}[$__range])) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[$__range:5m]) / 3600 ",
+                        "instant": true,
+                        "legendFormat": "Today's Live Consumption",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "hideTimeOverride": true,
+                "timeFrom": "now/d"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Today's power consumption for the site.",
+          "id": 91,
+          "links": [],
+          "title": "Today's Live Consumption",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "watth"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-92": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(increase(hw_host_energy_joules_total{site=~\"$site\"}[$__range])) * avg_over_time(avg(hw_site_pue_ratio{site=~\"$site\"})[$__range:5m]) * avg_over_time(avg(hw_site_electricity_cost{site=~\"$site\"})[$__range:5m]) / 3600 / 1000",
+                        "instant": true,
+                        "legendFormat": "Today's Live Cost",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "hideTimeOverride": true,
+                "timeFrom": "now/d"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Today's power cost for the site.",
+          "id": 92,
+          "links": [],
+          "title": "Today's Live Cost",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "currencyUSD"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-44"
+                        },
+                        "height": 2,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-36"
+                        },
+                        "height": 4,
+                        "width": 2,
+                        "x": 0,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-127"
+                        },
+                        "height": 4,
+                        "width": 2,
+                        "x": 2,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-61"
+                        },
+                        "height": 4,
+                        "width": 2,
+                        "x": 4,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-37"
+                        },
+                        "height": 4,
+                        "width": 2,
+                        "x": 6,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-59"
+                        },
+                        "height": 7,
+                        "width": 4,
+                        "x": 8,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-87"
+                        },
+                        "height": 7,
+                        "width": 4,
+                        "x": 12,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-129"
+                        },
+                        "height": 4,
+                        "width": 5,
+                        "x": 16,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-132"
+                        },
+                        "height": 4,
+                        "width": 3,
+                        "x": 21,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-68"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 0,
+                        "y": 6
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-70"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 2,
+                        "y": 6
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-69"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 4,
+                        "y": 6
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-71"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 6,
+                        "y": 6
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-56"
+                        },
+                        "height": 3,
+                        "width": 4,
+                        "x": 16,
+                        "y": 6
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-55"
+                        },
+                        "height": 3,
+                        "width": 4,
+                        "x": 20,
+                        "y": 6
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Overall Information"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-38"
+                        },
+                        "height": 4,
+                        "width": 4,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-130"
+                        },
+                        "height": 11,
+                        "width": 8,
+                        "x": 4,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-112"
+                        },
+                        "height": 2,
+                        "width": 3,
+                        "x": 12,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-114"
+                        },
+                        "height": 2,
+                        "width": 9,
+                        "x": 15,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-91"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 12,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-154"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 15,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-151"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 18,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-152"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 21,
+                        "y": 2
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-19"
+                        },
+                        "height": 4,
+                        "width": 4,
+                        "x": 0,
+                        "y": 4
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-92"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 12,
+                        "y": 5
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-155"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 15,
+                        "y": 5
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-148"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 18,
+                        "y": 5
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-149"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 21,
+                        "y": 5
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-125"
+                        },
+                        "height": 3,
+                        "width": 4,
+                        "x": 0,
+                        "y": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-48"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 12,
+                        "y": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-153"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 15,
+                        "y": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-145"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 18,
+                        "y": 8
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-146"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 21,
+                        "y": 8
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Power, Costs and CO₂ Emissions"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-2"
+                        },
+                        "height": 3,
+                        "width": 4,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-74"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 4,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-76"
+                        },
+                        "height": 9,
+                        "width": 9,
+                        "x": 7,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-4"
+                        },
+                        "height": 5,
+                        "width": 4,
+                        "x": 16,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-82"
+                        },
+                        "height": 3,
+                        "width": 4,
+                        "x": 20,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-157"
+                        },
+                        "height": 6,
+                        "width": 7,
+                        "x": 0,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-83"
+                        },
+                        "height": 3,
+                        "width": 4,
+                        "x": 20,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-81"
+                        },
+                        "height": 4,
+                        "width": 4,
+                        "x": 16,
+                        "y": 5
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-84"
+                        },
+                        "height": 3,
+                        "width": 4,
+                        "x": 20,
+                        "y": 6
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Site Temperature Optimization"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-6"
+                        },
+                        "height": 13,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Hosts"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-156"
+                        },
+                        "height": 14,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "History"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-107"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-89"
+                        },
+                        "height": 3,
+                        "width": 18,
+                        "x": 3,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-159"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 21,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Hardware Sentry Agent Status"
+            }
+          }
+        ]
+      }
+    },
+    "links": [
       {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(metricshub_host_configured,site)",
-        "includeAll": false,
-        "label": "Site",
-        "name": "site",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(metricshub_host_configured,site)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "sort": 5,
-        "type": "query"
+        "asDropdown": false,
+        "icon": "external link",
+        "includeVars": false,
+        "keepTime": true,
+        "tags": [
+          "hw_main"
+        ],
+        "targetBlank": false,
+        "title": "",
+        "tooltip": "",
+        "type": "dashboards",
+        "url": ""
       },
       {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(metricshub_host_configured{site=\"$site\"},agent_host_name)",
-        "hide": 2,
-        "includeAll": false,
-        "name": "agent",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(metricshub_host_configured{site=\"$site\"},agent_host_name)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "type": "query"
+        "asDropdown": false,
+        "icon": "external link",
+        "includeVars": true,
+        "keepTime": false,
+        "tags": [
+          "hw_host"
+        ],
+        "targetBlank": false,
+        "title": "Host",
+        "tooltip": "",
+        "type": "dashboards",
+        "url": ""
+      }
+    ],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "hw_site"
+    ],
+    "timeSettings": {
+      "autoRefresh": "30s",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-7d",
+      "hideTimepicker": false,
+      "timezone": "browser",
+      "to": "now"
+    },
+    "title": "Hardware Site (MetricsHub)",
+    "variables": [
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(metricshub_host_configured,site)",
+          "hide": "dontHide",
+          "includeAll": false,
+          "label": "Site",
+          "multi": false,
+          "name": "site",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(metricshub_host_configured,site)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(metricshub_host_configured{site=\"$site\"},agent_host_name)",
+          "hide": "hideVariable",
+          "includeAll": false,
+          "multi": false,
+          "name": "agent",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(metricshub_host_configured{site=\"$site\"},agent_host_name)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
       }
     ]
   },
-  "time": {
-    "from": "now-7d",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "Europe/Paris",
-  "title": "Hardware Site (MetricsHub)",
-  "uid": "SHFBpSH7z",
-  "version": 15,
-  "weekStart": "",
-  "id": null
+  "status": {}
 }

--- a/src/dashboards/Storage/Storage System (MetricsHub).json
+++ b/src/dashboards/Storage/Storage System (MetricsHub).json
@@ -1,0 +1,13941 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "adgtcq2",
+    "generation": 403,
+    "creationTimestamp": "2026-03-10T08:35:57Z",
+    "labels": {},
+    "annotations": {}
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {},
+            "version": "v0"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Crosshair",
+    "description": "\n\nActive Count: number of volumes that served I/O over the selected time range.\n\nActive Consumed Capacity: total capacity currently stored across active volumes.\n\nInactive Count: number of volumes that served no measurable I/O over the selected time range.\n\nInactive Consumed Capacity: total capacity currently stored across inactive volumes. ",
+    "editable": true,
+    "elements": {
+      "panel-10": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_limit_bytes{host_name=~\"$host_name\", storage_type=\"storage_system\"}",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "serial_number"
+                        ],
+                        "pattern": "(vendor|model)"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "model": true,
+                        "vendor": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "family": 1,
+                        "model": 2,
+                        "vendor": 0
+                      },
+                      "renameByName": {}
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 10,
+          "links": [],
+          "title": "Serial Number",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#808080",
+                    "mode": "fixed"
+                  },
+                  "noValue": "N/A",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "vendor"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Host Vendor"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "model"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Host Model"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "fields": "/.*/",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 17
+                },
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-122": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  storage_usage_bytes{host_name=\"$host_name\", storage_type=\"pool\", storage_provisioning_state=\"used\"} \r\n  / ignoring(storage_provisioning_state) \r\n  storage_limit_bytes{host_name=\"$host_name\", storage_type=\"pool\"}\r\n) \r\n- \r\n(\r\n  storage_usage_bytes{host_name=\"$host_name\", storage_type=\"pool\", storage_provisioning_state=\"used\"} offset $__range\r\n  / ignoring(storage_provisioning_state) \r\n  storage_limit_bytes{host_name=\"$host_name\", storage_type=\"pool\"} offset $__range\r\n  or vector(0)\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Consumed Capacity % Change"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "storage_usage_bytes{host_name=\"$host_name\", storage_type=\"pool\", storage_provisioning_state=\"used\"}",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Trend Usage"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "100 * storage_provisioning_bytes{\r\n  host_name=\"$host_name\",\r\n  storage_type=\"pool\",\r\n  storage_provisioning_state=\"subscribed\"\r\n}\r\n/\r\nignoring(storage_provisioning_state)\r\nstorage_limit_bytes{\r\n   host_name=\"$host_name\",\r\n   storage_type=\"pool\"\r\n}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Oversubscription %"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_usage_bytes{\r\n  host_name=\"$host_name\",\r\n  storage_type=\"pool\",\r\n  storage_provisioning_state=\"used\"\r\n}\r\n/\r\nignoring(storage_provisioning_state)\r\nstorage_limit_bytes{\r\n  host_name=\"$host_name\",\r\n  storage_type=\"pool\"\r\n}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Consumed Capacity %"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "storage_provisioning_bytes{\r\n  host_name=\"$host_name\",\r\n  storage_type=\"pool\",\r\n  storage_provisioning_state=\"subscribed\"\r\n}",
+                        "format": "table",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Subscribed"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_limit_bytes{\r\n  host_name=\"$host_name\",\r\n  storage_type=\"pool\"\r\n}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_provisioning_bytes{\r\n  host_name=\"$host_name\",\r\n  storage_type=\"pool\",\r\n  storage_provisioning_state=\"subscribed\"\r\n}\r\n/\r\nignoring(storage_provisioning_state)\r\nstorage_limit_bytes{\r\n   host_name=\"$host_name\",\r\n   storage_type=\"pool\"\r\n}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Subscription %"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  (\r\n    storage_limit_bytes{host_name=\"$host_name\", storage_type=\"pool\"}\r\n    - ignoring(storage_provisioning_state)\r\n    storage_usage_bytes{host_name=\"$host_name\", storage_type=\"pool\", storage_provisioning_state=\"used\"}\r\n  )\r\n  / ignoring(storage_provisioning_state)\r\n  deriv(\r\n    storage_usage_bytes{host_name=\"$host_name\", storage_type=\"pool\", storage_provisioning_state=\"used\"}[$__range]\r\n  )\r\n) > 0",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Time Until Saturation"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "deriv(\r\n  storage_usage_bytes{host_name=\"$host_name\", storage_type=\"pool\", storage_provisioning_state=\"used\"}[$__range]\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Growth Rate"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 50
+              },
+              "transformations": [
+                {
+                  "kind": "timeSeriesTable",
+                  "spec": {
+                    "filter": {
+                      "id": "byRefId",
+                      "options": "/^(?:Trend Usage)$/"
+                    },
+                    "id": "timeSeriesTable",
+                    "options": {
+                      "Capacity": {
+                        "timeField": "Time"
+                      },
+                      "Configured": {
+                        "timeField": "Time"
+                      },
+                      "Subscribed": {
+                        "timeField": "Time"
+                      },
+                      "Trend": {
+                        "timeField": "Time"
+                      },
+                      "Trend Usage": {
+                        "timeField": "Time"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "id",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "filterByValue",
+                  "spec": {
+                    "id": "filterByValue",
+                    "options": {
+                      "filters": [
+                        {
+                          "config": {
+                            "id": "greater",
+                            "options": {
+                              "value": "1"
+                            }
+                          },
+                          "fieldName": "Value #Subscription %"
+                        }
+                      ],
+                      "match": "any",
+                      "type": "include"
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Status": true,
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Time 5": true,
+                        "Time 6": true,
+                        "Time 7": true,
+                        "Time 8": true,
+                        "Time 9": true,
+                        "Value #State": true,
+                        "__name__": true,
+                        "__name__ 1": true,
+                        "__name__ 2": true,
+                        "__name__ 3": true,
+                        "__name__ 4": true,
+                        "__name__ 5": true,
+                        "__name__ 6": true,
+                        "__name__ 7": true,
+                        "agent_host_name": true,
+                        "agent_host_name 1": true,
+                        "agent_host_name 2": true,
+                        "agent_host_name 3": true,
+                        "agent_host_name 4": true,
+                        "agent_host_name 5": true,
+                        "agent_host_name 6": true,
+                        "agent_host_name 7": true,
+                        "agent_host_name 8": true,
+                        "connector_id": true,
+                        "connector_id 1": true,
+                        "connector_id 2": true,
+                        "connector_id 3": true,
+                        "connector_id 4": true,
+                        "connector_id 5": true,
+                        "connector_id 6": true,
+                        "connector_id 7": true,
+                        "connector_id 8": true,
+                        "dellemc_powerstore_storage_type 1": true,
+                        "dellemc_powerstore_storage_type 2": true,
+                        "dellemc_powerstore_storage_type 3": true,
+                        "dellemc_powerstore_storage_type 4": true,
+                        "dellemc_powerstore_storage_type 5": true,
+                        "disk_type 1": true,
+                        "disk_type 2": true,
+                        "disk_type 3": true,
+                        "disk_type 4": true,
+                        "disk_type 5": true,
+                        "disk_type 6": true,
+                        "disk_type 7": true,
+                        "disk_type 8": true,
+                        "entityName 1": true,
+                        "entityName 2": true,
+                        "entityName 3": true,
+                        "entityName 4": true,
+                        "entityName 5": true,
+                        "entityName 6": true,
+                        "entityName 7": true,
+                        "entityName 8": true,
+                        "entityTypeId 1": true,
+                        "entityTypeId 2": true,
+                        "entityTypeId 3": true,
+                        "entityTypeId 4": true,
+                        "entityTypeId 5": true,
+                        "entityTypeId 6": true,
+                        "entityTypeId 7": true,
+                        "entityTypeId 8": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_name 3": true,
+                        "host_name 4": true,
+                        "host_name 5": true,
+                        "host_name 6": true,
+                        "host_name 7": true,
+                        "host_name 8": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "host_type 3": true,
+                        "host_type 4": true,
+                        "host_type 5": true,
+                        "host_type 6": true,
+                        "host_type 7": true,
+                        "host_type 8": true,
+                        "id": true,
+                        "instanceName 1": true,
+                        "instanceName 2": true,
+                        "instanceName 3": true,
+                        "instanceName 4": true,
+                        "instanceName 5": true,
+                        "instanceName 6": true,
+                        "instanceName 7": true,
+                        "instanceName 8": true,
+                        "name 2": true,
+                        "name 3": true,
+                        "name 4": true,
+                        "name 5": true,
+                        "name 6": true,
+                        "name 7": true,
+                        "name 8": true,
+                        "netapp_storage_type 1": true,
+                        "netapp_storage_type 2": true,
+                        "netapp_storage_type 3": true,
+                        "netapp_storage_type 4": true,
+                        "netapp_storage_type 5": true,
+                        "netapp_storage_type 6": true,
+                        "netapp_storage_type 7": true,
+                        "netapp_storage_type 8": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "os_type 3": true,
+                        "os_type 4": true,
+                        "os_type 5": true,
+                        "os_type 6": true,
+                        "os_type 7": true,
+                        "os_type 8": true,
+                        "otel_scope_name 1": true,
+                        "otel_scope_name 2": true,
+                        "otel_scope_name 3": true,
+                        "otel_scope_name 4": true,
+                        "otel_scope_name 5": true,
+                        "otel_scope_name 6": true,
+                        "otel_scope_name 7": true,
+                        "otel_scope_name 8": true,
+                        "raid_level 1": true,
+                        "raid_level 2": true,
+                        "raid_level 3": true,
+                        "raid_level 4": true,
+                        "raid_level 5": true,
+                        "raid_level 6": true,
+                        "raid_level 7": true,
+                        "raid_level 8": true,
+                        "site": true,
+                        "site 1": true,
+                        "site 2": true,
+                        "site 3": true,
+                        "site 4": true,
+                        "site 5": true,
+                        "site 6": true,
+                        "site 7": true,
+                        "site 8": true,
+                        "state": true,
+                        "state 1": true,
+                        "state 2": true,
+                        "state 3": true,
+                        "state 4": true,
+                        "state 5": true,
+                        "storage_consumer_state": true,
+                        "storage_parent_id": true,
+                        "storage_parent_id 1": true,
+                        "storage_parent_id 2": true,
+                        "storage_parent_id 3": true,
+                        "storage_parent_id 4": true,
+                        "storage_parent_id 5": true,
+                        "storage_parent_id 6": true,
+                        "storage_parent_id 7": true,
+                        "storage_parent_id 8": true,
+                        "storage_parent_type": true,
+                        "storage_parent_type 1": true,
+                        "storage_parent_type 2": true,
+                        "storage_parent_type 3": true,
+                        "storage_parent_type 4": true,
+                        "storage_parent_type 5": true,
+                        "storage_parent_type 6": true,
+                        "storage_parent_type 7": true,
+                        "storage_parent_type 8": true,
+                        "storage_perent_id 1": true,
+                        "storage_perent_id 2": true,
+                        "storage_perent_id 3": true,
+                        "storage_perent_id 4": true,
+                        "storage_perent_id 5": true,
+                        "storage_perent_type 1": true,
+                        "storage_perent_type 2": true,
+                        "storage_perent_type 3": true,
+                        "storage_perent_type 4": true,
+                        "storage_perent_type 5": true,
+                        "storage_provisioning_state": true,
+                        "storage_provisioning_state 1": true,
+                        "storage_provisioning_state 2": true,
+                        "storage_provisioning_state 3": true,
+                        "storage_provisioning_state 4": true,
+                        "storage_provisioning_state 5": true,
+                        "storage_type": true,
+                        "storage_type 1": true,
+                        "storage_type 2": true,
+                        "storage_type 3": true,
+                        "storage_type 4": true,
+                        "storage_type 5": true,
+                        "storage_type 6": true,
+                        "storage_type 7": true,
+                        "storage_type 8": true,
+                        "storage_volume_type": true,
+                        "tier_id 1": true,
+                        "tier_id 2": true,
+                        "tier_id 3": true,
+                        "tier_id 4": true,
+                        "tier_id 5": true,
+                        "tier_name 1": true,
+                        "tier_name 2": true,
+                        "tier_name 3": true,
+                        "tier_name 4": true,
+                        "tier_name 5": true,
+                        "type 1": true,
+                        "type 2": true,
+                        "type 3": true,
+                        "type 4": true,
+                        "type 5": true,
+                        "type 6": true,
+                        "type 7": true,
+                        "type 8": true,
+                        "usage": true,
+                        "usage 1": true,
+                        "usage 2": true,
+                        "usage 3": true,
+                        "usage 4": true,
+                        "usage 5": true,
+                        "usage 6": true,
+                        "usage 7": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Time 1": 11,
+                        "Time 2": 21,
+                        "Time 3": 33,
+                        "Time 4": 47,
+                        "Time 5": 61,
+                        "Time 6": 97,
+                        "Time 7": 111,
+                        "Trend #Trend Usage": 9,
+                        "Value #Capacity": 2,
+                        "Value #Consumed Capacity %": 5,
+                        "Value #Consumed Capacity % Change": 8,
+                        "Value #Growth Rate": 7,
+                        "Value #Subscribed": 3,
+                        "Value #Subscription %": 4,
+                        "Value #Time Until Saturation": 10,
+                        "__name__ 1": 45,
+                        "__name__ 2": 48,
+                        "__name__ 3": 62,
+                        "agent_host_name 1": 12,
+                        "agent_host_name 2": 22,
+                        "agent_host_name 3": 34,
+                        "agent_host_name 4": 49,
+                        "agent_host_name 5": 63,
+                        "agent_host_name 6": 84,
+                        "agent_host_name 7": 98,
+                        "agent_host_name 8": 112,
+                        "connector_id 1": 13,
+                        "connector_id 2": 23,
+                        "connector_id 3": 35,
+                        "connector_id 4": 50,
+                        "connector_id 5": 64,
+                        "connector_id 6": 85,
+                        "connector_id 7": 99,
+                        "connector_id 8": 113,
+                        "disk_type 1": 74,
+                        "disk_type 2": 76,
+                        "disk_type 3": 78,
+                        "disk_type 4": 80,
+                        "disk_type 5": 82,
+                        "disk_type 6": 86,
+                        "disk_type 7": 100,
+                        "disk_type 8": 114,
+                        "host_name 1": 14,
+                        "host_name 2": 24,
+                        "host_name 3": 36,
+                        "host_name 4": 51,
+                        "host_name 5": 65,
+                        "host_name 6": 87,
+                        "host_name 7": 101,
+                        "host_name 8": 115,
+                        "host_type 1": 15,
+                        "host_type 2": 25,
+                        "host_type 3": 37,
+                        "host_type 4": 52,
+                        "host_type 5": 66,
+                        "host_type 6": 88,
+                        "host_type 7": 102,
+                        "host_type 8": 116,
+                        "id": 0,
+                        "name 1": 1,
+                        "name 2": 26,
+                        "name 3": 38,
+                        "name 4": 53,
+                        "name 5": 67,
+                        "name 6": 89,
+                        "name 7": 103,
+                        "name 8": 117,
+                        "netapp_storage_type 1": 126,
+                        "netapp_storage_type 2": 127,
+                        "netapp_storage_type 3": 128,
+                        "netapp_storage_type 4": 129,
+                        "netapp_storage_type 5": 130,
+                        "netapp_storage_type 6": 131,
+                        "netapp_storage_type 7": 132,
+                        "netapp_storage_type 8": 133,
+                        "os_type 1": 16,
+                        "os_type 2": 27,
+                        "os_type 3": 39,
+                        "os_type 4": 54,
+                        "os_type 5": 68,
+                        "os_type 6": 90,
+                        "os_type 7": 104,
+                        "os_type 8": 118,
+                        "raid_level 1": 75,
+                        "raid_level 2": 77,
+                        "raid_level 3": 79,
+                        "raid_level 4": 81,
+                        "raid_level 5": 83,
+                        "raid_level 6": 91,
+                        "raid_level 7": 105,
+                        "raid_level 8": 119,
+                        "site 1": 17,
+                        "site 2": 28,
+                        "site 3": 40,
+                        "site 4": 55,
+                        "site 5": 69,
+                        "site 6": 92,
+                        "site 7": 106,
+                        "site 8": 120,
+                        "storage_parent_id 1": 18,
+                        "storage_parent_id 2": 29,
+                        "storage_parent_id 3": 41,
+                        "storage_parent_id 4": 56,
+                        "storage_parent_id 5": 70,
+                        "storage_parent_id 6": 93,
+                        "storage_parent_id 7": 107,
+                        "storage_parent_id 8": 121,
+                        "storage_parent_type 1": 19,
+                        "storage_parent_type 2": 30,
+                        "storage_parent_type 3": 42,
+                        "storage_parent_type 4": 57,
+                        "storage_parent_type 5": 71,
+                        "storage_parent_type 6": 94,
+                        "storage_parent_type 7": 108,
+                        "storage_parent_type 8": 122,
+                        "storage_provisioning_state 1": 46,
+                        "storage_provisioning_state 2": 58,
+                        "storage_provisioning_state 3": 123,
+                        "storage_type 1": 20,
+                        "storage_type 2": 31,
+                        "storage_type 3": 43,
+                        "storage_type 4": 59,
+                        "storage_type 5": 72,
+                        "storage_type 6": 95,
+                        "storage_type 7": 109,
+                        "storage_type 8": 124,
+                        "type 1": 6,
+                        "type 2": 32,
+                        "type 3": 44,
+                        "type 4": 60,
+                        "type 5": 73,
+                        "type 6": 96,
+                        "type 7": 110,
+                        "type 8": 125
+                      },
+                      "orderByMode": "manual",
+                      "renameByName": {
+                        "Consumed Capacity Percentage": "Consumed Capacity %",
+                        "State": "",
+                        "Status": "Status",
+                        "Time 4": "",
+                        "Trend #Trend": "Trend",
+                        "Trend #Trend Usage": "Trend",
+                        "Value": "Size",
+                        "Value #Capacity": "Capacity",
+                        "Value #Configured": "Configured Capacity",
+                        "Value #Configured Capacity": "Subscribed Capacity",
+                        "Value #Consumed Capacity %": "Consumed %",
+                        "Value #Consumed Capacity % Change": "Change",
+                        "Value #Free": "Available Capacity",
+                        "Value #Growth Rate": "Growth Rate",
+                        "Value #Operations Rate": "Operations Rate",
+                        "Value #Oversubscription %": "Oversubscription %",
+                        "Value #Pool Size": "Capacity",
+                        "Value #State": "",
+                        "Value #Status": "Status",
+                        "Value #Subscribed": "Subscribed",
+                        "Value #Subscribed Capacity": "Subscribed Capacity",
+                        "Value #Subscription %": "Subscription %",
+                        "Value #Time Until Saturation": "Time Until Saturation",
+                        "Value #Transfer Rate": "Transfer Rate",
+                        "Value #Used": "Consumed Capacity",
+                        "__name__ 7": "",
+                        "disk_type": "Pool Disk Type",
+                        "disk_type 1": "Pool Disk Type",
+                        "disk_type 2": "",
+                        "id": "",
+                        "name": "Name",
+                        "name 1": "Name",
+                        "netapp_storage_type 1": "Type",
+                        "netapp_storage_type 2": "",
+                        "raid_level": "RAID Level",
+                        "raid_level 1": "RAID Level",
+                        "raid_level 5": "",
+                        "storage_perent_id 1": "",
+                        "storage_type": "",
+                        "storage_type 8": "",
+                        "type": "Pool Type",
+                        "type 1": "Array Pool Type",
+                        "usage": "Usage",
+                        "usage 1": "",
+                        "usage 2": "",
+                        "usage 3": ""
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Lists the storage pools whose subscribed capacity exceeds their usable capacity.\n\nCapacity: total usable capacity of the pool available for data.\n\nSubscribed: capacity committed to hosts through volumes mapped to initiators.\n\nSubscription %: ratio of Subscribed to Capacity. Above 100% means the pool is oversubscribed, more capacity has been promised than physically exists.\n\nConsumed Capacity %: share of the pool's usable capacity currently storing data.\n\nConsumed Capacity % Change: change in Consumed Capacity % over the selected time range. Positive values indicate growth.\n\nGrowth Rate: rate at which consumed capacity is increasing, averaged over the selected time range.\n\nTime Until Saturation: projected time until the pool's free capacity is fully consumed, assuming consumption keeps growing at the current rate. Pools that are flat or shrinking have no value.",
+          "id": 122,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Subscribed"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Used"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Operations Rate"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "iops"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "fieldMinMax",
+                        "value": true
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "super-light-yellow",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "name"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Consumed %"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "#EAB839",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.9
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "NaN": {
+                                "index": 0,
+                                "text": "-"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Consumed Capacity % Change"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "thresholds"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": -0.01
+                            },
+                            {
+                              "color": "blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.01
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "NaN": {
+                                "index": 0,
+                                "text": "-"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend #Trend Usage"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "hideValue": true,
+                          "type": "sparkline"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Subscription %"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "#EAB839",
+                              "value": 3
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Time Until Saturation"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "from": 157788000,
+                              "result": {
+                                "index": 0,
+                                "text": ">  5 years"
+                              }
+                            },
+                            "type": "range"
+                          },
+                          {
+                            "options": {
+                              "match": "null+nan",
+                              "result": {
+                                "index": 1,
+                                "text": "-"
+                              }
+                            },
+                            "type": "special"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Growth Rate"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "binBps"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": -0.1
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Consumed Capacity %"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-123": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {},
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 123,
+          "links": [],
+          "title": "Dashboard Version",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "2026.2",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "light-green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-124": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count by (state) (\r\n  label_replace(\r\n    (\r\n      sum by (id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            storage_type=\"volume\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) > 0.001\r\n    )\r\n    unless on (id)\r\n    storage_usage_bytes{\r\n      host_name=~\"$host_name\",\r\n      storage_type=\"volume\",\r\n      storage_consumer_state=\"unmapped\"\r\n    },\r\n    \"state\", \"Mapped & Active\", \"\", \"\"\r\n  )\r\n)\r\nor\r\nlabel_replace(vector(0), \"state\", \"Mapped & Active\", \"__name__\", \".*\")",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Mapped & Active Volumes Count"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (state) (\r\n  label_replace(\r\n    storage_usage_bytes{\r\n      host_name=~\"$host_name\",\r\n      storage_type=\"volume\",\r\n      storage_consumer_state=\"mapped\",\r\n      storage_provisioning_state=\"used\"\r\n    }\r\n    and on (host_name, id)\r\n    (\r\n      sum by (host_name, id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            storage_type=\"volume\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) > 0.001\r\n    ),\r\n    \"state\", \"Mapped & Active\", \"\", \"\"\r\n  )\r\n)",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Mapped & Active Consumed Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count by (state) (\r\n  label_replace(\r\n    (\r\n      sum by (id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            storage_type=\"volume\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) <= 0.001\r\n    )\r\n    unless on (id)\r\n    storage_usage_bytes{\r\n      host_name=~\"$host_name\",\r\n      storage_type=\"volume\",\r\n      storage_consumer_state=\"unmapped\"\r\n    },\r\n    \"state\", \"Mapped & Inactive\", \"\", \"\"\r\n  )\r\n) or label_replace(vector(0), \"state\", \"Mapped & Inactive\", \"\", \"\")",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Mapped & Inactive Count"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (state) (\r\n  label_replace(\r\n    storage_usage_bytes{\r\n      host_name=~\"$host_name\",\r\n      storage_type=\"volume\",\r\n      storage_consumer_state=\"mapped\",\r\n      storage_provisioning_state=\"used\"\r\n    }\r\n    and on (host_name, id)\r\n    (\r\n      sum by (host_name, id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            storage_type=\"volume\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) <= 0.001\r\n    ),\r\n    \"state\", \"Mapped & Inactive\", \"\", \"\"\r\n  )\r\n)",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Mapped & Inactive Consumed Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_replace(\r\n  count(\r\n    sum by (id) (\r\n      storage_usage_bytes{\r\n        host_name=~\"$host_name\",\r\n        storage_consumer_state=\"unmapped\",\r\n        storage_type=\"volume\"\r\n      }\r\n    )\r\n  ),\r\n  \"state\", \"Unmapped\", \"\", \"\"\r\n)\r\nor label_replace(vector(0), \"state\", \"Unmapped\", \"\", \"\")",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Unmapped Count"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_replace(\r\n  sum(\r\n    storage_usage_bytes{\r\n      host_name=~\"$host_name\",\r\n      storage_consumer_state=\"unmapped\",\r\n      storage_type=\"volume\",\r\n      storage_provisioning_state=\"used\"\r\n    }\r\n  ),\r\n  \"state\", \"Unmapped\", \"\", \"\"\r\n)\r\nor\r\nlabel_replace(vector(0), \"state\", \"Unmapped\", \"\", \"\")",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Unammped Consumed Capacity"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "joinByLabels",
+                  "spec": {
+                    "id": "joinByLabels",
+                    "options": {
+                      "value": "state"
+                    }
+                  }
+                },
+                {
+                  "kind": "labelsToFields",
+                  "spec": {
+                    "id": "labelsToFields",
+                    "options": {
+                      "mode": "columns",
+                      "valueLabel": "state"
+                    }
+                  }
+                },
+                {
+                  "kind": "transpose",
+                  "spec": {
+                    "id": "transpose",
+                    "options": {}
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Breaks the volumes into three categories based on whether each volume is mapped to a host and whether it has served any I/O over the displayed time range.\n\nMapped & Active - Count: number of volumes mapped to a host that have served I/O over the selected range.\n\nMapped & Active - Consumed Capacity: capacity currently storing data across the active volumes.\n\nMapped & Inactive - Count: number of volumes mapped to a host but idle over the selected range.\n\nMapped & Inactive - Consumed Capacity: space that is exposed to a host but not being used. This is often a sign of stale or forgotten volumes still holding data.\n\nUnmapped - Count: number of volumes that exist but are not mapped to any host.\n\nUnmapped - Consumed Capacity: space consumed on the array that no host can reach. Possibly a strong candidate for reclamation.",
+          "id": 124,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "decimals": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "1"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Count"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "volumes"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max"
+                      },
+                      {
+                        "id": "fieldMinMax",
+                        "value": true
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "2"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Consumed Capacity"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 1
+                      },
+                      {
+                        "id": "fieldMinMax",
+                        "value": true
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Field"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Volume State"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-129": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(hw_network_io_bytes_total{host_name=\"$host_name\", direction=\"transmit\"}[$__rate_interval]))",
+                        "instant": false,
+                        "legendFormat": "Transmitted",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(hw_network_io_bytes_total{host_name=\"$host_name\", direction=\"receive\"}[$__rate_interval]))",
+                        "instant": false,
+                        "legendFormat": "Received",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Total network throughput across all ports on the storage system, split by direction.\n\nTransmitted: bytes per second sent out of the storage system's ports.\n\nReceived: bytes per second arriving on the storage system's ports.",
+          "id": 129,
+          "links": [],
+          "title": "Network Traffic - Total",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "red",
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": true,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 50,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "binBps"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "A"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "purple",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.transform",
+                        "value": "negative-Y"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "min",
+                    "mean",
+                    "max",
+                    "lastNotNull"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true,
+                  "sortBy": "Name",
+                  "sortDesc": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-130": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "rate(hw_network_io_bytes_total{host_name=\"$host_name\", direction=\"transmit\", id=~\"$network_id\"}[$__rate_interval])",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "Transmitted",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "rate(hw_network_io_bytes_total{host_name=\"$host_name\", direction=\"receive\", id=~\"$network_id\"}[$__rate_interval])",
+                        "instant": false,
+                        "legendFormat": "Received",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Per-port network throughput across every port on the storage system, split by direction. \n\nOne sub-chart is drawn per port, letting you identify which specific port is carrying the traffic shown in the Total chart above.\n\nTransmitted: bytes per second sent out of the port.\n\nReceived: bytes per second arriving on the port. ",
+          "id": 130,
+          "links": [],
+          "title": "Traffic: $network_id",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": true,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 50,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "stepBefore",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 1,
+                    "pointSize": 7,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "binBps"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Received"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.axisCenteredZero",
+                        "value": true
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.transform",
+                        "value": "negative-Y"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Transmitted"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "purple",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "last",
+                    "min",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-131": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "hw_network_up{host_name=\"$host_name\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Network Link"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "hw_status{host_name=\"$host_name\", hw_type=\"network\", state=~\"degraded|failed|ok\"} == 1",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Status"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "id",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Address",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "address 1",
+                          "address 2"
+                        ],
+                        "reducer": "last"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Type",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "network_type 1",
+                          "network_type 2"
+                        ],
+                        "reducer": "last"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Role",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "role 1",
+                          "role 2"
+                        ],
+                        "reducer": "last"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Name",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "name 1",
+                          "name 2"
+                        ],
+                        "reducer": "last"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Attachment Type",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "hw_parent_type 1",
+                          "hw_parent_type 2"
+                        ],
+                        "reducer": "last"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Attachment ID",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "hw_parent_id 1",
+                          "hw_parent_id 2"
+                        ],
+                        "reducer": "last"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Value #Network Link": false,
+                        "Value #Status": true,
+                        "__name__": true,
+                        "__name__ 1": true,
+                        "__name__ 2": true,
+                        "address 1": true,
+                        "address 2": true,
+                        "agent_host_name": true,
+                        "agent_host_name 1": true,
+                        "agent_host_name 2": true,
+                        "connector_id": true,
+                        "connector_id 1": true,
+                        "connector_id 2": true,
+                        "device_type 1": true,
+                        "device_type 2": true,
+                        "entityName 1": true,
+                        "entityName 2": true,
+                        "entityTypeId 1": true,
+                        "entityTypeId 2": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "hw_parent_id": true,
+                        "hw_parent_id 1": true,
+                        "hw_parent_id 2": true,
+                        "hw_parent_type": true,
+                        "hw_parent_type 1": true,
+                        "hw_parent_type 2": true,
+                        "hw_type": true,
+                        "id": true,
+                        "id 1": true,
+                        "instanceName 1": true,
+                        "instanceName 2": true,
+                        "logical_address 1": true,
+                        "logical_address 2": true,
+                        "name 1": true,
+                        "name 2": true,
+                        "network_type 1": true,
+                        "network_type 2": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "otel_scope_name 1": true,
+                        "otel_scope_name 2": true,
+                        "physical_address 1": true,
+                        "physical_address 2": true,
+                        "physical_address_type 1": true,
+                        "physical_address_type 2": true,
+                        "role 1": true,
+                        "role 2": true,
+                        "site": true,
+                        "site 1": true,
+                        "site 2": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Address": 5,
+                        "Attachment ID": 2,
+                        "Attachment Type": 1,
+                        "Name": 0,
+                        "Role": 4,
+                        "Time 1": 9,
+                        "Time 2": 23,
+                        "Type": 3,
+                        "Value #Network Link": 6,
+                        "Value #Status": 38,
+                        "__name__ 1": 10,
+                        "__name__ 2": 24,
+                        "address 1": 11,
+                        "address 2": 25,
+                        "agent_host_name 1": 12,
+                        "agent_host_name 2": 26,
+                        "connector_id 1": 13,
+                        "connector_id 2": 27,
+                        "host_name 1": 14,
+                        "host_name 2": 28,
+                        "host_type 1": 15,
+                        "host_type 2": 29,
+                        "hw_parent_id 1": 16,
+                        "hw_parent_id 2": 30,
+                        "hw_parent_type 1": 17,
+                        "hw_parent_type 2": 31,
+                        "hw_type": 32,
+                        "id": 8,
+                        "name 1": 18,
+                        "name 2": 33,
+                        "network_type 1": 19,
+                        "network_type 2": 34,
+                        "os_type 1": 20,
+                        "os_type 2": 35,
+                        "role 1": 21,
+                        "role 2": 36,
+                        "site 1": 22,
+                        "site 2": 37,
+                        "state": 7
+                      },
+                      "renameByName": {
+                        "Address": "Address",
+                        "Attachement ID": "Attachment ID",
+                        "Attachment ID": "Attachment ID",
+                        "Attachment Type": "Attachment Type",
+                        "Name": "Name",
+                        "Role": "Role",
+                        "Type": "Type",
+                        "Value": "Link Status",
+                        "Value #Network Link": "Link Status",
+                        "address": "Address",
+                        "name": "Name",
+                        "network_type": "Type",
+                        "role": "Role",
+                        "site": "",
+                        "state": "Status"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Lists every network port discovered on the storage system. Not all columns are reported by every platform.\n\nName: port name as reported by the array.\n\nAttachment Type: kind of component the port is attached to (for example, a controller, a node, or an enclosure).\n\nAttachment ID: identifier of the component the port is attached to.\n\nType: kind of network interface (for example, Fibre Channel, iSCSI, or Ethernet).\n\nRole: functional role of the port (for example, Front-end or Back-end).\n\nAddress: physical network address of the port. Typically a WWN for Fibre Channel ports or a MAC address for Ethernet ports.\n\nLink Status: physical link state of the port (up or down).\n\nStatus: operational status of the port, classified as OK, Degraded, or Failed.",
+          "id": 131,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false,
+                    "wrapHeaderText": true,
+                    "wrapText": true
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Link Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "0": {
+                                "color": "orange",
+                                "index": 0,
+                                "text": "Unplugged"
+                              },
+                              "1": {
+                                "color": "transparent",
+                                "index": 1,
+                                "text": "Plugged"
+                              }
+                            },
+                            "type": "value"
+                          },
+                          {
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "color": "transparent",
+                                "index": 2
+                              }
+                            },
+                            "type": "special"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "degraded": {
+                                "color": "orange",
+                                "index": 1,
+                                "text": "Degraded"
+                              },
+                              "failed": {
+                                "color": "red",
+                                "index": 2,
+                                "text": "Failed"
+                              },
+                              "ok": {
+                                "color": "transparent",
+                                "index": 0,
+                                "text": "OK"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Name"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Link Status"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-136": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(storage_limit_bytes{host_name=\"$host_name\", netapp_storage_type=\"lun\"})",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Total number of NetApp LUNs discovered on the storage system.",
+          "id": 136,
+          "links": [],
+          "title": "LUNs",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "#e069b4",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-137": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(storage_usage_bytes{host_name=~\"$host_name\", netapp_storage_type=\"lun\", storage_provisioning_state=\"used\"})",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Sum of the capacity currently storing data across all NetApp LUNs on the storage system.",
+          "id": 137,
+          "links": [],
+          "title": "Total Consumed Capacity",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "#e069b4",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-138": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count by (state) (\r\n  label_replace(\r\n    (\r\n      sum by (id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            netapp_storage_type=\"lun\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) > 0.001\r\n    )\r\n    unless on (id)\r\n    storage_usage_bytes{\r\n      host_name=~\"$host_name\",\r\n      netapp_storage_type=\"lun\",\r\n      storage_consumer_state=\"unmapped\"\r\n    },\r\n    \"state\", \"Mapped & Active\", \"\", \"\"\r\n  )\r\n)\r\nor\r\nlabel_replace(vector(0), \"state\", \"Mapped & Active\", \"__name__\", \".*\")",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Mapped & Active Volumes Count"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (state) (\r\n  label_replace(\r\n    storage_usage_bytes{\r\n      host_name=~\"$host_name\",\r\n      netapp_storage_type=\"lun\",\r\n      storage_consumer_state=\"mapped\",\r\n      storage_provisioning_state=\"used\"\r\n    }\r\n    and on (host_name, id)\r\n    (\r\n      sum by (host_name, id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            netapp_storage_type=\"lun\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) > 0.001\r\n    ),\r\n    \"state\", \"Mapped & Active\", \"\", \"\"\r\n  )\r\n)",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Mapped & Active Consumed Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count by (state) (\r\n  label_replace(\r\n    (\r\n      sum by (id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            netapp_storage_type=\"lun\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) <= 0.001\r\n    )\r\n    unless on (id)\r\n    storage_usage_bytes{\r\n      host_name=~\"$host_name\",\r\n      netapp_storage_type=\"lun\",\r\n      storage_consumer_state=\"unmapped\"\r\n    },\r\n    \"state\", \"Mapped & Inactive\", \"\", \"\"\r\n  )\r\n) or label_replace(vector(0), \"state\", \"Mapped & Inactive\", \"\", \"\")",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Mapped & Inactive Count"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (state) (\r\n  label_replace(\r\n    storage_usage_bytes{\r\n      host_name=~\"$host_name\",\r\n      netapp_storage_type=\"lun\",\r\n      storage_consumer_state=\"mapped\",\r\n      storage_provisioning_state=\"used\"\r\n    }\r\n    and on (host_name, id)\r\n    (\r\n      sum by (host_name, id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            netapp_storage_type=\"lun\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) <= 0.001\r\n    ),\r\n    \"state\", \"Mapped & Inactive\", \"\", \"\"\r\n  )\r\n)",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Mapped & Inactive Consumed Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_replace(\r\n  count(\r\n    sum by (id) (\r\n      storage_usage_bytes{\r\n        host_name=~\"$host_name\",\r\n        storage_consumer_state=\"unmapped\",\r\n        netapp_storage_type=\"lun\"\r\n      }\r\n    )\r\n  ),\r\n  \"state\", \"Unmapped\", \"\", \"\"\r\n)\r\nor label_replace(vector(0), \"state\", \"Unmapped\", \"\", \"\")",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Unmapped Count"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_replace(\r\n  sum(\r\n    storage_usage_bytes{\r\n      host_name=~\"$host_name\",\r\n      storage_consumer_state=\"unmapped\",\r\n      netapp_storage_type=\"lun\",\r\n      storage_provisioning_state=\"used\"\r\n    }\r\n  ),\r\n  \"state\", \"Unmapped\", \"\", \"\"\r\n)\r\nor\r\nlabel_replace(vector(0), \"state\", \"Unmapped\", \"\", \"\")",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Unammped Consumed Capacity"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "joinByLabels",
+                  "spec": {
+                    "id": "joinByLabels",
+                    "options": {
+                      "value": "state"
+                    }
+                  }
+                },
+                {
+                  "kind": "labelsToFields",
+                  "spec": {
+                    "id": "labelsToFields",
+                    "options": {
+                      "mode": "columns",
+                      "valueLabel": "state"
+                    }
+                  }
+                },
+                {
+                  "kind": "transpose",
+                  "spec": {
+                    "id": "transpose",
+                    "options": {}
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Breaks the NetApp LUNs into three categories based on whether each LUN is mapped to a host and whether it has served any I/O over the selected time range.\n\nMapped & Active - Count: number of LUNs mapped to a host that have served I/O over the selected range.\n\nMapped & Active - Consumed Capacity: capacity currently storing data across the active LUNs.\n\nMapped & Inactive - Count: number of LUNs mapped to a host but idle over the range.\n\nMapped & Inactive - Consumed Capacity: space that is exposed to a host but not being used. This often a sign of stale or forgotten volumes still holding data.\n\nUnmapped - Count: number of LUNs that exist but are not mapped to any host.\nUnmapped - Consumed Capacity: space consumed on the array that no host can reach. Possibly a strong candidate for reclamation.",
+          "id": 138,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "decimals": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "1"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Count"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "LUN"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max"
+                      },
+                      {
+                        "id": "fieldMinMax",
+                        "value": true
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "2"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Consumed Capacity"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 1
+                      },
+                      {
+                        "id": "fieldMinMax",
+                        "value": true
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Field"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "LUN State"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-139": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "# Total consumed capacity of all volumes\r\nsum(storage_usage_bytes{host_name=~\"$host_name\", netapp_storage_type=\"lun\", storage_provisioning_state=\"used\"})",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "# Total capacity of unmapped and inactive volumes\r\nsum(\r\n  storage_usage_bytes{\r\n    host_name=~\"$host_name\",\r\n    netapp_storage_type=\"lun\",\r\n    storage_consumer_state=\"unmapped\",\r\n    storage_provisioning_state=\"used\"\r\n  }\r\n  or\r\n  (\r\n    (\r\n      storage_usage_bytes{\r\n        host_name=~\"$host_name\",\r\n        netapp_storage_type=\"lun\",\r\n        storage_provisioning_state=\"used\"\r\n      }\r\n      unless on (host_name, id)\r\n      storage_usage_bytes{\r\n        host_name=~\"$host_name\",\r\n        storage_type=\"volume\",\r\n        storage_consumer_state=\"unmapped\",\r\n        storage_provisioning_state=\"used\"\r\n      }\r\n    )\r\n    and on (host_name, id)\r\n    (\r\n      sum by (host_name, id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            netapp_storage_type=\"lun\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) <= 0.001\r\n    )\r\n  )\r\n) or vector(0)",
+                        "instant": true,
+                        "legendFormat": "Reclaimable  Capacity (Inactive or Unmapped)",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "# Failed Capacity\r\nsum(\r\n  storage_usage_bytes{\r\n    host_name=~\"$host_name\",\r\n    netapp_storage_type=\"lun\",\r\n    storage_consumer_state=\"mapped\",\r\n    storage_provisioning_state=\"used\"\r\n  }\r\n  and on (host_name, id)\r\n  storage_status{\r\n    host_name=~\"$host_name\",\r\n    netapp_storage_type=\"lun\",\r\n    state=~\"failed\"\r\n  } > 0\r\n) or vector(0)",
+                        "instant": true,
+                        "legendFormat": "Failed LUN Capacity",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "__expr__",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expression": "$A - $B - $C",
+                        "type": "math"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Active Capacity"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Breaks down the total consumed LUN capacity into categories that indicate how much space could potentially be recovered.\n\nReclaimable Capacity (Inactive or Unmapped): consumed capacity of LUNs that are either unmapped, or mapped but idle over the selected time range.\n\nFailed LUN Capacity: consumed capacity of LUNs that are mapped to a host but report a failed state.\n\nActive Capacity: consumed capacity of LUNs that are mapped to a host and actively serving I/O.",
+          "id": 139,
+          "links": [],
+          "title": "Reclaimable Consumed Capacity",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  "decimals": 1,
+                  "unit": "bytes"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Reclaimable  Capacity (Inactive or Unmapped)"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "#c8c8c8",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Active Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Failed Volumes Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "displayLabels": [
+                  "name"
+                ],
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true,
+                  "values": [
+                    "percent",
+                    "value"
+                  ]
+                },
+                "pieType": "pie",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": true
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-140": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(storage_limit_bytes{host_name=\"$host_name\", netapp_storage_type=\"volume\"})",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Total number of NetApp volumes discovered on the storage system.",
+          "id": 140,
+          "links": [],
+          "title": "Volumes",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "purple",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-141": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(storage_usage_bytes{host_name=~\"$host_name\", netapp_storage_type=\"volume\", storage_provisioning_state=\"used\"})",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Sum of the capacity currently storing data across all NetApp volumes on the storage system.",
+          "id": 141,
+          "links": [],
+          "title": "Total Consumed Capacity",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "purple",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-142": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count by (state) (\r\n  label_replace(\r\n    (\r\n      sum by (id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            netapp_storage_type=\"volume\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) > 0.001\r\n    ),\r\n    \"state\", \"Active\", \"\", \"\"\r\n  )\r\n)\r\nor\r\nlabel_replace(vector(0), \"state\", \"Active\", \"__name__\", \".*\")",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Active Volumes Count"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (state) (\r\n  label_replace(\r\n    storage_usage_bytes{\r\n      host_name=~\"$host_name\",\r\n      netapp_storage_type=\"volume\",\r\n      storage_provisioning_state=\"used\"\r\n    }\r\n    and on (host_name, id)\r\n    (\r\n      sum by (host_name, id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            netapp_storage_type=\"volume\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) > 0.001\r\n    ),\r\n    \"state\", \"Active\", \"\", \"\"\r\n  )\r\n)",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Active Consumed Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count by (state) (\r\n  label_replace(\r\n    (\r\n      sum by (id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            netapp_storage_type=\"volume\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) <= 0.001\r\n    ),\r\n    \"state\", \"Inactive\", \"\", \"\"\r\n  )\r\n)\r\nor\r\nlabel_replace(vector(0), \"state\", \"Inactive\", \"__name__\", \".*\")",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Inactive Count"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (state) (\r\n  label_replace(\r\n    storage_usage_bytes{\r\n      host_name=~\"$host_name\",\r\n      netapp_storage_type=\"volume\",\r\n      storage_provisioning_state=\"used\"\r\n    }\r\n    and on (host_name, id)\r\n    (\r\n      sum by (host_name, id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            netapp_storage_type=\"volume\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) <= 0.001\r\n    ),\r\n    \"state\", \"Inactive\", \"\", \"\"\r\n  )\r\n)",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Inactive Consumed Capacity"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "joinByLabels",
+                  "spec": {
+                    "id": "joinByLabels",
+                    "options": {
+                      "value": "state"
+                    }
+                  }
+                },
+                {
+                  "kind": "labelsToFields",
+                  "spec": {
+                    "id": "labelsToFields",
+                    "options": {
+                      "mode": "columns",
+                      "valueLabel": "state"
+                    }
+                  }
+                },
+                {
+                  "kind": "transpose",
+                  "spec": {
+                    "id": "transpose",
+                    "options": {}
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Active Count: number of volumes that served I/O over the selected time range.\n\nActive Consumed Capacity: total capacity currently stored across active volumes.\n\nInactive Count: number of volumes that served no measurable I/O over the selected time range.\n\nInactive Consumed Capacity: total capacity currently stored across inactive volumes. ",
+          "id": 142,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "decimals": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "1"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Count"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "volumes"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max"
+                      },
+                      {
+                        "id": "fieldMinMax",
+                        "value": true
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "2"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Consumed Capacity"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 1
+                      },
+                      {
+                        "id": "fieldMinMax",
+                        "value": true
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Field"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Volume State"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-143": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_limit_bytes{host_name=\"$host_name\", netapp_storage_type=\"volume\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Visible Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_usage_bytes{host_name=\"$host_name\", netapp_storage_type=\"volume\", storage_provisioning_state=\"used\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Consumed Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_usage_bytes{host_name=\"$host_name\", netapp_storage_type=\"volume\", storage_provisioning_state=\"free\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Available Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_status{host_name=~\"$host_name\", netapp_storage_type=\"volume\", state=~\"ok|degraded|failed\"} > 0",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "State"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (id) (rate(storage_operations_total{host_name=~\"$host_name\", netapp_storage_type=\"volume\", storage_io_direction=~\"read|write\"}[$__range]))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Operations Rate"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (id) (rate(storage_io_bytes_total{host_name=~\"$host_name\", netapp_storage_type=\"volume\", storage_io_direction=~\"read|write\"}[$__range]))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Transfer Rate"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "storage_usage_bytes{host_name=\"$host_name\", netapp_storage_type=\"volume\", storage_provisioning_state=\"used\"} ",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Trend"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (id) (rate(storage_operations_total{host_name=~\"$host_name\", netapp_storage_type=\"volume\", storage_io_direction=~\"read|write\"}[5m]))",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Operations Rate Trend"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "timeSeriesTable",
+                  "spec": {
+                    "id": "timeSeriesTable",
+                    "options": {
+                      "Operations Rate Trend": {
+                        "timeField": "Time"
+                      },
+                      "Oprations Rate Trend": {
+                        "timeField": "Time"
+                      },
+                      "Trend": {
+                        "timeField": "Time"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "id",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "disabled": true,
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "id",
+                          "name 1",
+                          "storage_volume_type 1",
+                          "Value #Visible Capacity",
+                          "Value #Consumed Capacity",
+                          "Value #Available Capacity",
+                          "state"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Status",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "state"
+                        ],
+                        "reducer": "last"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Type",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "storage_volume_type 1",
+                          "storage_volume_type 2",
+                          "storage_volume_type 3"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Mapping State",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "storage_consumer_state 1",
+                          "storage_consumer_state 2",
+                          "storage_consumer_state 3"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "NAA ID",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "storage_consumer_naa_id 1",
+                          "storage_consumer_naa_id 2",
+                          "storage_consumer_naa_id 3"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Name",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "name 1",
+                          "name 3",
+                          "name 2"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Host",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "storage_consumer_name 1",
+                          "storage_consumer_name 2",
+                          "storage_consumer_name 4",
+                          "storage_consumer_name 3"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "ConsumedCapacityPercentage",
+                      "binary": {
+                        "left": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value #Consumed Capacity"
+                          }
+                        },
+                        "operator": "/",
+                        "right": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value #Visible Capacity"
+                          }
+                        }
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "reducer": "sum"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "NAA ID": false,
+                        "Status": false,
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Time 5": true,
+                        "Time 6": true,
+                        "Time 7": true,
+                        "Value #A": false,
+                        "Value #State": true,
+                        "Value #Status": true,
+                        "Value #Transfer Rate": false,
+                        "__name__": true,
+                        "__name__ 1": true,
+                        "__name__ 2": true,
+                        "__name__ 3": true,
+                        "__name__ 4": true,
+                        "__name__ 5": true,
+                        "agent_host_name": true,
+                        "agent_host_name 1": true,
+                        "agent_host_name 2": true,
+                        "agent_host_name 3": true,
+                        "agent_host_name 4": true,
+                        "agent_host_name 5": true,
+                        "connector_id": true,
+                        "connector_id 1": true,
+                        "connector_id 2": true,
+                        "connector_id 3": true,
+                        "connector_id 4": true,
+                        "connector_id 5": true,
+                        "device_id": true,
+                        "entityName 1": true,
+                        "entityName 2": true,
+                        "entityName 3": true,
+                        "entityName 4": true,
+                        "entityName 5": true,
+                        "entityTypeId 1": true,
+                        "entityTypeId 2": true,
+                        "entityTypeId 3": true,
+                        "entityTypeId 5": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_name 3": true,
+                        "host_name 4": true,
+                        "host_name 5": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "host_type 3": true,
+                        "host_type 4": true,
+                        "host_type 5": true,
+                        "hw_parent_id 1": true,
+                        "hw_parent_id 2": true,
+                        "hw_parent_id 3": true,
+                        "hw_parent_type 1": true,
+                        "hw_parent_type 2": true,
+                        "hw_parent_type 3": true,
+                        "id": true,
+                        "id 1": true,
+                        "instanceName 1": true,
+                        "instanceName 2": true,
+                        "instanceName 3": true,
+                        "instanceName 4": true,
+                        "instanceName 5": true,
+                        "name 1": true,
+                        "name 2": true,
+                        "name 3": true,
+                        "name 4": true,
+                        "name 5": true,
+                        "netapp_storage_type": true,
+                        "netapp_storage_type 1": true,
+                        "netapp_storage_type 2": true,
+                        "netapp_storage_type 3": true,
+                        "netapp_storage_type 4": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "os_type 3": true,
+                        "os_type 4": true,
+                        "os_type 5": true,
+                        "otel_scope_name 1": true,
+                        "otel_scope_name 2": true,
+                        "otel_scope_name 4": true,
+                        "otel_scope_name 5": true,
+                        "raid_level 1": false,
+                        "raid_level 2": true,
+                        "raid_level 3": true,
+                        "site": true,
+                        "site 1": true,
+                        "site 2": true,
+                        "site 3": true,
+                        "site 4": true,
+                        "site 5": true,
+                        "state": true,
+                        "storage_consumer_naa_id 1": true,
+                        "storage_consumer_naa_id 2": true,
+                        "storage_consumer_naa_id 3": true,
+                        "storage_consumer_naa_id 4": true,
+                        "storage_consumer_naa_id 5": true,
+                        "storage_consumer_name 5": true,
+                        "storage_consumer_state": false,
+                        "storage_consumer_state 1": true,
+                        "storage_consumer_state 2": true,
+                        "storage_consumer_state 3": true,
+                        "storage_consumer_state 4": true,
+                        "storage_consumer_state 5": true,
+                        "storage_parent_id": true,
+                        "storage_parent_id 1": true,
+                        "storage_parent_id 2": true,
+                        "storage_parent_id 3": true,
+                        "storage_parent_id 4": true,
+                        "storage_parent_id 5": true,
+                        "storage_parent_type": true,
+                        "storage_parent_type 1": true,
+                        "storage_parent_type 2": true,
+                        "storage_parent_type 3": true,
+                        "storage_parent_type 4": true,
+                        "storage_parent_type 5": true,
+                        "storage_provisioning_state": true,
+                        "storage_provisioning_state 1": true,
+                        "storage_provisioning_state 2": true,
+                        "storage_system_id": true,
+                        "storage_system_id 1": true,
+                        "storage_system_id 2": true,
+                        "storage_system_id 3": true,
+                        "storage_system_id 4": true,
+                        "storage_type": true,
+                        "storage_type 1": true,
+                        "storage_type 2": true,
+                        "storage_type 3": true,
+                        "storage_type 4": true,
+                        "storage_type 5": true,
+                        "storage_volume_type": true,
+                        "storage_volume_type 1": true,
+                        "storage_volume_type 2": true,
+                        "storage_volume_type 3": true,
+                        "storage_volume_type 4": true,
+                        "storage_volume_type 5": true,
+                        "type 1": true,
+                        "type 2": true,
+                        "type 3": true,
+                        "type 4": true,
+                        "type 5": true,
+                        "usage": true,
+                        "usage 1": true,
+                        "usage 2": true,
+                        "usage 3": true,
+                        "usage 4": true,
+                        "volume_type 2": true,
+                        "volume_type 3": true,
+                        "volume_type 4": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "ConsumedCapacityPercentage": 8,
+                        "Host": 3,
+                        "Mapping State": 2,
+                        "NAA ID": 4,
+                        "Name": 0,
+                        "Status": 12,
+                        "Time 1": 13,
+                        "Time 2": 25,
+                        "Time 3": 38,
+                        "Time 4": 51,
+                        "Time 5": 91,
+                        "Time 6": 92,
+                        "Trend #Operations Rate Trend": 53,
+                        "Trend #Trend": 52,
+                        "Type": 1,
+                        "Value #Available Capacity": 6,
+                        "Value #Consumed Capacity": 7,
+                        "Value #Operations Rate": 9,
+                        "Value #State": 90,
+                        "Value #Transfer Rate": 10,
+                        "Value #Visible Capacity": 5,
+                        "__name__ 1": 14,
+                        "__name__ 2": 26,
+                        "__name__ 3": 39,
+                        "__name__ 4": 72,
+                        "__name__ 5": 93,
+                        "agent_host_name 1": 15,
+                        "agent_host_name 2": 27,
+                        "agent_host_name 3": 40,
+                        "agent_host_name 4": 73,
+                        "agent_host_name 5": 94,
+                        "connector_id 1": 16,
+                        "connector_id 2": 28,
+                        "connector_id 3": 41,
+                        "connector_id 4": 74,
+                        "connector_id 5": 95,
+                        "entityName 1": 59,
+                        "entityName 2": 63,
+                        "entityName 3": 67,
+                        "entityName 4": 75,
+                        "entityName 5": 96,
+                        "entityTypeId 1": 60,
+                        "entityTypeId 2": 64,
+                        "entityTypeId 3": 68,
+                        "entityTypeId 4": 76,
+                        "entityTypeId 5": 97,
+                        "host_name 1": 17,
+                        "host_name 2": 29,
+                        "host_name 3": 42,
+                        "host_name 4": 77,
+                        "host_name 5": 98,
+                        "host_type 1": 18,
+                        "host_type 2": 30,
+                        "host_type 3": 43,
+                        "host_type 4": 78,
+                        "host_type 5": 99,
+                        "id": 11,
+                        "instanceName 1": 61,
+                        "instanceName 2": 65,
+                        "instanceName 3": 69,
+                        "instanceName 4": 79,
+                        "instanceName 5": 100,
+                        "name 1": 19,
+                        "name 2": 31,
+                        "name 3": 44,
+                        "name 4": 80,
+                        "name 5": 101,
+                        "netapp_storage_type 1": 55,
+                        "netapp_storage_type 2": 56,
+                        "netapp_storage_type 3": 58,
+                        "netapp_storage_type 4": 81,
+                        "netapp_storage_type 5": 102,
+                        "os_type 1": 20,
+                        "os_type 2": 32,
+                        "os_type 3": 45,
+                        "os_type 4": 82,
+                        "os_type 5": 103,
+                        "otel_scope_name 1": 62,
+                        "otel_scope_name 2": 66,
+                        "otel_scope_name 3": 70,
+                        "otel_scope_name 4": 83,
+                        "otel_scope_name 5": 104,
+                        "site 1": 21,
+                        "site 2": 33,
+                        "site 3": 46,
+                        "site 4": 84,
+                        "site 5": 105,
+                        "state": 85,
+                        "storage_parent_id 1": 22,
+                        "storage_parent_id 2": 34,
+                        "storage_parent_id 3": 47,
+                        "storage_parent_id 4": 86,
+                        "storage_parent_id 5": 106,
+                        "storage_parent_type 1": 23,
+                        "storage_parent_type 2": 35,
+                        "storage_parent_type 3": 48,
+                        "storage_parent_type 4": 87,
+                        "storage_parent_type 5": 107,
+                        "storage_provisioning_state 1": 36,
+                        "storage_provisioning_state 2": 49,
+                        "storage_provisioning_state 3": 108,
+                        "storage_type 1": 24,
+                        "storage_type 2": 37,
+                        "storage_type 3": 50,
+                        "storage_type 4": 88,
+                        "storage_type 5": 109,
+                        "type 1": 54,
+                        "type 2": 57,
+                        "type 3": 71,
+                        "type 4": 89,
+                        "type 5": 110
+                      },
+                      "renameByName": {
+                        "ConsumedCapacityPercentage": "Consumed %",
+                        "Host": "Host",
+                        "Mapping State": "Mapping State",
+                        "NAA ID": "NAA ID",
+                        "Name": "Volume",
+                        "Status": "",
+                        "Time 1": "",
+                        "Trend #Oprations Rate Trend": "Operations Rate Trend",
+                        "Trend #Trend": "Trend",
+                        "Type": "Type",
+                        "Value #A": "Change",
+                        "Value #Available Capacity": "Available ",
+                        "Value #Consume Capacity % Change": "Change",
+                        "Value #Consumed Capacity": "Consumed ",
+                        "Value #Operations Rate": "Operations",
+                        "Value #Status": "",
+                        "Value #Transfer Rate": "Transfers",
+                        "Value #Visible Capacity": "Visible Capacity",
+                        "Volume": "Name",
+                        "connector_id 5": "",
+                        "host_name 5": "",
+                        "host_type 1": "",
+                        "id": "",
+                        "name": "Volume",
+                        "name 1": "",
+                        "netapp_storage_type 1": "",
+                        "raid_level": "RAID Level",
+                        "raid_level 1": "RAID Level",
+                        "site 3": "",
+                        "site 4": "",
+                        "state": "",
+                        "storage_consumer_naa_id 1": "",
+                        "storage_consumer_name 5": "",
+                        "storage_consumer_state": "Mapping State",
+                        "storage_consumer_state 1": "",
+                        "storage_type 1": "",
+                        "storage_volume_type": "",
+                        "storage_volume_type 1": "",
+                        "type": "Type",
+                        "type 1": "",
+                        "usage 4": "",
+                        "usage 6": "",
+                        "volume_type": "Type",
+                        "volume_type 1": "Type"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Lists every NetApp volume discovered on the storage system.\n\nName: volume name as reported by ONTAP.\n\nVisible Capacity: configured size of the volume in ONTAP.\n\nAvailable: capacity still free within the volume.\n\nConsumed: capacity currently storing data within the volume.\n\nConsumed %: share of the volume's visible capacity currently storing data.\n\nOperations: combined read and write operations per second, averaged over the displayed time range.\n\nTransfers: combined read and write throughput in bytes per second, averaged over the displayed time range.\n\nStatus: operational state of the volume, classified as ok, degraded, or failed based on the underlying ONTAP state.",
+          "id": 143,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false,
+                    "wrapHeaderText": false,
+                    "wrapText": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Visible Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Consumed Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Available Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "thresholds"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "text",
+                              "value": 0
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "degraded": {
+                                "color": "orange",
+                                "index": 1,
+                                "text": "Degraded"
+                              },
+                              "failed": {
+                                "color": "red",
+                                "index": 2,
+                                "text": "Failed"
+                              },
+                              "ok": {
+                                "color": "transparent",
+                                "index": 0,
+                                "text": "OK"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Mapping State"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "mapped": {
+                                "color": "transparent",
+                                "index": 1,
+                                "text": "Mapped"
+                              },
+                              "unmapped": {
+                                "color": "red",
+                                "index": 0,
+                                "text": "Not Mapped"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "noValue"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Volume"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byValue",
+                      "options": {
+                        "op": "gte",
+                        "reducer": "allIsNull",
+                        "value": 0
+                      }
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hideFrom.viz",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Consumed %"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "#EAB839",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.9
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Operations"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "ops"
+                      },
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Transfers"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "binBps"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Volume"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Type"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Mapping State"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Consume Capacity % Change"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": -0.01
+                            },
+                            {
+                              "color": "blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.01
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "hideValue": false,
+                          "type": "sparkline"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Host"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "NAA ID"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend #Operations Rate Trend"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "sparkline"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Operations Rate"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-144": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_limit_bytes{host_name=\"$host_name\", netapp_storage_type=\"lun\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Visible Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_usage_bytes{host_name=\"$host_name\", netapp_storage_type=\"lun\", storage_provisioning_state=\"used\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Consumed Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_usage_bytes{host_name=\"$host_name\", netapp_storage_type=\"lun\", storage_provisioning_state=\"free\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Available Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_status{host_name=~\"$host_name\", netapp_storage_type=\"lun\", state=~\"ok|degraded|failed\"} > 0",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "State"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (id) (rate(storage_operations_total{host_name=~\"$host_name\", netapp_storage_type=\"lun\", storage_io_direction=~\"read|write\"}[$__range]))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Operations Rate"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (id) (rate(storage_io_bytes_total{host_name=~\"$host_name\", netapp_storage_type=\"lun\", storage_io_direction=~\"read|write\"}[$__range]))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Transfer Rate"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "storage_usage_bytes{host_name=\"$host_name\", storage_type=\"volume\", storage_provisioning_state=\"used\"} ",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Trend"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (id) (rate(storage_operations_total{host_name=~\"$host_name\", netapp_storage_type=\"lun\", storage_io_direction=~\"read|write\"}[5m]))",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Operations Rate Trend"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "timeSeriesTable",
+                  "spec": {
+                    "id": "timeSeriesTable",
+                    "options": {
+                      "Operations Rate Trend": {
+                        "timeField": "Time"
+                      },
+                      "Oprations Rate Trend": {
+                        "timeField": "Time"
+                      },
+                      "Trend": {
+                        "timeField": "Time"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "id",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "disabled": true,
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "id",
+                          "name 1",
+                          "storage_volume_type 1",
+                          "Value #Visible Capacity",
+                          "Value #Consumed Capacity",
+                          "Value #Available Capacity",
+                          "state"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Status",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "state"
+                        ],
+                        "reducer": "last"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Type",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "storage_volume_type 1",
+                          "storage_volume_type 2",
+                          "storage_volume_type 3"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Mapping State",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "storage_consumer_state 1",
+                          "storage_consumer_state 2",
+                          "storage_consumer_state 3"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "NAA ID",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "storage_consumer_naa_id 1",
+                          "storage_consumer_naa_id 2",
+                          "storage_consumer_naa_id 3"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Name",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "name 1",
+                          "name 3",
+                          "name 2"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Host",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "storage_consumer_name 1",
+                          "storage_consumer_name 2",
+                          "storage_consumer_name 4",
+                          "storage_consumer_name 3"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "ConsumedCapacityPercentage",
+                      "binary": {
+                        "left": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value #Consumed Capacity"
+                          }
+                        },
+                        "operator": "/",
+                        "right": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value #Visible Capacity"
+                          }
+                        }
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "reducer": "sum"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "NAA ID": false,
+                        "Status": false,
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Time 5": true,
+                        "Time 6": true,
+                        "Time 7": true,
+                        "Value #A": false,
+                        "Value #State": true,
+                        "Value #Status": true,
+                        "Value #Transfer Rate": false,
+                        "__name__": true,
+                        "__name__ 1": true,
+                        "__name__ 2": true,
+                        "__name__ 3": true,
+                        "__name__ 4": true,
+                        "agent_host_name": true,
+                        "agent_host_name 1": true,
+                        "agent_host_name 2": true,
+                        "agent_host_name 3": true,
+                        "agent_host_name 4": true,
+                        "agent_host_name 5": true,
+                        "connector_id": true,
+                        "connector_id 1": true,
+                        "connector_id 2": true,
+                        "connector_id 3": true,
+                        "connector_id 4": true,
+                        "connector_id 5": true,
+                        "device_id": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_name 3": true,
+                        "host_name 4": true,
+                        "host_name 5": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "host_type 3": true,
+                        "host_type 4": true,
+                        "host_type 5": true,
+                        "hw_parent_id 1": true,
+                        "hw_parent_id 2": true,
+                        "hw_parent_id 3": true,
+                        "hw_parent_type 1": true,
+                        "hw_parent_type 2": true,
+                        "hw_parent_type 3": true,
+                        "id": true,
+                        "id 1": true,
+                        "name 1": true,
+                        "name 2": true,
+                        "name 3": true,
+                        "name 4": true,
+                        "name 5": true,
+                        "netapp_storage_type": true,
+                        "netapp_storage_type 1": true,
+                        "netapp_storage_type 2": true,
+                        "netapp_storage_type 3": true,
+                        "netapp_storage_type 4": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "os_type 3": true,
+                        "os_type 4": true,
+                        "os_type 5": true,
+                        "raid_level 1": false,
+                        "raid_level 2": true,
+                        "raid_level 3": true,
+                        "site": true,
+                        "site 1": true,
+                        "site 2": true,
+                        "site 3": true,
+                        "site 4": true,
+                        "site 5": true,
+                        "state": true,
+                        "storage_consumer_naa_id 1": true,
+                        "storage_consumer_naa_id 2": true,
+                        "storage_consumer_naa_id 3": true,
+                        "storage_consumer_naa_id 4": true,
+                        "storage_consumer_naa_id 5": true,
+                        "storage_consumer_name 5": true,
+                        "storage_consumer_state": false,
+                        "storage_consumer_state 1": true,
+                        "storage_consumer_state 2": true,
+                        "storage_consumer_state 3": true,
+                        "storage_consumer_state 4": true,
+                        "storage_consumer_state 5": true,
+                        "storage_parent_id": true,
+                        "storage_parent_id 1": true,
+                        "storage_parent_id 2": true,
+                        "storage_parent_id 3": true,
+                        "storage_parent_id 4": true,
+                        "storage_parent_id 5": true,
+                        "storage_parent_type": true,
+                        "storage_parent_type 1": true,
+                        "storage_parent_type 2": true,
+                        "storage_parent_type 3": true,
+                        "storage_parent_type 4": true,
+                        "storage_parent_type 5": true,
+                        "storage_provisioning_state": true,
+                        "storage_provisioning_state 1": true,
+                        "storage_provisioning_state 2": true,
+                        "storage_system_id": true,
+                        "storage_system_id 1": true,
+                        "storage_system_id 2": true,
+                        "storage_system_id 3": true,
+                        "storage_system_id 4": true,
+                        "storage_type": true,
+                        "storage_type 1": true,
+                        "storage_type 2": true,
+                        "storage_type 3": true,
+                        "storage_type 4": true,
+                        "storage_type 5": true,
+                        "storage_volume_type 1": true,
+                        "storage_volume_type 2": true,
+                        "storage_volume_type 3": true,
+                        "storage_volume_type 4": true,
+                        "storage_volume_type 5": true,
+                        "type 2": true,
+                        "type 3": true,
+                        "usage": true,
+                        "usage 1": true,
+                        "usage 2": true,
+                        "usage 3": true,
+                        "usage 4": true,
+                        "volume_type 2": true,
+                        "volume_type 3": true,
+                        "volume_type 4": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "ConsumedCapacityPercentage": 8,
+                        "Host": 3,
+                        "Mapping State": 2,
+                        "NAA ID": 4,
+                        "Name": 0,
+                        "Status": 12,
+                        "Time 1": 14,
+                        "Time 2": 30,
+                        "Time 3": 47,
+                        "Time 4": 64,
+                        "Time 5": 81,
+                        "Time 6": 82,
+                        "Trend #Operations Rate Trend": 100,
+                        "Trend #Trend": 99,
+                        "Type": 1,
+                        "Value #Available Capacity": 6,
+                        "Value #Consumed Capacity": 7,
+                        "Value #Operations Rate": 9,
+                        "Value #State": 80,
+                        "Value #Transfer Rate": 10,
+                        "Value #Visible Capacity": 5,
+                        "__name__ 1": 15,
+                        "__name__ 2": 31,
+                        "__name__ 3": 48,
+                        "__name__ 4": 65,
+                        "__name__ 5": 97,
+                        "agent_host_name 1": 16,
+                        "agent_host_name 2": 32,
+                        "agent_host_name 3": 49,
+                        "agent_host_name 4": 66,
+                        "agent_host_name 5": 83,
+                        "connector_id 1": 17,
+                        "connector_id 2": 33,
+                        "connector_id 3": 50,
+                        "connector_id 4": 67,
+                        "connector_id 5": 84,
+                        "host_name 1": 18,
+                        "host_name 2": 34,
+                        "host_name 3": 51,
+                        "host_name 4": 68,
+                        "host_name 5": 85,
+                        "host_type 1": 19,
+                        "host_type 2": 35,
+                        "host_type 3": 52,
+                        "host_type 4": 69,
+                        "host_type 5": 86,
+                        "id": 11,
+                        "name 1": 20,
+                        "name 2": 36,
+                        "name 3": 53,
+                        "name 4": 70,
+                        "name 5": 87,
+                        "os_type 1": 21,
+                        "os_type 2": 37,
+                        "os_type 3": 54,
+                        "os_type 4": 71,
+                        "os_type 5": 88,
+                        "site 1": 22,
+                        "site 2": 38,
+                        "site 3": 55,
+                        "site 4": 72,
+                        "site 5": 89,
+                        "state": 13,
+                        "storage_consumer_naa_id 1": 23,
+                        "storage_consumer_naa_id 2": 39,
+                        "storage_consumer_naa_id 3": 56,
+                        "storage_consumer_naa_id 4": 73,
+                        "storage_consumer_naa_id 5": 90,
+                        "storage_consumer_name 1": 29,
+                        "storage_consumer_name 2": 46,
+                        "storage_consumer_name 3": 63,
+                        "storage_consumer_name 4": 79,
+                        "storage_consumer_name 5": 96,
+                        "storage_consumer_state 1": 24,
+                        "storage_consumer_state 2": 40,
+                        "storage_consumer_state 3": 57,
+                        "storage_consumer_state 4": 74,
+                        "storage_consumer_state 5": 91,
+                        "storage_parent_id 1": 25,
+                        "storage_parent_id 2": 41,
+                        "storage_parent_id 3": 58,
+                        "storage_parent_id 4": 75,
+                        "storage_parent_id 5": 92,
+                        "storage_parent_type 1": 26,
+                        "storage_parent_type 2": 42,
+                        "storage_parent_type 3": 59,
+                        "storage_parent_type 4": 76,
+                        "storage_parent_type 5": 93,
+                        "storage_provisioning_state 1": 43,
+                        "storage_provisioning_state 2": 60,
+                        "storage_provisioning_state 3": 98,
+                        "storage_type 1": 27,
+                        "storage_type 2": 44,
+                        "storage_type 3": 61,
+                        "storage_type 4": 77,
+                        "storage_type 5": 94,
+                        "storage_volume_type 1": 28,
+                        "storage_volume_type 2": 45,
+                        "storage_volume_type 3": 62,
+                        "storage_volume_type 4": 78,
+                        "storage_volume_type 5": 95
+                      },
+                      "renameByName": {
+                        "ConsumedCapacityPercentage": "Consumed %",
+                        "Host": "Host",
+                        "Mapping State": "Mapping State",
+                        "NAA ID": "NAA ID",
+                        "Name": "Volume",
+                        "Status": "",
+                        "Time 1": "",
+                        "Trend #Oprations Rate Trend": "Operations Rate Trend",
+                        "Trend #Trend": "Trend",
+                        "Type": "Type",
+                        "Value #A": "Change",
+                        "Value #Available Capacity": "Available ",
+                        "Value #Consume Capacity % Change": "Change",
+                        "Value #Consumed Capacity": "Consumed ",
+                        "Value #Operations Rate": "Operations",
+                        "Value #Status": "",
+                        "Value #Transfer Rate": "Transfers",
+                        "Value #Visible Capacity": "Visible Capacity",
+                        "Volume": "Name",
+                        "connector_id 5": "",
+                        "host_name 5": "",
+                        "host_type 1": "",
+                        "id": "",
+                        "name": "Volume",
+                        "name 1": "",
+                        "netapp_storage_type 1": "",
+                        "raid_level": "RAID Level",
+                        "raid_level 1": "RAID Level",
+                        "site 3": "",
+                        "site 4": "",
+                        "state": "",
+                        "storage_consumer_naa_id 1": "",
+                        "storage_consumer_name 5": "",
+                        "storage_consumer_state": "Mapping State",
+                        "storage_consumer_state 1": "",
+                        "storage_type 1": "",
+                        "storage_volume_type 1": "",
+                        "type": "Type",
+                        "type 1": "Type",
+                        "usage 4": "",
+                        "usage 6": "",
+                        "volume_type": "Type",
+                        "volume_type 1": "Type"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Lists every NetApp LUN discovered on the storage system.\n\nVolume: full path of the LUN in ONTAP.\n\nType: style of the FlexVol hosting the LUN.\n\nMapping State: whether the LUN is currently mapped to a host.\n\nVisible Capacity: configured size of the LUN as reported by ONTAP.\n\nAvailable: capacity still free within the LUN.\n\nConsumed: capacity currently storing data within the LUN.\n\nConsumed %: share of the LUN's visible capacity currently storing data.\n\nOperations: combined read and write operations per second, averaged over the selected time range.\n\nTransfers: combined read and write throughput in bytes per second, averaged over the displayed time range.\n\nStatus: operational state of the LUN, classified as OK, Degraded, or Failed based on the underlying ONTAP state.",
+          "id": 144,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false,
+                    "wrapHeaderText": false,
+                    "wrapText": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Visible Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Consumed Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Available Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "thresholds"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "text",
+                              "value": 0
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "degraded": {
+                                "color": "orange",
+                                "index": 1,
+                                "text": "Degraded"
+                              },
+                              "failed": {
+                                "color": "red",
+                                "index": 2,
+                                "text": "Failed"
+                              },
+                              "ok": {
+                                "color": "transparent",
+                                "index": 0,
+                                "text": "OK"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Mapping State"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "mapped": {
+                                "color": "transparent",
+                                "index": 1,
+                                "text": "Mapped"
+                              },
+                              "unmapped": {
+                                "color": "red",
+                                "index": 0,
+                                "text": "Not Mapped"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "noValue"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Volume"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byValue",
+                      "options": {
+                        "op": "gte",
+                        "reducer": "allIsNull",
+                        "value": 0
+                      }
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hideFrom.viz",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Consumed %"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "#EAB839",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.9
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Operations"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "ops"
+                      },
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Transfers"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "binBps"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Volume"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Type"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Mapping State"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Consume Capacity % Change"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": -0.01
+                            },
+                            {
+                              "color": "blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.01
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "hideValue": false,
+                          "type": "sparkline"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Host"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "NAA ID"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend #Operations Rate Trend"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "sparkline"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Operations Rate"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-148": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 148,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "alertlist",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "alertInstanceLabelFilter": "host_name=$host_name",
+                "alertName": "",
+                "dashboardAlerts": false,
+                "groupBy": [],
+                "groupMode": "default",
+                "maxItems": 20,
+                "showInactiveAlerts": false,
+                "sortOrder": 1,
+                "stateFilter": {
+                  "error": true,
+                  "firing": true,
+                  "noData": false,
+                  "normal": false,
+                  "pending": false,
+                  "recovering": false
+                },
+                "viewMode": "list"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-150": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(ALERTS_FOR_STATE{severity=\"critical\", host_name=~\"$host_name\", alertname=~\"MetricsHub-Storage-.*|MetricsHub-Hardware-.*\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Critical Alerts",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 100
+              },
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 150,
+          "links": [],
+          "title": "Critical",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "max": 10,
+                  "min": 0,
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-151": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(ALERTS_FOR_STATE{severity=\"warning\", host_name=~\"$host_name\", alertname=~\"MetricsHub-Storage-.*|MetricsHub-Hardware-.*\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Warning Alerts",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 100
+              },
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 151,
+          "links": [],
+          "title": "Warning",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "max": 10,
+                  "min": 0,
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-152": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(ALERTS_FOR_STATE{severity=\"info\", host_name=~\"$host_name\", alertname=~\"MetricsHub-Storage-.*|MetricsHub-Hardware-.*\"})",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Warning Alerts",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 100
+              },
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 152,
+          "links": [],
+          "title": "Info",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "max": 10,
+                  "min": 0,
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "super-light-blue",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-154": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "max(hw_host_ambient_temperature_celsius{host_name=~\"$host_name\"})",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "Ambient Temperature",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": [
+                {
+                  "kind": "reduce",
+                  "spec": {
+                    "id": "reduce",
+                    "options": {
+                      "reducers": []
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The current estimated internal temperature of the storage system.",
+          "id": 154,
+          "links": [],
+          "title": "Ambient Temperature",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-BlYlRd"
+                  },
+                  "decimals": 1,
+                  "links": [
+                    {
+                      "title": "",
+                      "url": "/d/PwSWpSN7k/device-temperature?orgId=1&${host_name:queryparam}&${site:queryparam}"
+                    }
+                  ],
+                  "max": 60,
+                  "min": 15,
+                  "noValue": "No sensors",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "celsius"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-155": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "hw_host_heating_margin_celsius{host_name=~\"$host_name\"}",
+                        "format": "time_series",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "Heating Margin",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "The number of degrees Celsius (°C) remaining before the temperature reaches the closest warning temperature threshold of the host.\n\nA value of 0 indicates a critical temperature.",
+          "id": 155,
+          "links": [],
+          "title": "Heating Margin",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "links": [
+                    {
+                      "title": "More information about temperature sensors",
+                      "url": "/d/PwSWpSN7k/device-temperature?orgId=1&${host_name:queryparam}&${site:queryparam}"
+                    }
+                  ],
+                  "max": 20,
+                  "min": 0,
+                  "noValue": "N/A",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 5
+                      },
+                      {
+                        "color": "green",
+                        "value": 10
+                      }
+                    ]
+                  },
+                  "unit": "celsius"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-156": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  rate(storage_operations_total{host_name=\"$host_name\", storage_type=\"storage_system\", storage_io_direction=\"read\"}[$__range]) \r\n/ ignoring(storage_io_direction)\r\n  sum without(storage_io_direction) (\r\n    rate(storage_operations_total{host_name=\"$host_name\", storage_type=\"storage_system\"}[$__range])\r\n  )\r\n) unless sum(rate(storage_operations_total{host_name=\"$host_name\", storage_type=\"storage_system\"}[$__range])) == 0",
+                        "instant": true,
+                        "legendFormat": "Read",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Read"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  rate(storage_operations_total{host_name=\"$host_name\", storage_type=\"storage_system\", storage_io_direction=\"write\"}[$__range]) \r\n/ ignoring(storage_io_direction)\r\n  sum without(storage_io_direction) (\r\n    rate(storage_operations_total{host_name=\"$host_name\", storage_type=\"storage_system\"}[$__range])\r\n  )\r\n) unless sum(rate(storage_operations_total{host_name=\"$host_name\", storage_type=\"storage_system\"}[$__range])) == 0",
+                        "instant": true,
+                        "legendFormat": "Write",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Write"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Share of total I/O operations that are reads versus writes, averaged over the selected time range.\n\nRead: fraction of operations that are reads.\n\nWrite: fraction of operations that are writes.\n\nThe two values sum to 100% when there is activity; fully idle periods show nothing.",
+          "id": 156,
+          "links": [],
+          "title": "Read/Write Ratio",
+          "vizConfig": {
+            "group": "barchart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "shades"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "hidden",
+                    "fillOpacity": 80,
+                    "gradientMode": "scheme",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "decimals": 1,
+                  "noValue": "N/A",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Read"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Write"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "purple",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "barRadius": 0,
+                "barWidth": 0.97,
+                "fullHighlight": false,
+                "groupWidth": 0.7,
+                "legend": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "orientation": "horizontal",
+                "showValue": "always",
+                "stacking": "percent",
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                },
+                "xTickLabelRotation": 0,
+                "xTickLabelSpacing": 0
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-157": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_provisioning_bytes{host_name=\"$host_name\", storage_type=\"storage_system\", storage_provisioning_state=\"subscribed\"}",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_limit_bytes{host_name=\"$host_name\", storage_type=\"storage_system\"}",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "__expr__",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expression": "100 * $A / $B",
+                        "type": "math"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Ratio of subscribed (promised) capacity to the system's usable capacity, expressed as a percentage.\n\nA value above 100% means the system is thin provisioned: more capacity has been promised to hosts than physically exists.",
+          "id": 157,
+          "links": [],
+          "title": "Thin Provisioning Commitment",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 1,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 100
+                      },
+                      {
+                        "color": "red",
+                        "value": 120
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-158": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  storage_usage_bytes{\r\n    host_name=\"$host_name\",\r\n    storage_type=\"storage_system\",\r\n    storage_provisioning_state=\"free\"\r\n  }\r\n  / ignoring(storage_provisioning_state)\r\n  deriv(\r\n    storage_usage_bytes{\r\n      host_name=\"$host_name\",\r\n      storage_type=\"storage_system\",\r\n      storage_provisioning_state=\"used\"\r\n    }[$__range]\r\n  )\r\n) > 0",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Projects how long until the storage system's free capacity is fully consumed, assuming usage keeps growing at the rate observed over the selected time range.",
+          "id": 158,
+          "links": [],
+          "title": "Time Until Saturation",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-RdYlGr"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "from": 157788000,
+                        "result": {
+                          "color": "green",
+                          "index": 0,
+                          "text": "> 5 years"
+                        }
+                      },
+                      "type": "range"
+                    },
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "color": "green",
+                          "index": 1,
+                          "text": "> 5 years"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "max": 157788000,
+                  "min": 0,
+                  "noValue": "Never (decreasing)",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-159": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 159,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<a href=\"https://metricshub.com/\" target=\"_blank\">\n  <div style=\"\n    display: block;\n    margin: 0 auto; \n    \n    background: transparent url(https://metricshub.com/images/logo-darkgrey.svg) no-repeat center center;\n    background-size: contain;\n    \n    width: 100%;   \n    height: 100%;\n    border-radius: 3px;\n  \">\n  </div>\n</a>\n",
+                "mode": "html"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-160": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "min_over_time(timestamp(metricshub_host_configured{host_name=\"$host_name\"})[1y:1d])",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "__auto"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": [
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Collect Started",
+                      "binary": {
+                        "left": "Value",
+                        "operator": "*",
+                        "reducer": "sum",
+                        "right": "1000"
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "include": [
+                          "Last Seen"
+                        ],
+                        "reducer": "last"
+                      },
+                      "replaceFields": false
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "agent_host_name",
+                          "site",
+                          "Collect Started"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Value": true,
+                        "Value #A": true,
+                        "__name__": true,
+                        "agent_host_name": false,
+                        "build_number": true,
+                        "build_number 2": true,
+                        "hc_version 2": true,
+                        "host_id": true,
+                        "host_id 1": true,
+                        "host_id 2": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "project_name": true,
+                        "project_name 1": true,
+                        "project_name 2": true,
+                        "project_version 2": true,
+                        "service_name": true,
+                        "service_name 1": true,
+                        "service_name 2": true,
+                        "site 2": true,
+                        "timestamp": true,
+                        "timestamp 1": true,
+                        "timestamp 2": true
+                      },
+                      "indexByName": {
+                        "Last Seen": 15,
+                        "Time": 6,
+                        "Value": 14,
+                        "agent_host_name": 1,
+                        "build_date": 3,
+                        "build_number": 4,
+                        "hc_version": 5,
+                        "host_id": 7,
+                        "host_name": 8,
+                        "host_type": 9,
+                        "os_type": 10,
+                        "project_name": 11,
+                        "project_version": 2,
+                        "service_name": 12,
+                        "site": 0,
+                        "timestamp": 13
+                      },
+                      "renameByName": {
+                        "Time": "",
+                        "Value": "",
+                        "agent_host_name": "Hostname",
+                        "build_date": "Agent Build Date",
+                        "build_number": "",
+                        "build_number 1": "Agent Build Number",
+                        "hc_version": "Connectors Version",
+                        "hc_version 1": "Connectors Version",
+                        "project_version": "Agent Version",
+                        "project_version 1": "Agent Version",
+                        "site": "Site",
+                        "site 1": "Site",
+                        "timestamp": ""
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Time since MetricsHub started monitoring this system.",
+          "id": 160,
+          "links": [],
+          "title": "Collect Started",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "text",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "dateTimeFromNow"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value * 1000"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Collect Started"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 32
+                },
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-19": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(storage_io_bytes_total{host_name=\"$host_name\", storage_type=\"storage_system\", storage_io_direction=\"read\"}[5m]))",
+                        "instant": false,
+                        "legendFormat": "Read",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Read"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(storage_io_bytes_total{host_name=\"$host_name\", storage_type=\"storage_system\", storage_io_direction=\"write\"}[5m]))",
+                        "instant": false,
+                        "legendFormat": "Write",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Write"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Throughput handled by the storage system, broken down by direction\n\nRead: bytes per second served to hosts.\n\nWrite: bytes per second accepted from hosts.",
+          "id": 19,
+          "links": [],
+          "title": "Transfer Rate",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "axisSoftMin": 0,
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 50,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "stepBefore",
+                    "lineWidth": 2,
+                    "pointSize": 1,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "binBps"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Write"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "purple",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Write Tx"
+                      },
+                      {
+                        "id": "custom.transform"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Read"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Read Tx"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "last",
+                    "min",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-21": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum (rate(storage_operations_total{host_name=\"$host_name\", storage_type=\"storage_system\"}[5m]))",
+                        "instant": false,
+                        "legendFormat": "Total IOPS",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Total"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 250
+              },
+              "transformations": []
+            }
+          },
+          "description": "Total I/O operations per second handled by the storage system.\n\nRead and write operations are summed together.",
+          "id": 21,
+          "links": [],
+          "title": "Operation Rate",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "axisSoftMin": 0,
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "hue",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 2,
+                    "pointSize": 1,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "iops"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Total IOPS"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "super-light-yellow",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "last",
+                    "min",
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-23": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_limit_bytes{host_name=\"$host_name\", storage_type=\"pool\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_provisioning_bytes{host_name=\"$host_name\", storage_type=\"pool\", storage_provisioning_state=\"configured\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Configured"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_provisioning_bytes{host_name=\"$host_name\", storage_type=\"pool\", storage_provisioning_state=\"subscribed\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Subscribed"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_usage_bytes{host_name=\"$host_name\", storage_type=\"pool\", storage_provisioning_state=\"free\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Free"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_usage_bytes{host_name=\"$host_name\", storage_type=\"pool\", storage_provisioning_state=\"used\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Used"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (id) (rate(storage_operations_total{host_name=\"$host_name\", storage_type=\"pool\", storage_io_direction=~\"read|write\"}[5m]))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Operations Rate"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (id) (rate(storage_io_bytes_total{host_name=\"$host_name\", storage_type=\"pool\", storage_io_direction=~\"read|write\"}[5m]))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Transfer Rate"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  storage_usage_bytes{host_name=\"$host_name\", storage_type=\"pool\", storage_provisioning_state=\"used\"} \r\n  / ignoring(storage_provisioning_state) \r\n  storage_limit_bytes{host_name=\"$host_name\", storage_type=\"pool\"}\r\n) \r\n- \r\n(\r\n  storage_usage_bytes{host_name=\"$host_name\", storage_type=\"pool\", storage_provisioning_state=\"used\"} offset $__range\r\n  / ignoring(storage_provisioning_state) \r\n  storage_limit_bytes{host_name=\"$host_name\", storage_type=\"pool\"} offset $__range\r\n  or vector(0)\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Consumed Capacity % Change"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_status{host_name=~\"$host_name\", storage_type=\"pool\", state=~\"ok|degraded|failed\"} > 0",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "State"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_provisioning_bytes{\r\n  host_name=\"$host_name\",\r\n  storage_type=\"pool\",\r\n  storage_provisioning_state=\"subscribed\"\r\n}\r\n/\r\nignoring(storage_provisioning_state)\r\nstorage_provisioning_bytes{\r\n  host_name=\"$host_name\",\r\n  storage_type=\"pool\",\r\n  storage_provisioning_state=\"configured\"\r\n}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Configured Capacity %"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 50
+              },
+              "transformations": [
+                {
+                  "kind": "timeSeriesTable",
+                  "spec": {
+                    "filter": {
+                      "id": "byRefId",
+                      "options": "/^(?:Trend Usage)$/"
+                    },
+                    "id": "timeSeriesTable",
+                    "options": {
+                      "Capacity": {
+                        "timeField": "Time"
+                      },
+                      "Configured": {
+                        "timeField": "Time"
+                      },
+                      "Subscribed": {
+                        "timeField": "Time"
+                      },
+                      "Trend": {
+                        "timeField": "Time"
+                      },
+                      "Trend Usage": {
+                        "timeField": "Time"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "id",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Consumed Capacity Percentage",
+                      "binary": {
+                        "left": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value #Used"
+                          }
+                        },
+                        "operator": "/",
+                        "right": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value #Capacity"
+                          }
+                        }
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "reducer": "sum"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Status",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "state"
+                        ],
+                        "reducer": "last"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Status": true,
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Time 5": true,
+                        "Time 6": true,
+                        "Time 7": true,
+                        "Time 8": true,
+                        "Time 9": true,
+                        "Value #State": true,
+                        "__name__": true,
+                        "__name__ 1": true,
+                        "__name__ 2": true,
+                        "__name__ 3": true,
+                        "__name__ 4": true,
+                        "__name__ 5": true,
+                        "__name__ 6": true,
+                        "__name__ 7": true,
+                        "agent_host_name": true,
+                        "agent_host_name 1": true,
+                        "agent_host_name 2": true,
+                        "agent_host_name 3": true,
+                        "agent_host_name 4": true,
+                        "agent_host_name 5": true,
+                        "agent_host_name 6": true,
+                        "agent_host_name 7": true,
+                        "agent_host_name 8": true,
+                        "connector_id": true,
+                        "connector_id 1": true,
+                        "connector_id 2": true,
+                        "connector_id 3": true,
+                        "connector_id 4": true,
+                        "connector_id 5": true,
+                        "connector_id 6": true,
+                        "connector_id 7": true,
+                        "connector_id 8": true,
+                        "dellemc_powerstore_storage_type 1": true,
+                        "dellemc_powerstore_storage_type 2": true,
+                        "dellemc_powerstore_storage_type 3": true,
+                        "dellemc_powerstore_storage_type 4": true,
+                        "dellemc_powerstore_storage_type 5": true,
+                        "disk_type": true,
+                        "disk_type 1": true,
+                        "disk_type 2": true,
+                        "disk_type 3": true,
+                        "disk_type 4": true,
+                        "disk_type 5": true,
+                        "disk_type 6": true,
+                        "disk_type 7": true,
+                        "disk_type 8": true,
+                        "entityName 1": true,
+                        "entityName 2": true,
+                        "entityName 3": true,
+                        "entityName 4": true,
+                        "entityName 5": true,
+                        "entityName 6": true,
+                        "entityName 7": true,
+                        "entityTypeId 1": true,
+                        "entityTypeId 2": true,
+                        "entityTypeId 3": true,
+                        "entityTypeId 4": true,
+                        "entityTypeId 5": true,
+                        "entityTypeId 6": true,
+                        "entityTypeId 7": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_name 3": true,
+                        "host_name 4": true,
+                        "host_name 5": true,
+                        "host_name 6": true,
+                        "host_name 7": true,
+                        "host_name 8": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "host_type 3": true,
+                        "host_type 4": true,
+                        "host_type 5": true,
+                        "host_type 6": true,
+                        "host_type 7": true,
+                        "host_type 8": true,
+                        "id": true,
+                        "instanceName 1": true,
+                        "instanceName 2": true,
+                        "instanceName 3": true,
+                        "instanceName 4": true,
+                        "instanceName 5": true,
+                        "instanceName 6": true,
+                        "instanceName 7": true,
+                        "name 2": true,
+                        "name 3": true,
+                        "name 4": true,
+                        "name 5": true,
+                        "name 6": true,
+                        "name 7": true,
+                        "name 8": true,
+                        "netapp_storage_type 1": false,
+                        "netapp_storage_type 2": true,
+                        "netapp_storage_type 3": true,
+                        "netapp_storage_type 4": true,
+                        "netapp_storage_type 5": true,
+                        "netapp_storage_type 6": true,
+                        "netapp_storage_type 7": true,
+                        "netapp_storage_type 8": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "os_type 3": true,
+                        "os_type 4": true,
+                        "os_type 5": true,
+                        "os_type 6": true,
+                        "os_type 7": true,
+                        "os_type 8": true,
+                        "otel_scope_name 1": true,
+                        "otel_scope_name 2": true,
+                        "otel_scope_name 3": true,
+                        "otel_scope_name 4": true,
+                        "otel_scope_name 5": true,
+                        "otel_scope_name 6": true,
+                        "otel_scope_name 7": true,
+                        "raid_level": true,
+                        "raid_level 1": true,
+                        "raid_level 2": true,
+                        "raid_level 3": true,
+                        "raid_level 4": true,
+                        "raid_level 5": true,
+                        "raid_level 6": true,
+                        "raid_level 7": true,
+                        "raid_level 8": true,
+                        "site": true,
+                        "site 1": true,
+                        "site 2": true,
+                        "site 3": true,
+                        "site 4": true,
+                        "site 5": true,
+                        "site 6": true,
+                        "site 7": true,
+                        "site 8": true,
+                        "state": true,
+                        "state 1": true,
+                        "state 2": true,
+                        "state 3": true,
+                        "state 4": true,
+                        "state 5": true,
+                        "storage_consumer_state": true,
+                        "storage_parent_id": true,
+                        "storage_parent_id 1": true,
+                        "storage_parent_id 2": true,
+                        "storage_parent_id 3": true,
+                        "storage_parent_id 4": true,
+                        "storage_parent_id 5": true,
+                        "storage_parent_id 6": true,
+                        "storage_parent_id 7": true,
+                        "storage_parent_id 8": true,
+                        "storage_parent_type": true,
+                        "storage_parent_type 1": true,
+                        "storage_parent_type 2": true,
+                        "storage_parent_type 3": true,
+                        "storage_parent_type 4": true,
+                        "storage_parent_type 5": true,
+                        "storage_parent_type 6": true,
+                        "storage_parent_type 7": true,
+                        "storage_parent_type 8": true,
+                        "storage_perent_id 1": true,
+                        "storage_perent_id 2": true,
+                        "storage_perent_id 3": true,
+                        "storage_perent_id 4": true,
+                        "storage_perent_id 5": true,
+                        "storage_perent_type 1": true,
+                        "storage_perent_type 2": true,
+                        "storage_perent_type 3": true,
+                        "storage_perent_type 4": true,
+                        "storage_perent_type 5": true,
+                        "storage_provisioning_state": true,
+                        "storage_provisioning_state 1": true,
+                        "storage_provisioning_state 2": true,
+                        "storage_provisioning_state 3": true,
+                        "storage_provisioning_state 4": true,
+                        "storage_provisioning_state 5": true,
+                        "storage_type": true,
+                        "storage_type 1": true,
+                        "storage_type 2": true,
+                        "storage_type 3": true,
+                        "storage_type 4": true,
+                        "storage_type 5": true,
+                        "storage_type 6": true,
+                        "storage_type 7": true,
+                        "storage_type 8": true,
+                        "storage_volume_type": true,
+                        "tier_id 1": true,
+                        "tier_id 2": true,
+                        "tier_id 3": true,
+                        "tier_id 4": true,
+                        "tier_id 5": true,
+                        "tier_name 1": true,
+                        "tier_name 2": true,
+                        "tier_name 3": true,
+                        "tier_name 4": true,
+                        "tier_name 5": true,
+                        "type 1": true,
+                        "type 2": true,
+                        "type 3": true,
+                        "type 4": true,
+                        "type 5": true,
+                        "type 6": true,
+                        "type 7": true,
+                        "type 8": true,
+                        "usage": true,
+                        "usage 1": true,
+                        "usage 2": true,
+                        "usage 3": true,
+                        "usage 4": true,
+                        "usage 5": true,
+                        "usage 6": true,
+                        "usage 7": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Consumed Capacity Percentage": 10,
+                        "Status": 15,
+                        "Time 1": 16,
+                        "Time 2": 27,
+                        "Time 3": 41,
+                        "Time 4": 55,
+                        "Time 5": 80,
+                        "Time 6": 83,
+                        "Time 7": 133,
+                        "Time 8": 134,
+                        "Time 9": 139,
+                        "Value #Capacity": 6,
+                        "Value #Configured": 11,
+                        "Value #Configured Capacity %": 12,
+                        "Value #Free": 7,
+                        "Value #Operations Rate": 13,
+                        "Value #State": 138,
+                        "Value #Subscribed": 8,
+                        "Value #Transfer Rate": 14,
+                        "Value #Used": 9,
+                        "__name__ 1": 17,
+                        "__name__ 2": 28,
+                        "__name__ 3": 42,
+                        "__name__ 4": 56,
+                        "__name__ 5": 81,
+                        "__name__ 6": 135,
+                        "agent_host_name 1": 18,
+                        "agent_host_name 2": 29,
+                        "agent_host_name 3": 43,
+                        "agent_host_name 4": 57,
+                        "agent_host_name 5": 69,
+                        "agent_host_name 6": 84,
+                        "agent_host_name 7": 140,
+                        "connector_id 1": 19,
+                        "connector_id 2": 30,
+                        "connector_id 3": 44,
+                        "connector_id 4": 58,
+                        "connector_id 5": 70,
+                        "connector_id 6": 85,
+                        "connector_id 7": 141,
+                        "disk_type 1": 4,
+                        "disk_type 2": 95,
+                        "disk_type 3": 97,
+                        "disk_type 4": 99,
+                        "disk_type 5": 101,
+                        "disk_type 6": 103,
+                        "disk_type 7": 142,
+                        "entityName 1": 105,
+                        "entityName 2": 109,
+                        "entityName 3": 113,
+                        "entityName 4": 117,
+                        "entityName 5": 121,
+                        "entityName 6": 125,
+                        "entityName 7": 143,
+                        "entityTypeId 1": 106,
+                        "entityTypeId 2": 110,
+                        "entityTypeId 3": 114,
+                        "entityTypeId 4": 118,
+                        "entityTypeId 5": 122,
+                        "entityTypeId 6": 126,
+                        "entityTypeId 7": 144,
+                        "host_name 1": 20,
+                        "host_name 2": 31,
+                        "host_name 3": 45,
+                        "host_name 4": 59,
+                        "host_name 5": 71,
+                        "host_name 6": 86,
+                        "host_name 7": 145,
+                        "host_type 1": 21,
+                        "host_type 2": 32,
+                        "host_type 3": 46,
+                        "host_type 4": 60,
+                        "host_type 5": 72,
+                        "host_type 6": 87,
+                        "host_type 7": 146,
+                        "id": 0,
+                        "instanceName 1": 107,
+                        "instanceName 2": 111,
+                        "instanceName 3": 115,
+                        "instanceName 4": 119,
+                        "instanceName 5": 123,
+                        "instanceName 6": 127,
+                        "instanceName 7": 147,
+                        "name 1": 1,
+                        "name 2": 33,
+                        "name 3": 47,
+                        "name 4": 61,
+                        "name 5": 73,
+                        "name 6": 88,
+                        "name 7": 148,
+                        "netapp_storage_type 1": 2,
+                        "netapp_storage_type 2": 129,
+                        "netapp_storage_type 3": 130,
+                        "netapp_storage_type 4": 131,
+                        "netapp_storage_type 5": 132,
+                        "netapp_storage_type 6": 136,
+                        "netapp_storage_type 7": 149,
+                        "os_type 1": 22,
+                        "os_type 2": 34,
+                        "os_type 3": 48,
+                        "os_type 4": 62,
+                        "os_type 5": 74,
+                        "os_type 6": 89,
+                        "os_type 7": 150,
+                        "otel_scope_name 1": 108,
+                        "otel_scope_name 2": 112,
+                        "otel_scope_name 3": 116,
+                        "otel_scope_name 4": 120,
+                        "otel_scope_name 5": 124,
+                        "otel_scope_name 6": 128,
+                        "otel_scope_name 7": 151,
+                        "raid_level 1": 5,
+                        "raid_level 2": 96,
+                        "raid_level 3": 98,
+                        "raid_level 4": 100,
+                        "raid_level 5": 102,
+                        "raid_level 6": 104,
+                        "raid_level 7": 152,
+                        "site 1": 23,
+                        "site 2": 35,
+                        "site 3": 49,
+                        "site 4": 63,
+                        "site 5": 75,
+                        "site 6": 90,
+                        "site 7": 153,
+                        "state": 137,
+                        "storage_parent_id 1": 24,
+                        "storage_parent_id 2": 36,
+                        "storage_parent_id 3": 50,
+                        "storage_parent_id 4": 64,
+                        "storage_parent_id 5": 76,
+                        "storage_parent_id 6": 91,
+                        "storage_parent_id 7": 154,
+                        "storage_parent_type 1": 25,
+                        "storage_parent_type 2": 37,
+                        "storage_parent_type 3": 51,
+                        "storage_parent_type 4": 65,
+                        "storage_parent_type 5": 77,
+                        "storage_parent_type 6": 92,
+                        "storage_parent_type 7": 155,
+                        "storage_provisioning_state 1": 40,
+                        "storage_provisioning_state 2": 52,
+                        "storage_provisioning_state 3": 66,
+                        "storage_provisioning_state 4": 82,
+                        "storage_type 1": 26,
+                        "storage_type 2": 38,
+                        "storage_type 3": 53,
+                        "storage_type 4": 67,
+                        "storage_type 5": 78,
+                        "storage_type 6": 93,
+                        "storage_type 7": 156,
+                        "type 1": 3,
+                        "type 2": 39,
+                        "type 3": 54,
+                        "type 4": 68,
+                        "type 5": 79,
+                        "type 6": 94,
+                        "type 7": 157
+                      },
+                      "orderByMode": "manual",
+                      "renameByName": {
+                        "Consumed Capacity Percentage": "Consumed %",
+                        "State": "",
+                        "Status": "Status",
+                        "Time 4": "",
+                        "Trend #Trend": "Trend",
+                        "Trend #Trend Usage": "Trend",
+                        "Value": "Size",
+                        "Value #Capacity": "Capacity",
+                        "Value #Configured": "Configured",
+                        "Value #Configured Capacity": "Subscribed Capacity",
+                        "Value #Configured Capacity %": "Configured %",
+                        "Value #Consumed Capacity % Change": "Change",
+                        "Value #Free": "Available",
+                        "Value #Operations Rate": "Operations ",
+                        "Value #Oversubscription %": "Oversubscription %",
+                        "Value #Pool Size": "Capacity",
+                        "Value #State": "",
+                        "Value #Status": "Status",
+                        "Value #Subscribed": "Subscribed ",
+                        "Value #Subscribed Capacity": "Subscribed Capacity",
+                        "Value #Transfer Rate": "Transfers",
+                        "Value #Used": "Consumed",
+                        "__name__ 7": "",
+                        "disk_type": "Pool Disk Type",
+                        "disk_type 1": "Pool Disk Type",
+                        "disk_type 2": "",
+                        "id": "",
+                        "name": "Name",
+                        "name 1": "Name",
+                        "netapp_storage_type 1": "Type",
+                        "netapp_storage_type 2": "",
+                        "otel_scope_name 3": "",
+                        "raid_level": "RAID Level",
+                        "raid_level 1": "RAID Level",
+                        "raid_level 5": "",
+                        "storage_perent_id 1": "",
+                        "storage_type": "",
+                        "storage_type 8": "",
+                        "type": "Pool Type",
+                        "type 1": "Array Pool Type",
+                        "usage": "Usage",
+                        "usage 1": "",
+                        "usage 2": ""
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Capacity: total usable capacity of the pool available for data.\n\nAvailable: capacity currently free in the pool.\n\nConsumed: capacity in the pool currently storing data.\n\nSubscribed: capacity committed to hosts through volumes mapped to initiators. Not all subscribed capacity is necessarily stored yet. The gap between Subscribed and Consumed reflects thin-provisioning commitment that hosts haven't written to.\n\nConfigured: total virtual capacity of all volumes carved from the pool, whether mapped to hosts or not. The gap between Configured and Subscribed reflects capacity that has been provisioned but not yet exposed to hosts.",
+          "id": 23,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "decimals": 2,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Configured"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Subscribed"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Free"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Used"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Operations "
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "iops"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "fieldMinMax",
+                        "value": true
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "super-light-yellow",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Transfers"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "binBps"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "fieldMinMax",
+                        "value": true
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "name"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Consumed %"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "#EAB839",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.9
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "NaN": {
+                                "index": 0,
+                                "text": "-"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Consumed Capacity % Change"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "thresholds"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": -0.01
+                            },
+                            {
+                              "color": "blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.01
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "NaN": {
+                                "index": 0,
+                                "text": "-"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend #Trend Usage"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "hideValue": true,
+                          "type": "sparkline"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "NaN": {
+                                "index": 0,
+                                "text": "-"
+                              },
+                              "degraded": {
+                                "color": "orange",
+                                "index": 2,
+                                "text": "Degraded"
+                              },
+                              "failed": {
+                                "color": "red",
+                                "index": 3,
+                                "text": "Failed"
+                              },
+                              "ok": {
+                                "color": "transparent",
+                                "index": 1,
+                                "text": "OK"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Configured %"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Consumed %"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-24": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "metricshub_connector_status{host_name=~\"$host_name\", applies_to_os=\"storage\"}",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "filterByValue",
+                  "spec": {
+                    "id": "filterByValue",
+                    "options": {
+                      "filters": [
+                        {
+                          "config": {
+                            "id": "lower",
+                            "options": {
+                              "value": 1
+                            }
+                          },
+                          "fieldName": "Value"
+                        }
+                      ],
+                      "match": "any",
+                      "type": "exclude"
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "description",
+                          "name",
+                          "state"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Value": true,
+                        "__name__": true,
+                        "agent_host_name": true,
+                        "applies_to_os": true,
+                        "compiled_file_name": true,
+                        "connector_id": true,
+                        "description": false,
+                        "device_id": true,
+                        "display_name": true,
+                        "fqdn": true,
+                        "host_id": true,
+                        "host_name": true,
+                        "host_type": true,
+                        "id": true,
+                        "instance": true,
+                        "job": true,
+                        "os_type": true,
+                        "parent": true,
+                        "site": true,
+                        "zone": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Value": 4,
+                        "applies_to_os": 11,
+                        "connector_id": 12,
+                        "description": 1,
+                        "host_id": 7,
+                        "host_name": 8,
+                        "host_type": 9,
+                        "id": 3,
+                        "name": 0,
+                        "os_type": 10,
+                        "parent": 5,
+                        "site": 6,
+                        "state": 2
+                      },
+                      "renameByName": {
+                        "Status": "Status",
+                        "Time": "",
+                        "Value": "",
+                        "__name__": "",
+                        "compiled_file_name": "",
+                        "description": "Description",
+                        "id": "",
+                        "identifying_information": "More Information",
+                        "label": "Name",
+                        "model": "Model",
+                        "name": "Connector Name",
+                        "serial_number": "Serial Number",
+                        "site": "",
+                        "state": "Status",
+                        "type": "Type",
+                        "vendor": "Vendor"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Name and status of the MetricsHub connector(s) currently monitoring the storage system.",
+          "id": 24,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "degraded": {
+                                "color": "orange",
+                                "index": 1,
+                                "text": "Degraded"
+                              },
+                              "failed": {
+                                "color": "red",
+                                "index": 2,
+                                "text": "Failed"
+                              },
+                              "ok": {
+                                "color": "light-green",
+                                "index": 0,
+                                "text": "OK"
+                              },
+                              "present": {
+                                "color": "red",
+                                "index": 3,
+                                "text": "Missing"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 125
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Connector Name"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-26": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "last_over_time(timestamp(metricshub_agent_info{agent_host_name=\"$agent\"})[6h:])",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "1h"
+              },
+              "transformations": [
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Last Seen",
+                      "binary": {
+                        "left": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value"
+                          }
+                        },
+                        "operator": "*",
+                        "right": {
+                          "fixed": "1000"
+                        }
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "include": [
+                          "Last Seen"
+                        ],
+                        "reducer": "last"
+                      },
+                      "replaceFields": false
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "agent_host_name",
+                          "build_date",
+                          "build_number",
+                          "version",
+                          "Last Seen",
+                          "cc_version"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Value": true,
+                        "Value #A": true,
+                        "__name__": true,
+                        "agent_host_name": false,
+                        "build_number": false,
+                        "build_number 2": true,
+                        "hc_version 2": true,
+                        "host_id": true,
+                        "host_id 1": true,
+                        "host_id 2": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "job": true,
+                        "name": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "otel_version": true,
+                        "project_name": true,
+                        "project_name 1": true,
+                        "project_name 2": true,
+                        "project_version": true,
+                        "project_version 2": true,
+                        "service_name": true,
+                        "service_name 1": true,
+                        "service_name 2": true,
+                        "site": true,
+                        "site 2": true,
+                        "timestamp": true,
+                        "timestamp 1": true,
+                        "timestamp 2": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Last Seen": 5,
+                        "agent_host_name": 0,
+                        "build_date": 2,
+                        "build_number": 3,
+                        "cc_version": 4,
+                        "version": 1
+                      },
+                      "renameByName": {
+                        "Time": "",
+                        "Value": "",
+                        "agent_host_name": "Hostname",
+                        "build_date": "Build Date",
+                        "build_number": "Build Number",
+                        "build_number 1": "Agent Build Number",
+                        "cc_version": "Connectors Version",
+                        "hc_version": "Connectors Version",
+                        "hc_version 1": "Connectors Version",
+                        "project_version": "",
+                        "project_version 1": "Agent Version",
+                        "site": "",
+                        "site 1": "Site",
+                        "timestamp": "",
+                        "version": "Version"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 26,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Last Seen"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dateTimeFromNow"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Hostname"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Site"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-28": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_limit_bytes{host_name=\"$host_name\", storage_type=\"volume\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Visible Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_usage_bytes{host_name=\"$host_name\", storage_type=\"volume\", storage_provisioning_state=\"used\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Consumed Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_usage_bytes{host_name=\"$host_name\", storage_type=\"volume\", storage_provisioning_state=\"free\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Available Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_status{host_name=~\"$host_name\", storage_type=\"volume\", state=~\"ok|degraded|failed\"} > 0",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "State"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (id) (rate(storage_operations_total{host_name=~\"$host_name\", storage_type=\"volume\", storage_io_direction=~\"read|write\"}[$__range]))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Operations Rate"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (id) (rate(storage_io_bytes_total{host_name=~\"$host_name\", storage_type=\"volume\", storage_io_direction=~\"read|write\"}[$__range]))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Transfer Rate"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "storage_usage_bytes{host_name=\"$host_name\", storage_type=\"volume\", storage_provisioning_state=\"used\"} ",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Trend"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (id) (rate(storage_operations_total{host_name=~\"$host_name\", storage_type=\"volume\", storage_io_direction=~\"read|write\"}[5m]))",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Operations Rate Trend"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "timeSeriesTable",
+                  "spec": {
+                    "id": "timeSeriesTable",
+                    "options": {
+                      "Operations Rate Trend": {
+                        "timeField": "Time"
+                      },
+                      "Oprations Rate Trend": {
+                        "timeField": "Time"
+                      },
+                      "Trend": {
+                        "timeField": "Time"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "id",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "disabled": true,
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "id",
+                          "name 1",
+                          "storage_volume_type 1",
+                          "Value #Visible Capacity",
+                          "Value #Consumed Capacity",
+                          "Value #Available Capacity",
+                          "state"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Status",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "state"
+                        ],
+                        "reducer": "last"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Type",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "storage_volume_type 1",
+                          "storage_volume_type 2",
+                          "storage_volume_type 3"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Mapping State",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "storage_consumer_state 1",
+                          "storage_consumer_state 2",
+                          "storage_consumer_state 3"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "NAA ID",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "storage_consumer_naa_id 1",
+                          "storage_consumer_naa_id 2",
+                          "storage_consumer_naa_id 3"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Name",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "name 1",
+                          "name 3",
+                          "name 2"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Host",
+                      "mode": "reduceRow",
+                      "reduce": {
+                        "include": [
+                          "storage_consumer_name 1",
+                          "storage_consumer_name 2",
+                          "storage_consumer_name 4",
+                          "storage_consumer_name 3"
+                        ],
+                        "reducer": "lastNotNull"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "ConsumedCapacityPercentage",
+                      "binary": {
+                        "left": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value #Consumed Capacity"
+                          }
+                        },
+                        "operator": "/",
+                        "right": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value #Visible Capacity"
+                          }
+                        }
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "reducer": "sum"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "NAA ID": false,
+                        "Status": false,
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Time 5": true,
+                        "Time 6": true,
+                        "Time 7": true,
+                        "Value #A": false,
+                        "Value #State": true,
+                        "Value #Status": true,
+                        "Value #Transfer Rate": false,
+                        "__name__": true,
+                        "__name__ 1": true,
+                        "__name__ 2": true,
+                        "__name__ 3": true,
+                        "__name__ 4": true,
+                        "agent_host_name": true,
+                        "agent_host_name 1": true,
+                        "agent_host_name 2": true,
+                        "agent_host_name 3": true,
+                        "agent_host_name 4": true,
+                        "agent_host_name 5": true,
+                        "connector_id": true,
+                        "connector_id 1": true,
+                        "connector_id 2": true,
+                        "connector_id 3": true,
+                        "connector_id 4": true,
+                        "connector_id 5": true,
+                        "device_id": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_name 3": true,
+                        "host_name 4": true,
+                        "host_name 5": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "host_type 3": true,
+                        "host_type 4": true,
+                        "host_type 5": true,
+                        "hw_parent_id 1": true,
+                        "hw_parent_id 2": true,
+                        "hw_parent_id 3": true,
+                        "hw_parent_type 1": true,
+                        "hw_parent_type 2": true,
+                        "hw_parent_type 3": true,
+                        "id": true,
+                        "id 1": true,
+                        "name 1": true,
+                        "name 2": true,
+                        "name 3": true,
+                        "name 4": true,
+                        "name 5": true,
+                        "netapp_storage_type": true,
+                        "netapp_storage_type 1": true,
+                        "netapp_storage_type 2": true,
+                        "netapp_storage_type 3": true,
+                        "netapp_storage_type 4": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "os_type 3": true,
+                        "os_type 4": true,
+                        "os_type 5": true,
+                        "raid_level 1": false,
+                        "raid_level 2": true,
+                        "raid_level 3": true,
+                        "site": true,
+                        "site 1": true,
+                        "site 2": true,
+                        "site 3": true,
+                        "site 4": true,
+                        "site 5": true,
+                        "state": true,
+                        "storage_consumer_naa_id 1": true,
+                        "storage_consumer_naa_id 2": true,
+                        "storage_consumer_naa_id 3": true,
+                        "storage_consumer_naa_id 4": true,
+                        "storage_consumer_naa_id 5": true,
+                        "storage_consumer_name 5": true,
+                        "storage_consumer_state": false,
+                        "storage_consumer_state 1": true,
+                        "storage_consumer_state 2": true,
+                        "storage_consumer_state 3": true,
+                        "storage_consumer_state 4": true,
+                        "storage_consumer_state 5": true,
+                        "storage_parent_id": true,
+                        "storage_parent_id 1": true,
+                        "storage_parent_id 2": true,
+                        "storage_parent_id 3": true,
+                        "storage_parent_id 4": true,
+                        "storage_parent_id 5": true,
+                        "storage_parent_type": true,
+                        "storage_parent_type 1": true,
+                        "storage_parent_type 2": true,
+                        "storage_parent_type 3": true,
+                        "storage_parent_type 4": true,
+                        "storage_parent_type 5": true,
+                        "storage_provisioning_state": true,
+                        "storage_provisioning_state 1": true,
+                        "storage_provisioning_state 2": true,
+                        "storage_system_id": true,
+                        "storage_system_id 1": true,
+                        "storage_system_id 2": true,
+                        "storage_system_id 3": true,
+                        "storage_system_id 4": true,
+                        "storage_type": true,
+                        "storage_type 1": true,
+                        "storage_type 2": true,
+                        "storage_type 3": true,
+                        "storage_type 4": true,
+                        "storage_type 5": true,
+                        "storage_volume_type 1": true,
+                        "storage_volume_type 2": true,
+                        "storage_volume_type 3": true,
+                        "storage_volume_type 4": true,
+                        "storage_volume_type 5": true,
+                        "type 2": true,
+                        "type 3": true,
+                        "usage": true,
+                        "usage 1": true,
+                        "usage 2": true,
+                        "usage 3": true,
+                        "usage 4": true,
+                        "volume_type 2": true,
+                        "volume_type 3": true,
+                        "volume_type 4": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "ConsumedCapacityPercentage": 8,
+                        "Host": 3,
+                        "Mapping State": 2,
+                        "NAA ID": 4,
+                        "Name": 0,
+                        "Status": 12,
+                        "Time 1": 14,
+                        "Time 2": 30,
+                        "Time 3": 47,
+                        "Time 4": 64,
+                        "Time 5": 81,
+                        "Time 6": 82,
+                        "Trend #Operations Rate Trend": 100,
+                        "Trend #Trend": 99,
+                        "Type": 1,
+                        "Value #Available Capacity": 6,
+                        "Value #Consumed Capacity": 7,
+                        "Value #Operations Rate": 9,
+                        "Value #State": 80,
+                        "Value #Transfer Rate": 10,
+                        "Value #Visible Capacity": 5,
+                        "__name__ 1": 15,
+                        "__name__ 2": 31,
+                        "__name__ 3": 48,
+                        "__name__ 4": 65,
+                        "__name__ 5": 97,
+                        "agent_host_name 1": 16,
+                        "agent_host_name 2": 32,
+                        "agent_host_name 3": 49,
+                        "agent_host_name 4": 66,
+                        "agent_host_name 5": 83,
+                        "connector_id 1": 17,
+                        "connector_id 2": 33,
+                        "connector_id 3": 50,
+                        "connector_id 4": 67,
+                        "connector_id 5": 84,
+                        "host_name 1": 18,
+                        "host_name 2": 34,
+                        "host_name 3": 51,
+                        "host_name 4": 68,
+                        "host_name 5": 85,
+                        "host_type 1": 19,
+                        "host_type 2": 35,
+                        "host_type 3": 52,
+                        "host_type 4": 69,
+                        "host_type 5": 86,
+                        "id": 11,
+                        "name 1": 20,
+                        "name 2": 36,
+                        "name 3": 53,
+                        "name 4": 70,
+                        "name 5": 87,
+                        "os_type 1": 21,
+                        "os_type 2": 37,
+                        "os_type 3": 54,
+                        "os_type 4": 71,
+                        "os_type 5": 88,
+                        "site 1": 22,
+                        "site 2": 38,
+                        "site 3": 55,
+                        "site 4": 72,
+                        "site 5": 89,
+                        "state": 13,
+                        "storage_consumer_naa_id 1": 23,
+                        "storage_consumer_naa_id 2": 39,
+                        "storage_consumer_naa_id 3": 56,
+                        "storage_consumer_naa_id 4": 73,
+                        "storage_consumer_naa_id 5": 90,
+                        "storage_consumer_name 1": 29,
+                        "storage_consumer_name 2": 46,
+                        "storage_consumer_name 3": 63,
+                        "storage_consumer_name 4": 79,
+                        "storage_consumer_name 5": 96,
+                        "storage_consumer_state 1": 24,
+                        "storage_consumer_state 2": 40,
+                        "storage_consumer_state 3": 57,
+                        "storage_consumer_state 4": 74,
+                        "storage_consumer_state 5": 91,
+                        "storage_parent_id 1": 25,
+                        "storage_parent_id 2": 41,
+                        "storage_parent_id 3": 58,
+                        "storage_parent_id 4": 75,
+                        "storage_parent_id 5": 92,
+                        "storage_parent_type 1": 26,
+                        "storage_parent_type 2": 42,
+                        "storage_parent_type 3": 59,
+                        "storage_parent_type 4": 76,
+                        "storage_parent_type 5": 93,
+                        "storage_provisioning_state 1": 43,
+                        "storage_provisioning_state 2": 60,
+                        "storage_provisioning_state 3": 98,
+                        "storage_type 1": 27,
+                        "storage_type 2": 44,
+                        "storage_type 3": 61,
+                        "storage_type 4": 77,
+                        "storage_type 5": 94,
+                        "storage_volume_type 1": 28,
+                        "storage_volume_type 2": 45,
+                        "storage_volume_type 3": 62,
+                        "storage_volume_type 4": 78,
+                        "storage_volume_type 5": 95
+                      },
+                      "renameByName": {
+                        "ConsumedCapacityPercentage": "Consumed %",
+                        "Host": "Host",
+                        "Mapping State": "Mapping State",
+                        "NAA ID": "NAA ID",
+                        "Name": "Volume",
+                        "Status": "",
+                        "Time 1": "",
+                        "Trend #Oprations Rate Trend": "Operations Rate Trend",
+                        "Trend #Trend": "Trend",
+                        "Type": "Type",
+                        "Value #A": "Change",
+                        "Value #Available Capacity": "Available ",
+                        "Value #Consume Capacity % Change": "Change",
+                        "Value #Consumed Capacity": "Consumed ",
+                        "Value #Operations Rate": "Operations",
+                        "Value #Status": "",
+                        "Value #Transfer Rate": "Transfers",
+                        "Value #Visible Capacity": "Visible Capacity",
+                        "Volume": "Name",
+                        "connector_id 5": "",
+                        "host_name 5": "",
+                        "host_type 1": "",
+                        "id": "",
+                        "name": "Volume",
+                        "name 1": "",
+                        "netapp_storage_type 1": "",
+                        "raid_level": "RAID Level",
+                        "raid_level 1": "RAID Level",
+                        "site 3": "",
+                        "site 4": "",
+                        "state": "",
+                        "storage_consumer_naa_id 1": "",
+                        "storage_consumer_name 5": "",
+                        "storage_consumer_state": "Mapping State",
+                        "storage_consumer_state 1": "",
+                        "storage_type 1": "",
+                        "storage_volume_type 1": "",
+                        "type": "Type",
+                        "type 1": "Type",
+                        "usage 4": "",
+                        "usage 6": "",
+                        "volume_type": "Type",
+                        "volume_type 1": "Type"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Lists every volume discovered on the storage system. The information available depends on what is exposed by the platform.\n\nVolume: name of the volume as reported by the array.\n\nType: kind of volume reported by the array. Meaning varies by platform.\n\nMapping State: whether the volume is currently mapped to a host (Mapped or Not Mapped).\n\nHost: name of the host the volume is mapped to, if any.\n\nNAA ID: Network Address Authority identifier of the volume, as seen by hosts.\n\nVisible Capacity: logical size of the volume as presented to hosts.\n\nAvailable: portion of the volume's logical size not yet storing data.\n\nConsumed: portion of the volume's logical size currently storing data. On thin volumes, this reflects physical allocation.\n\nConsumed %: share of the volume's visible capacity currently storing data.\n\nOperations: combined read and write operations per second, averaged over the selected time range.\n\nTransfers: combined read and write throughput in bytes per second, averaged over the selected time range.\n\nStatus: operational state of the volume, classified as OK, Degraded, or Failed.",
+          "id": 28,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false,
+                    "wrapHeaderText": false,
+                    "wrapText": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Visible Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Consumed Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Available Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "thresholds"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "text",
+                              "value": 0
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "degraded": {
+                                "color": "orange",
+                                "index": 1,
+                                "text": "Degraded"
+                              },
+                              "failed": {
+                                "color": "red",
+                                "index": 2,
+                                "text": "Failed"
+                              },
+                              "ok": {
+                                "color": "transparent",
+                                "index": 0,
+                                "text": "OK"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Mapping State"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "mapped": {
+                                "color": "transparent",
+                                "index": 1,
+                                "text": "Mapped"
+                              },
+                              "unmapped": {
+                                "color": "red",
+                                "index": 0,
+                                "text": "Not Mapped"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "noValue"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Volume"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byValue",
+                      "options": {
+                        "op": "gte",
+                        "reducer": "allIsNull",
+                        "value": 0
+                      }
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hideFrom.viz",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Consumed %"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "#EAB839",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.9
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Operations"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "ops"
+                      },
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Transfers"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "binBps"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Volume"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Type"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Mapping State"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Consume Capacity % Change"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": -0.01
+                            },
+                            {
+                              "color": "blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.01
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "hideValue": false,
+                          "type": "sparkline"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Host"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "NAA ID"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "string"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend #Operations Rate Trend"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "sparkline"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Operations Rate"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-43": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "(\r\n  sum by (site, storage_io_direction) (\r\n    rate(storage_operation_time_seconds_total{host_name=\"$host_name\", storage_type=\"storage_system\"}[5m])\r\n  ) / \r\n  clamp_min( # to make sure we don't divide by if no activity\r\n    sum by (site, storage_io_direction) (\r\n      rate(storage_operations_total{host_name=\"$host_name\", storage_type=\"storage_system\"}[5m])\r\n    ), \r\n    0.0001\r\n  )\r\n)\r\nand # Make sure there are some operations\r\n(\r\n  sum by (site, storage_io_direction) (\r\n    rate(storage_operations_total{host_name=\"$host_name\", storage_type=\"storage_system\"}[5m])\r\n  ) >= 1\r\n)",
+                        "instant": false,
+                        "legendFormat": "{{storage_io_direction}} ",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Read & Write"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "(\r\n  sum by (site) (\r\n    rate(storage_operation_time_seconds_total{host_name=\"$host_name\", storage_type=\"storage_system\"}[5m])\r\n  ) / \r\n  clamp_min(\r\n    sum by (site) (\r\n      rate(storage_operations_total{host_name=\"$host_name\", storage_type=\"storage_system\"}[5m])\r\n    ), \r\n    0.0001\r\n  )\r\n)",
+                        "instant": false,
+                        "legendFormat": "Average",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Average"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 250
+              },
+              "transformations": []
+            }
+          },
+          "description": "Average duration of read and write operations handled by the storage system.\n\nRead: mean time to serve a read operation.\n\nWrite: mean time to serve a write operation.\n\nAverage: mean time across all operations.",
+          "id": 43,
+          "links": [],
+          "title": "System Response Time",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "axisSoftMin": 0,
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "hue",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 2,
+                    "pointSize": 1,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "write "
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "purple",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Write"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "read "
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Read"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Average"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "text",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "last",
+                    "min",
+                    "mean",
+                    "max"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-62": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_size_bytes{storage_type=\"storage_system\", host_name=\"$host_name\"}",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "Size",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Size"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_limit_bytes{storage_type=\"storage_system\", host_name=\"$host_name\"}",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "Capacity",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Capacity"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Compares the raw capacity installed in the storage system to what is actually usable for data.\n\nSize: total raw capacity installed (sum of all physical drives).\n\nCapacity: usable capacity presentable to storage pools.",
+          "id": 62,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "bargauge",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Size"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "light-orange",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Subscribed"
+                    },
+                    "properties": []
+                  }
+                ]
+              },
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 8,
+                "namePlacement": "auto",
+                "orientation": "vertical",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": false,
+                "sizing": "auto",
+                "valueMode": "text"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-63": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "storage_usage_bytes{host_name=\"$host_name\", storage_type=\"storage_system\", storage_provisioning_state=\"used\"}",
+                        "instant": true,
+                        "legendFormat": "Consumed Capacity",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(storage_usage_bytes{host_name=\"$host_name\", storage_type=\"storage_system\", storage_provisioning_state=\"free\"})",
+                        "instant": true,
+                        "legendFormat": "Available Capacity",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Breakdown of the system's usable capacity between space already used by data and space still free.\n\nConsumed: capacity currently storing data.\n\nAvailable: capacity free for new allocations.",
+          "id": 63,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Available Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Available"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "#c8c8c8",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Consumed Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Consumed"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "light-blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "displayLabels": [
+                  "name"
+                ],
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true,
+                  "values": [
+                    "value",
+                    "percent"
+                  ]
+                },
+                "pieType": "donut",
+                "reduceOptions": {
+                  "calcs": [],
+                  "fields": "",
+                  "values": false
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-70": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(hw_status{host_name=~\"$host_name\", hw_type=\"physical_disk\"})",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Number of physical disks discovered on the storage system.",
+          "id": 70,
+          "links": [],
+          "title": "Physical Disks",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "light-blue",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-71": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(sum(hw_status{host_name=~\"$host_name\", hw_type=\"physical_disk\", state=~\"degraded|failed|missing\"}) or vector(0))\r\n+\r\n(sum(hw_physical_disk_endurance_utilization_ratio{host_name=~\"$host_name\", state=\"remaining\"} < 0.1) or vector(0))",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Failed Disks + Low Endurance Disks"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "disabled": true,
+                    "id": "calculateField",
+                    "options": {
+                      "binary": {
+                        "left": {
+                          "matcher": {
+                            "id": "byType",
+                            "options": "number"
+                          }
+                        },
+                        "right": {
+                          "fixed": ""
+                        }
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "reducer": "sum"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Number of physical disks that need attention.\n\nTo be counted, a disk has to be either in a failed state or has less than 10% of its endurance remaining.",
+          "id": 71,
+          "links": [],
+          "title": "Unhealthy Disks",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "light-red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-73": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(storage_size_bytes{storage_type=\"physical_disk\", host_name=~\"$host_name\"}) or sum(hw_physical_disk_size_bytes{host_name=\"$host_name\"})",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Sum of the raw capacity of every physical disk discovered on the storage system.",
+          "id": 73,
+          "links": [],
+          "title": "Size",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "light-blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-75": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "hw_status{host_name=~\"$host_name\", hw_type=\"physical_disk\", state=~\"degraded|failed|missing\"}",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "hw_physical_disk_endurance_utilization_ratio{host_name=~\"$host_name\", state=\"remaining\"} < 0.1",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "id",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Value": true,
+                        "Value #A": true,
+                        "__name__": true,
+                        "agent_host_name": true,
+                        "connector_id": true,
+                        "entityName": true,
+                        "entityTypeId": true,
+                        "host_name": true,
+                        "host_type": true,
+                        "hw_parent_id": true,
+                        "hw_parent_type": true,
+                        "hw_type": true,
+                        "id": true,
+                        "instanceName": true,
+                        "os_type": true,
+                        "otel_scope_name": true,
+                        "site": true,
+                        "speed": true,
+                        "storage_role": true,
+                        "type": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Time": 6,
+                        "Value": 21,
+                        "__name__": 7,
+                        "agent_host_name": 8,
+                        "connector_id": 9,
+                        "firmware_version": 4,
+                        "host_name": 10,
+                        "host_type": 11,
+                        "hw_parent_id": 12,
+                        "hw_parent_type": 13,
+                        "hw_type": 14,
+                        "id": 15,
+                        "model": 1,
+                        "name": 2,
+                        "os_type": 16,
+                        "serial_number": 3,
+                        "site": 17,
+                        "speed": 18,
+                        "state": 5,
+                        "storage_role": 19,
+                        "type": 20,
+                        "vendor": 0
+                      },
+                      "renameByName": {
+                        "connector_id": "",
+                        "firmware_version": "Firmware",
+                        "id": "",
+                        "model": "Model",
+                        "name": "Name",
+                        "os_type": "",
+                        "serial_number": "Serial Number",
+                        "state": "Status",
+                        "vendor": "Manufacturer"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 75,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "decimals": 2,
+                  "noValue": "No unhealthy disks",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "degradd": {
+                                "color": "light-orange",
+                                "index": 1,
+                                "text": "Degraded"
+                              },
+                              "failed": {
+                                "color": "red",
+                                "index": 0,
+                                "text": "Failed"
+                              },
+                              "present": {
+                                "color": "red",
+                                "index": 2,
+                                "text": "Missing"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Serial Number"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Firmware"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-83": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(storage_usage_bytes{host_name=\"$host_name\",storage_type=\"storage_system\"})",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "clamp_min(\r\n  predict_linear(\r\n    storage_usage_bytes{\r\n      host_name=\"$host_name\",\r\n      storage_type=\"storage_system\",\r\n      storage_provisioning_state=\"used\"\r\n    }[$__range],\r\n    7 * 24 * 3600\r\n  ),\r\n  0\r\n)",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "PredictedConsumedCapacity1W"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "clamp_min(\r\n  predict_linear(\r\n    storage_usage_bytes{\r\n      host_name=\"$host_name\",\r\n      storage_type=\"storage_system\",\r\n      storage_provisioning_state=\"used\"\r\n    }[$__range],\r\n    30 * 24 * 3600\r\n  ),\r\n  0\r\n)",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "PredictedConsumedCapacity1M"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "clamp_min(\r\n  predict_linear(\r\n    storage_usage_bytes{\r\n      host_name=\"$host_name\",\r\n      storage_type=\"storage_system\",\r\n      storage_provisioning_state=\"used\"\r\n    }[$__range],\r\n    365 * 24 * 3600\r\n  ),\r\n  0\r\n)",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "PredictedConsumedCapacity1Y"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "__expr__",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expression": "$PredictedConsumedCapacity1W/$Capacity",
+                        "type": "math"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "1Week"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "__expr__",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expression": "$PredictedConsumedCapacity1M/$Capacity",
+                        "type": "math"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "1Month"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "__expr__",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expression": "$PredictedConsumedCapacity1Y/$Capacity",
+                        "type": "math"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "1Year"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "byVariable": false,
+                      "include": {
+                        "pattern": "/^1/"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Linear projection of how much of the system's usable capacity will be consumed by data at the end of the period, based on the current growth trend.",
+          "id": 83,
+          "links": [],
+          "title": "Projected Consumed Capacity",
+          "vizConfig": {
+            "group": "bargauge",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 2,
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.7
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.9
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": "/^1Week/"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "1 Week"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": "/^1Month/"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "1 Month"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": "/^1Year/"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "1 Year"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "displayMode": "lcd",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 16,
+                "minVizWidth": 8,
+                "namePlacement": "auto",
+                "orientation": "vertical",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-85": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(storage_limit_bytes{host_name=\"$host_name\", storage_type=\"volume\"})",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Total number of volumes discovered on the storage system.",
+          "id": 85,
+          "links": [],
+          "title": "Volumes",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "purple",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-9": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "topk(1, storage_limit_bytes{host_name=~\"$host_name\", storage_type=\"storage_system\"})",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "family",
+                          "model",
+                          "vendor"
+                        ],
+                        "pattern": "(vendor|model)"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {},
+                      "includeByName": {},
+                      "indexByName": {
+                        "family": 1,
+                        "model": 2,
+                        "vendor": 0
+                      },
+                      "renameByName": {}
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "The vendor, family and model information of the storage system",
+          "id": 9,
+          "links": [],
+          "title": "Vendor and Model",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "#808080",
+                    "mode": "fixed"
+                  },
+                  "noValue": "N/A",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "vendor"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Host Vendor"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "model"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Host Model"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "colorMode": "none",
+                "graphMode": "none",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "fields": "/.*/",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {
+                  "valueSize": 20
+                },
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-90": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(\r\n  count by (storage_consumer_name) (\r\n    storage_limit_bytes{\r\n      host_name=~\"$host_name\",\r\n      storage_type=\"volume\",\r\n      storage_consumer_name!=\"\"\r\n    }\r\n  )\r\n)",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Number of distinct hosts (or host groups) to which at least one volume is mapped. \n\nCounts unique values of the consumer name across all mapped volumes on the storage system.",
+          "id": 90,
+          "links": [],
+          "title": "Hosts",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "-",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-92": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (storage_consumer_name) (storage_limit_bytes{host_name=~\"$host_name\", storage_type=\"volume\", storage_consumer_state=\"mapped\"})",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Visible Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (storage_consumer_name) (storage_usage_bytes{host_name=~\"$host_name\", storage_type=\"volume\", storage_consumer_state=\"mapped\", storage_provisioning_state=\"used\"})",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Consumed Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (storage_consumer_name) (rate(storage_operations_total{host_name=~\"$host_name\", storage_type=\"volume\", storage_consumer_state=\"mapped\", storage_io_direction=~\"read|write\"}[$__range]))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Operations Rate"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (storage_consumer_name) (rate(storage_io_bytes_total{host_name=~\"$host_name\", storage_type=\"volume\", storage_consumer_state=\"mapped\", storage_io_direction=~\"read|write\"}[$__range]))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Transfer Rate"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (storage_consumer_name) (rate(storage_operations_total{host_name=~\"$host_name\", storage_type=\"volume\", storage_consumer_state=\"mapped\", storage_io_direction=~\"read|write\"}[15m]))",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Operations Rate Trend"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (storage_consumer_name) (rate(storage_io_bytes_total{host_name=~\"$host_name\", storage_type=\"volume\", storage_consumer_state=\"mapped\", storage_io_direction=~\"read|write\"}[15m]))",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Transfer Rate Trend"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 50
+              },
+              "transformations": [
+                {
+                  "kind": "timeSeriesTable",
+                  "spec": {
+                    "id": "timeSeriesTable",
+                    "options": {
+                      "Operations Rate Trend": {
+                        "timeField": "Time"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "storage_consumer_name",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Time 5": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Consumed Capacity %": 4,
+                        "Time 1": 9,
+                        "Time 2": 10,
+                        "Time 3": 11,
+                        "Time 4": 12,
+                        "Time 5": 13,
+                        "Trend #Operations Rate Trend": 6,
+                        "Trend #Transfer Rate Trend": 8,
+                        "Value #Available Capacity": 2,
+                        "Value #Consumed Capacity": 3,
+                        "Value #Operations Rate": 5,
+                        "Value #Transfer Rate": 7,
+                        "Value #Visible Capacity": 1,
+                        "storage_consumer_name": 0
+                      },
+                      "renameByName": {
+                        "Consumed Capacity %": "Consumed Capacity %",
+                        "Time 5": "",
+                        "Trend #Operations Rate Trend": "Operations Trendline",
+                        "Trend #Transfer Rate Trend": "Transfers Trendline",
+                        "Value #A": "Visible Capacity",
+                        "Value #Available Capacity": "Available Capacity",
+                        "Value #Consumed Capacity": "Consumed Capacity",
+                        "Value #Operations Rate": "Operations",
+                        "Value #Transfer Rate": "Transfers",
+                        "Value #Visible Capacity": "Visible Capacity",
+                        "storage_consumer_name": "Consumer Name"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "Aggregates volume capacity and I/O by the host (or host group) the volumes are mapped to. Rows with multiple hosts (e.g. \"hci-esx-01,hci-esx-02\") correspond to a masking view shared between hosts.\n\nConsumer Name: name of the host, cluster, or initiator group to which the volumes are mapped.\n\nVisible Capacity: total logical capacity of all volumes mapped to this consumer.\n\nConsumed Capacity: total capacity currently storing data across those volumes.\n\nOperations: combined read and write operations per second across the consumer's volumes, averaged over the selected time range.\n\nOperations Trendline: sparkline of the operations rate\n.\nTransfers: combined read and write throughput in bytes per second across the consumer's volumes, averaged over the selected time range.\n\nTransfers Trendline: sparkline of the transfer rate.",
+          "id": 92,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Visible Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Available Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Consumed Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "bytes"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Operations"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "ops"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "fieldMinMax",
+                        "value": true
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "super-light-yellow",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Transfers"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "binBps"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "fieldMinMax",
+                        "value": true
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Consumed Capacity %"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Consumer Name"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend #Operations Rate Trend"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "hideValue": true,
+                          "type": "sparkline"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend #Transfer Rate Trend"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "gradientMode": "hue",
+                          "hideValue": true,
+                          "type": "sparkline"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Operations Rate"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-94": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "system_cpu_utilization_ratio{host_name=\"$host_name\", storage_type=\"controller\", id=\"$controller\"}",
+                        "legendFormat": "{{id}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Processor utilization of the storage controller.",
+          "id": 94,
+          "links": [],
+          "title": "Controller  $controller",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 16,
+                    "gradientMode": "hue",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 0.75
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.9
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "min",
+                    "mean",
+                    "max",
+                    "last"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-98": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "# Total consumed capacity of all volumes\r\nsum(storage_usage_bytes{host_name=~\"$host_name\", storage_type=\"volume\", storage_provisioning_state=\"used\"})",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "# Total capacity of unmapped and inactive volumes\r\nsum(\r\n  storage_usage_bytes{\r\n    host_name=~\"$host_name\",\r\n    storage_type=\"volume\",\r\n    storage_consumer_state=\"unmapped\",\r\n    storage_provisioning_state=\"used\"\r\n  }\r\n  or\r\n  (\r\n    (\r\n      storage_usage_bytes{\r\n        host_name=~\"$host_name\",\r\n        storage_type=\"volume\",\r\n        storage_provisioning_state=\"used\"\r\n      }\r\n      unless on (host_name, id)\r\n      storage_usage_bytes{\r\n        host_name=~\"$host_name\",\r\n        storage_type=\"volume\",\r\n        storage_consumer_state=\"unmapped\",\r\n        storage_provisioning_state=\"used\"\r\n      }\r\n    )\r\n    and on (host_name, id)\r\n    (\r\n      sum by (host_name, id) (\r\n        rate(\r\n          storage_operations_total{\r\n            host_name=~\"$host_name\",\r\n            storage_type=\"volume\",\r\n            storage_io_direction=~\"read|write\"\r\n          }[$__range]\r\n        )\r\n      ) <= 0.001\r\n    )\r\n  )\r\n) or vector(0)",
+                        "instant": true,
+                        "legendFormat": "Reclaimable  Capacity (Inactive or Unmapped)",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "# Failed Capacity\r\nsum(\r\n  storage_usage_bytes{\r\n    host_name=~\"$host_name\",\r\n    storage_type=\"volume\",\r\n    storage_consumer_state=\"mapped\",\r\n    storage_provisioning_state=\"used\"\r\n  }\r\n  and on (host_name, id)\r\n  storage_status{\r\n    host_name=~\"$host_name\",\r\n    storage_type=\"volume\",\r\n    state=~\"failed\"\r\n  } > 0\r\n) or vector(0)",
+                        "instant": true,
+                        "legendFormat": "Failed Volume Capacity",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "C"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "__expr__",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expression": "$A - $B - $C",
+                        "type": "math"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Active Capacity"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Breaks down the total consumed volume capacity into categories that indicate how much space could potentially be recovered.\n\nReclaimable Capacity (Inactive or Unmapped): consumed capacity of volumes that are either unmapped, or mapped but idle over the selected time range.\n\nFailed Volume Capacity: consumed capacity of volumes that are mapped to a host but report a failed state.\n\nActive Capacity: consumed capacity of volumes that are mapped to a host and actively serving I/O. ",
+          "id": 98,
+          "links": [],
+          "title": "Reclaimable Consumed Capacity",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  "decimals": 1,
+                  "unit": "bytes"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Reclaimable  Capacity (Inactive or Unmapped)"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "#c8c8c8",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Active Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Failed Volumes Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "displayLabels": [
+                  "name"
+                ],
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true,
+                  "values": [
+                    "percent",
+                    "value"
+                  ]
+                },
+                "pieType": "pie",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": true
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-99": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(storage_usage_bytes{host_name=~\"$host_name\", storage_type=\"volume\", storage_provisioning_state=\"used\"})",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "Sum of the capacity currently storing data across all volumes on the storage system.",
+          "id": 99,
+          "links": [],
+          "title": "Total Consumed Capacity",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "purple",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-9"
+                        },
+                        "height": 3,
+                        "width": 6,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-62"
+                        },
+                        "height": 8,
+                        "width": 7,
+                        "x": 6,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-63"
+                        },
+                        "height": 8,
+                        "width": 5,
+                        "x": 13,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-83"
+                        },
+                        "height": 8,
+                        "width": 6,
+                        "x": 18,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-10"
+                        },
+                        "height": 2,
+                        "width": 6,
+                        "x": 0,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-24"
+                        },
+                        "height": 3,
+                        "width": 6,
+                        "x": 0,
+                        "y": 5
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "System Information"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "narrow",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "conditionalRendering": {
+                          "kind": "ConditionalRenderingGroup",
+                          "spec": {
+                            "condition": "and",
+                            "items": [
+                              {
+                                "kind": "ConditionalRenderingData",
+                                "spec": {
+                                  "value": true
+                                }
+                              }
+                            ],
+                            "visibility": "show"
+                          }
+                        },
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-154"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "conditionalRendering": {
+                          "kind": "ConditionalRenderingGroup",
+                          "spec": {
+                            "condition": "and",
+                            "items": [
+                              {
+                                "kind": "ConditionalRenderingData",
+                                "spec": {
+                                  "value": true
+                                }
+                              }
+                            ],
+                            "visibility": "show"
+                          }
+                        },
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-155"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "conditionalRendering": {
+                          "kind": "ConditionalRenderingGroup",
+                          "spec": {
+                            "condition": "and",
+                            "items": [
+                              {
+                                "kind": "ConditionalRenderingData",
+                                "spec": {
+                                  "value": true
+                                }
+                              }
+                            ],
+                            "visibility": "show"
+                          }
+                        },
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-156"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-157"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-158"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-159"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 6,
+                  "rowHeightMode": "short"
+                }
+              },
+              "title": ""
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "conditionalRendering": {
+                "kind": "ConditionalRenderingGroup",
+                "spec": {
+                  "condition": "and",
+                  "items": [
+                    {
+                      "kind": "ConditionalRenderingVariable",
+                      "spec": {
+                        "operator": "notEquals",
+                        "value": "",
+                        "variable": "alert_show"
+                      }
+                    }
+                  ],
+                  "visibility": "show"
+                }
+              },
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-150"
+                        },
+                        "height": 3,
+                        "width": 4,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-148"
+                        },
+                        "height": 9,
+                        "width": 20,
+                        "x": 4,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-151"
+                        },
+                        "height": 3,
+                        "width": 4,
+                        "x": 0,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-152"
+                        },
+                        "height": 3,
+                        "width": 4,
+                        "x": 0,
+                        "y": 6
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Alerts"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "conditionalRendering": {
+                          "kind": "ConditionalRenderingGroup",
+                          "spec": {
+                            "condition": "and",
+                            "items": [
+                              {
+                                "kind": "ConditionalRenderingData",
+                                "spec": {
+                                  "value": true
+                                }
+                              }
+                            ],
+                            "visibility": "show"
+                          }
+                        },
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-43"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "conditionalRendering": {
+                          "kind": "ConditionalRenderingGroup",
+                          "spec": {
+                            "condition": "and",
+                            "items": [
+                              {
+                                "kind": "ConditionalRenderingData",
+                                "spec": {
+                                  "value": true
+                                }
+                              }
+                            ],
+                            "visibility": "show"
+                          }
+                        },
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-19"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "conditionalRendering": {
+                          "kind": "ConditionalRenderingGroup",
+                          "spec": {
+                            "condition": "and",
+                            "items": [
+                              {
+                                "kind": "ConditionalRenderingData",
+                                "spec": {
+                                  "value": true
+                                }
+                              }
+                            ],
+                            "visibility": "show"
+                          }
+                        },
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-21"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "Transfers"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "conditionalRendering": {
+                "kind": "ConditionalRenderingGroup",
+                "spec": {
+                  "condition": "and",
+                  "items": [
+                    {
+                      "kind": "ConditionalRenderingVariable",
+                      "spec": {
+                        "operator": "notEquals",
+                        "value": "",
+                        "variable": "controller_show"
+                      }
+                    }
+                  ],
+                  "visibility": "show"
+                }
+              },
+              "hideHeader": false,
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-94"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "controller"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 4,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "Controller CPU Usage"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-70"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-73"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 3,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-71"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 6,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-75"
+                        },
+                        "height": 3,
+                        "width": 15,
+                        "x": 9,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Physical Disks"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-23"
+                        },
+                        "height": 9,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Storage Pools"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "conditionalRendering": {
+                "kind": "ConditionalRenderingGroup",
+                "spec": {
+                  "condition": "and",
+                  "items": [
+                    {
+                      "kind": "ConditionalRenderingVariable",
+                      "spec": {
+                        "operator": "notEquals",
+                        "value": "",
+                        "variable": "pool_oversubscription_show"
+                      }
+                    }
+                  ],
+                  "visibility": "show"
+                }
+              },
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "conditionalRendering": {
+                          "kind": "ConditionalRenderingGroup",
+                          "spec": {
+                            "condition": "and",
+                            "items": [
+                              {
+                                "kind": "ConditionalRenderingData",
+                                "spec": {
+                                  "value": true
+                                }
+                              }
+                            ],
+                            "visibility": "show"
+                          }
+                        },
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-122"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "Oversubscribed Storage Pools"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "conditionalRendering": {
+                "kind": "ConditionalRenderingGroup",
+                "spec": {
+                  "condition": "and",
+                  "items": [
+                    {
+                      "kind": "ConditionalRenderingVariable",
+                      "spec": {
+                        "operator": "notEquals",
+                        "value": "",
+                        "variable": "netapp_lun_show"
+                      }
+                    }
+                  ],
+                  "visibility": "hide"
+                }
+              },
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-90"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-124"
+                        },
+                        "height": 9,
+                        "width": 14,
+                        "x": 3,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-98"
+                        },
+                        "height": 9,
+                        "width": 7,
+                        "x": 17,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-85"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-99"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 6
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Volumes (activity from ${__from:date:YYYY-MM-DD HH:mm} to ${__to:date:YYYY-MM-DD HH:mm})"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "conditionalRendering": {
+                "kind": "ConditionalRenderingGroup",
+                "spec": {
+                  "condition": "and",
+                  "items": [
+                    {
+                      "kind": "ConditionalRenderingVariable",
+                      "spec": {
+                        "operator": "notEquals",
+                        "value": "",
+                        "variable": "netapp_lun_show"
+                      }
+                    }
+                  ],
+                  "visibility": "show"
+                }
+              },
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-140"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-141"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 3,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-142"
+                        },
+                        "height": 4,
+                        "width": 18,
+                        "x": 6,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "NetApp Volumes  (activity from ${__from:date:YYYY-MM-DD HH:mm} to ${__to:date:YYYY-MM-DD HH:mm})"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": true,
+              "conditionalRendering": {
+                "kind": "ConditionalRenderingGroup",
+                "spec": {
+                  "condition": "and",
+                  "items": [
+                    {
+                      "kind": "ConditionalRenderingVariable",
+                      "spec": {
+                        "operator": "notEquals",
+                        "value": "",
+                        "variable": "netapp_lun_show"
+                      }
+                    }
+                  ],
+                  "visibility": "show"
+                }
+              },
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-143"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "NetApp Volume Details"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "conditionalRendering": {
+                "kind": "ConditionalRenderingGroup",
+                "spec": {
+                  "condition": "and",
+                  "items": [
+                    {
+                      "kind": "ConditionalRenderingVariable",
+                      "spec": {
+                        "operator": "notEquals",
+                        "value": "",
+                        "variable": "netapp_lun_show"
+                      }
+                    }
+                  ],
+                  "visibility": "show"
+                }
+              },
+              "hideHeader": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-136"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-138"
+                        },
+                        "height": 7,
+                        "width": 14,
+                        "x": 3,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-139"
+                        },
+                        "height": 7,
+                        "width": 7,
+                        "x": 17,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-137"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 3
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "NetApp LUNs (activity from ${__from:date:YYYY-MM-DD HH:mm} to ${__to:date:YYYY-MM-DD HH:mm})"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": true,
+              "conditionalRendering": {
+                "kind": "ConditionalRenderingGroup",
+                "spec": {
+                  "condition": "and",
+                  "items": [
+                    {
+                      "kind": "ConditionalRenderingVariable",
+                      "spec": {
+                        "operator": "notEquals",
+                        "value": "",
+                        "variable": "netapp_lun_show"
+                      }
+                    }
+                  ],
+                  "visibility": "show"
+                }
+              },
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-144"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "NetApp LUN Details"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "conditionalRendering": {
+                "kind": "ConditionalRenderingGroup",
+                "spec": {
+                  "condition": "and",
+                  "items": [
+                    {
+                      "kind": "ConditionalRenderingVariable",
+                      "spec": {
+                        "operator": "notEquals",
+                        "value": "",
+                        "variable": "storage_consumer_show"
+                      }
+                    }
+                  ],
+                  "visibility": "show"
+                }
+              },
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-92"
+                        },
+                        "height": 7,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Storage Consumers"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "conditionalRendering": {
+                "kind": "ConditionalRenderingGroup",
+                "spec": {
+                  "condition": "and",
+                  "items": [
+                    {
+                      "kind": "ConditionalRenderingVariable",
+                      "spec": {
+                        "operator": "equals",
+                        "value": "",
+                        "variable": "netapp_lun_show"
+                      }
+                    }
+                  ],
+                  "visibility": "show"
+                }
+              },
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-28"
+                        },
+                        "height": 12,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Volume Details"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "conditionalRendering": {
+                "kind": "ConditionalRenderingGroup",
+                "spec": {
+                  "condition": "and",
+                  "items": [
+                    {
+                      "kind": "ConditionalRenderingVariable",
+                      "spec": {
+                        "operator": "notEquals",
+                        "value": "",
+                        "variable": "network_show"
+                      }
+                    }
+                  ],
+                  "visibility": "show"
+                }
+              },
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-131"
+                        },
+                        "height": 9,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-129"
+                        },
+                        "height": 9,
+                        "width": 24,
+                        "x": 0,
+                        "y": 9
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Network - Overall"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "conditionalRendering": {
+                "kind": "ConditionalRenderingGroup",
+                "spec": {
+                  "condition": "and",
+                  "items": [
+                    {
+                      "kind": "ConditionalRenderingVariable",
+                      "spec": {
+                        "operator": "notEquals",
+                        "value": "",
+                        "variable": "network_show"
+                      }
+                    }
+                  ],
+                  "visibility": "show"
+                }
+              },
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "narrow",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-130"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "network_id"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 5,
+                  "rowHeightMode": "short"
+                }
+              },
+              "title": "Network Traffic - Individual "
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-160"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-26"
+                        },
+                        "height": 3,
+                        "width": 18,
+                        "x": 3,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-123"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 21,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "MetricsHub Agent Information"
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "MetricsHub",
+      "Otel"
+    ],
+    "timeSettings": {
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-6h",
+      "hideTimepicker": false,
+      "timezone": "browser",
+      "to": "now"
+    },
+    "title": "Storage System (MetricsHub)",
+    "variables": [
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(storage_limit_bytes{storage_type=\"storage_system\"},host_name)",
+          "description": "",
+          "hide": "dontHide",
+          "includeAll": false,
+          "label": "Hostname",
+          "multi": false,
+          "name": "host_name",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(storage_limit_bytes{storage_type=\"storage_system\"},host_name)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(system_cpu_utilization_ratio{storage_type=\"controller\", host_name=\"$host_name\"},id)",
+          "description": "",
+          "hide": "hideVariable",
+          "includeAll": true,
+          "label": "controller",
+          "multi": true,
+          "name": "controller",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(system_cpu_utilization_ratio{storage_type=\"controller\", host_name=\"$host_name\"},id)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(system_cpu_utilization_ratio{storage_type=\"controller\", host_name=\"$host_name\"},id)",
+          "description": "",
+          "hide": "hideVariable",
+          "includeAll": false,
+          "label": "controller_show",
+          "multi": false,
+          "name": "controller_show",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(system_cpu_utilization_ratio{storage_type=\"controller\", host_name=\"$host_name\"},id)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "query_result(ALERTS_FOR_STATE{host_name=~\"$host_name\", alertname=~\"MetricsHub-Storage-.*|MetricsHub-Hardware-.*\"})",
+          "description": "",
+          "hide": "hideVariable",
+          "includeAll": false,
+          "label": "alert_show",
+          "multi": false,
+          "name": "alert_show",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 3,
+              "query": "query_result(ALERTS_FOR_STATE{host_name=~\"$host_name\", alertname=~\"MetricsHub-Storage-.*|MetricsHub-Hardware-.*\"})",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(hw_network_io_bytes_total{host_name=\"$host_name\"},id)",
+          "description": "",
+          "hide": "hideVariable",
+          "includeAll": false,
+          "label": "network_show",
+          "multi": false,
+          "name": "network_show",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(hw_network_io_bytes_total{host_name=\"$host_name\"},id)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(storage_limit_bytes{host_name=\"$host_name\", netapp_storage_type=\"lun\"},id)",
+          "description": "",
+          "hide": "hideVariable",
+          "includeAll": false,
+          "label": "netapp_lun_show",
+          "multi": false,
+          "name": "netapp_lun_show",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(storage_limit_bytes{host_name=\"$host_name\", netapp_storage_type=\"lun\"},id)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(storage_limit_bytes{host_name=\"$host_name\", storage_type=\"volume\"},storage_consumer_name)",
+          "description": "",
+          "hide": "hideVariable",
+          "includeAll": false,
+          "label": "storage_consumer_show",
+          "multi": false,
+          "name": "storage_consumer_show",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(storage_limit_bytes{host_name=\"$host_name\", storage_type=\"volume\"},storage_consumer_name)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onTimeRangeChanged",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(metricshub_host_configured{host_name=\"$host_name\"},agent_host_name)",
+          "hide": "hideVariable",
+          "includeAll": false,
+          "multi": false,
+          "name": "agent",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(metricshub_host_configured{host_name=\"$host_name\"},agent_host_name)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "query_result((storage_provisioning_bytes{  host_name=\"$host_name\",  storage_type=\"pool\",  storage_provisioning_state=\"subscribed\"}/ignoring(storage_provisioning_state)storage_limit_bytes{   host_name=\"$host_name\",   storage_type=\"pool\"}) > 1)",
+          "hide": "hideVariable",
+          "includeAll": false,
+          "label": "pool_oversubscription_show",
+          "multi": false,
+          "name": "pool_oversubscription_show",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 3,
+              "query": "query_result((storage_provisioning_bytes{  host_name=\"$host_name\",  storage_type=\"pool\",  storage_provisioning_state=\"subscribed\"}/ignoring(storage_provisioning_state)storage_limit_bytes{   host_name=\"$host_name\",   storage_type=\"pool\"}) > 1)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onTimeRangeChanged",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(hw_network_io_bytes_total{host_name=\"$host_name\"},id)",
+          "hide": "hideVariable",
+          "includeAll": true,
+          "multi": true,
+          "name": "network_id",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(hw_network_io_bytes_total{host_name=\"$host_name\"},id)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
+      }
+    ]
+  },
+  "status": {}
+}

--- a/src/dashboards/System/System Performance Metrics (MetricsHub).json
+++ b/src/dashboards/System/System Performance Metrics (MetricsHub).json
@@ -1,5518 +1,6588 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "gauge",
-      "name": "Gauge",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "12.3.2"
-    },
-    {
-      "type": "panel",
-      "id": "piechart",
-      "name": "Pie chart",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "text",
-      "name": "Text",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "ad9xq42",
+    "generation": 6,
+    "creationTimestamp": "2026-04-22T14:02:47Z",
+    "labels": {},
+    "annotations": {}
   },
-  "description": "General OS performance metrics to assess the availability and performance of Linux and Windows systems. Leverages OpenTelemetry metrics collected with MetricsHub and stored in Prometheus.",
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 1,
-  "links": [
-    {
-      "asDropdown": false,
-      "icon": "external link",
-      "includeVars": false,
-      "keepTime": false,
-      "tags": [
-        "System Overview"
-      ],
-      "targetBlank": false,
-      "title": "Systems - Overview",
-      "tooltip": "",
-      "type": "dashboards",
-      "url": ""
-    }
-  ],
-  "liveNow": true,
-  "panels": [
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 54,
-      "panels": [],
-      "title": "Host Global Information",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
             },
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "decimals": 0,
-          "mappings": [
-            {
-              "options": {
-                "aix": {
-                  "index": 2,
-                  "text": "https://dl.sentrysoftware.com/public/ibmaix-logo-mh.svg"
-                },
-                "hpux": {
-                  "index": 4,
-                  "text": "https://dl.sentrysoftware.com/public/hpux-logo-mh.svg"
-                },
-                "linux": {
-                  "index": 1,
-                  "text": "https://dl.sentrysoftware.com/public/linux-logo-mh.svg"
-                },
-                "windows": {
-                  "index": 0,
-                  "text": "https://dl.sentrysoftware.com/public/windows-logo-mh.svg"
-                }
-              },
-              "type": "value"
-            },
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "index": 3,
-                  "text": "https://dl.sentrysoftware.com/public/unknown-logo-mh.svg"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "OS"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "image"
-                }
-              },
-              {
-                "id": "custom.width",
-                "value": 182
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 10,
-        "x": 0,
-        "y": 1
-      },
-      "id": 96,
-      "options": {
-        "cellHeight": "sm",
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(1, label_join(system_uptime_seconds{host_name=\"$host_name\"}, \"joined_os\", \" \", \"name\", \"version\", \"os_version\")) # Make sure only one result is returned",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "formatTime",
-          "options": {
-            "outputFormat": "MM-DD HH:mm:ss",
-            "timeField": "Uptime",
-            "timezone": "browser",
-            "useTimezone": true
-          }
-        },
-        {
-          "id": "concatenate",
-          "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Uptime": false,
-              "Value": true,
-              "__name__": true,
-              "agent_host_name": true,
-              "build_number": false,
-              "connector_id": true,
-              "host_id": true,
-              "host_name": true,
-              "host_type": true,
-              "id": true,
-              "name": true,
-              "os_type": false,
-              "os_version": true,
-              "serial_number": true,
-              "site": true,
-              "version": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Time": 6,
-              "Value": 13,
-              "__name__": 7,
-              "agent_host_name": 8,
-              "connector_id": 9,
-              "host_name": 2,
-              "host_type": 10,
-              "id": 11,
-              "joined_os": 0,
-              "name": 3,
-              "os_type": 1,
-              "os_version": 5,
-              "site": 12,
-              "version": 4
-            },
-            "renameByName": {
-              "Value": "Uptime",
-              "Value 2": "Uptime",
-              "agent_host_name": "",
-              "build_number": "Build Number",
-              "count(system_cpu_utilization_ratio{host_name=\"hegel\", system_cpu_state=\"idle\"})": "CPU Core",
-              "count(system_cpu_utilization_ratio{site=\"Sentry-Thésée\", host_name=\"dev-px-01\", system_cpu_state=\"idle\"})": "CPU Core",
-              "count(system_cpu_utilization_ratio{site=\"Sentry-Thésée\", host_name=\"ecs2-01\", system_cpu_state=\"idle\"})": "CPU Core",
-              "count(system_cpu_utilization_ratio{site=\"Sentry-Thésée\", host_name=\"scotus\", system_cpu_state=\"idle\"})": "CPU Core",
-              "host_name": "",
-              "joined_os": "Operating System",
-              "name": "",
-              "os_type": "OS",
-              "os_version": "",
-              "serial_number": "Serial Number",
-              "site": "",
-              "version": "",
-              "{__name__=\"system_memory_limit_bytes\", agent_host_name=\"lab-win-01.internal.sentrysoftware.net\", connector_id=\"Linux\", host_id=\"dev-px-01\", host_name=\"dev-px-01\", host_type=\"compute\", id=\"memory_usage\", os_type=\"linux\", site=\"Sentry-Thésée\"}": "Memory",
-              "{__name__=\"system_memory_limit_bytes\", agent_host_name=\"lab-win-01.internal.sentrysoftware.net\", connector_id=\"Linux\", host_id=\"ecs2-01-system\", host_name=\"ecs2-01\", host_type=\"compute\", id=\"memory_usage\", os_type=\"linux\", site=\"Sentry-Thésée\"}": "Memory",
-              "{__name__=\"system_memory_limit_bytes\", agent_host_name=\"lab-win-01.internal.sentrysoftware.net\", connector_id=\"Linux\", host_id=\"hegel\", host_name=\"hegel\", host_type=\"compute\", id=\"memory_usage\", os_type=\"linux\", site=\"Sentry-Thésée\"}": "Memory",
-              "{__name__=\"system_memory_limit_bytes\", agent_host_name=\"lab-win-01.internal.sentrysoftware.net\", connector_id=\"Windows\", host_id=\"scotus\", host_name=\"scotus\", host_type=\"compute\", id=\"memory_usage\", os_type=\"windows\", site=\"Sentry-Thésée\"}": "Memory"
-            }
+            "version": "v0"
           }
         }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "None",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Severity"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 109
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "critical": {
-                        "color": "red",
-                        "index": 1,
-                        "text": "Critical"
+      }
+    ],
+    "cursorSync": "Crosshair",
+    "description": "General OS performance metrics to assess the availability and performance of Linux and Windows systems. Leverages OpenTelemetry metrics collected with MetricsHub and stored in Prometheus.",
+    "editable": true,
+    "elements": {
+      "panel-100": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(system_filesystem_usage_bytes{host_name=\"$host_name\", system_filesystem_type !~\"$filesystemFilter\"})",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "Total",
+                        "range": false
                       },
-                      "warning": {
-                        "color": "orange",
-                        "index": 0,
-                        "text": "Warning"
-                      }
+                      "version": "v0"
                     },
-                    "type": "value"
+                    "refId": "B"
                   }
-                ]
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "basic",
-                  "type": "color-background"
                 }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "dateTimeAsLocal"
-              },
-              {
-                "id": "custom.width",
-                "value": 200
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Alert Name"
-            },
-            "properties": [
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "MetricsHub-System-CPU-High-Utilization-Warning": {
-                        "index": 1,
-                        "text": "CPU: High utilization"
-                      },
-                      "MetricsHub-System-Filesystem-Filesystem-High-Utilization-Warning": {
-                        "index": 0,
-                        "text": "Filesystem: High utilization"
-                      },
-                      "MetricsHub-System-Filesystem-High-Utilization-Critical": {
-                        "index": 2,
-                        "text": "Filesystem: Critically high utilization"
-                      },
-                      "MetricsHub-System-Filesystem-High-Utilization-Warning": {
-                        "index": 10,
-                        "text": "Filesystem: High utilization"
-                      },
-                      "MetricsHub-System-Memory-High-Utilization-Warning": {
-                        "index": 3,
-                        "text": "Memory: High utilization"
-                      },
-                      "MetricsHub-System-Network-Bandwidth-High-Critical": {
-                        "index": 5,
-                        "text": "Network: High bandwidth utilization"
-                      },
-                      "MetricsHub-System-Network-Bandwidth-High-Warning": {
-                        "index": 4,
-                        "text": "Network: High bandwidth utilization"
-                      },
-                      "MetricsHub-System-Network-Errors-Warning": {
-                        "index": 6,
-                        "text": "Network: High number of errors"
-                      },
-                      "MetricsHub-System-Network-Packets-Dropped-Warning": {
-                        "index": 7,
-                        "text": "Network: High number of packet drops"
-                      },
-                      "MetricsHub-System-Page-Fault-Rate-Critical": {
-                        "index": 9,
-                        "text": "Critical page fault rate"
-                      },
-                      "MetricsHub-System-Page-Fault-Rate-Warning": {
-                        "index": 8,
-                        "text": "Elevated page fault rate"
-                      }
-                    },
-                    "type": "value"
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {}
                   }
-                ]
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 12,
-        "x": 10,
-        "y": 1
-      },
-      "id": 138,
-      "options": {
-        "cellHeight": "sm",
-        "enablePagination": false,
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "Time"
-          }
-        ]
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "ALERTS_FOR_STATE{host_name=~\"$host_name\", alertname=~\"MetricsHub-System-.*\"}",
-          "format": "table",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "",
-          "refId": "A"
-        }
-      ],
-      "title": "System Alerts",
-      "transformations": [
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "include": {
-              "names": [
-                "Time",
-                "alertname",
-                "severity",
-                "system_device",
-                "__name__"
+                }
               ]
             }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": false,
-              "Value": false,
-              "Value #A": true,
-              "__name__": true,
-              "agent_host_name": true,
-              "alertstatus": true,
-              "alertstatus_code": true,
-              "applies_to_os": true,
-              "array_name": true,
-              "bandwidth": true,
-              "battery_state": true,
-              "blade_name": true,
-              "chemistry": true,
-              "compiled_file_name": true,
-              "connector_id": true,
-              "description": true,
-              "device_id": true,
-              "device_type": true,
-              "display_name": true,
-              "driver_version": true,
-              "firmware_version": true,
-              "fqdn": true,
-              "host_id": true,
-              "host_name": true,
-              "host_type": true,
-              "hw_type": false,
-              "id": true,
-              "identifying_information": true,
-              "info": true,
-              "instance": true,
-              "job": true,
-              "local_device_name": true,
-              "location": true,
-              "model": true,
-              "name": false,
-              "os_type": true,
-              "parent": true,
-              "physical_address": true,
-              "power_supply_type": true,
-              "raid_level": true,
-              "robotic_type": true,
-              "sensor_location": true,
-              "serial_number": true,
-              "severity": false,
-              "site": true,
-              "state": true,
-              "type": true,
-              "vendor": true,
-              "wwn": true,
-              "zone": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Time": 0,
-              "Value": 13,
-              "array_name": 20,
-              "battery_state": 23,
-              "device_id": 14,
-              "driver_version": 27,
-              "firmware_version": 28,
-              "host_id": 7,
-              "host_name": 8,
-              "host_type": 9,
-              "hw_type": 2,
-              "id": 5,
-              "info": 15,
-              "local_device_name": 21,
-              "location": 19,
-              "model": 16,
-              "name": 3,
-              "os_type": 10,
-              "parent": 6,
-              "power_supply_type": 26,
-              "protocol": 4,
-              "robotic_type": 25,
-              "sensor_location": 29,
-              "serial_number": 24,
-              "severity": 1,
-              "site": 11,
-              "state": 12,
-              "type": 17,
-              "vendor": 18,
-              "wwn": 22
-            },
-            "renameByName": {
-              "Time": "Time",
-              "alertname": "Alert Name",
-              "fqdn": "",
-              "hw_type": "Device Type",
-              "id": "",
-              "label": "Label",
-              "name": "Device Name",
-              "protocol": "Protocol",
-              "severity": "Severity",
-              "system_device": "Device"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Time"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 22,
-        "y": 1
-      },
-      "id": 117,
-      "links": [
-        {
-          "title": "Hardware Sentry OpenTelemetry Collector",
-          "url": "https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html"
-        }
-      ],
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<a href=\"https://metricshub.com/\" target=\"_blank\">\n  <div style=\"\n    display: block;\n    margin: 0 auto; \n    \n    background: transparent url(https://metricshub.com/images/logo-darkgrey.svg) no-repeat center center;\n    background-size: contain;\n    \n    width: 85px;   \n    height: 85px;\n    border-radius: 3px;\n  \">\n  </div>\n</a>",
-        "mode": "html"
-      },
-      "pluginVersion": "12.3.2",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
           },
-          "fieldMinMax": false,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 0,
-        "y": 4
-      },
-      "id": 91,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "vertical",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(system_cpu_utilization_ratio{host_name=\"$host_name\", system_cpu_state=\"idle\"})",
-          "format": "time_series",
-          "instant": true,
-          "legendFormat": "Connector",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "CPU Cores",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 0,
-          "fieldMinMax": false,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 2,
-        "y": 4
-      },
-      "id": 93,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "vertical",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "system_memory_limit_bytes{host_name=\"$host_name\"}",
-          "format": "time_series",
-          "instant": true,
-          "legendFormat": "Connector",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Memory",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "fieldMinMax": false,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-purple",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 4,
-        "y": 4
-      },
-      "id": 100,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(system_filesystem_usage_bytes{host_name=\"$host_name\", system_filesystem_type !~\"$filesystemFilter\"})",
-          "format": "time_series",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "Total",
-          "range": false,
-          "refId": "B"
-        }
-      ],
-      "title": "Capacity",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {}
-        }
-      ],
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 0,
-          "fieldMinMax": false,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "#62615b",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 6,
-        "y": 4
-      },
-      "id": 92,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "vertical",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "system_uptime_seconds{host_name=\"$host_name\"}",
-          "format": "time_series",
-          "instant": true,
-          "legendFormat": "Connector",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Uptime",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "fieldMinMax": false,
-          "mappings": [
-            {
-              "options": {
-                "0": {
-                  "color": "red",
-                  "index": 1,
-                  "text": "Failed"
-                },
-                "1": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "OK"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 8,
-        "y": 4
-      },
-      "id": 86,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "vertical",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": false
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "metricshub_connector_status{host_name=\"$host_name\", connector_id=~\"Linux|Windows|Aix|HPUX\", state=\"ok\"}",
-          "format": "time_series",
-          "instant": false,
-          "legendFormat": "Connector",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Connector",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "noValue": "2026.1",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-green",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 22,
-        "y": 4
-      },
-      "id": 128,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "",
-          "instant": false,
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Dashboard",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 7
-      },
-      "id": 116,
-      "panels": [],
-      "title": "Protocols",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "color-background"
-            },
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "fieldMinMax": false,
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Response Time"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "drawStyle": "line",
-                  "fillOpacity": 17,
-                  "gradientMode": "hue",
-                  "hideValue": true,
-                  "lineInterpolation": "stepBefore",
-                  "lineStyle": {
-                    "dash": [
-                      10,
-                      10
-                    ],
-                    "fill": "solid"
+          "description": "",
+          "id": 100,
+          "links": [],
+          "title": "Capacity",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
                   },
-                  "type": "sparkline"
-                }
-              },
-              {
-                "id": "decimals"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "min",
-                "value": 0
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Highest"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "lcd",
-                  "type": "gauge",
-                  "valueDisplayMode": "text"
-                }
-              },
-              {
-                "id": "unit",
-                "value": "s"
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 7
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Lowest"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "lcd",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 0.5
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Average"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "lcd",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 2
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Up Percentage"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-text"
-                }
-              },
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "red",
-                      "value": 0
-                    },
-                    {
-                      "color": "yellow",
-                      "value": 0.85
-                    },
-                    {
-                      "color": "green",
-                      "value": 0.99
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Response Time"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Protocol"
-            },
-            "properties": [
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "http": {
-                        "index": 5,
-                        "text": "HTTP"
-                      },
-                      "jmx": {
-                        "index": 7,
-                        "text": "JMX"
-                      },
-                      "ping": {
-                        "index": 0,
-                        "text": "Ping"
-                      },
-                      "snmp": {
-                        "index": 1,
-                        "text": "SNMP"
-                      },
-                      "snmpv3": {
-                        "index": 6,
-                        "text": "SNMP v3"
-                      },
-                      "ssh": {
-                        "index": 2,
-                        "text": "SSH"
-                      },
-                      "wbem": {
-                        "index": 4,
-                        "text": "WBEM"
-                      },
-                      "wmi": {
-                        "index": 3,
-                        "text": "WMI"
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "light-purple",
+                        "value": 0
                       }
-                    },
-                    "type": "value"
-                  }
-                ]
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "transparent",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Trend #UP"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "fillOpacity": 3,
-                  "hideValue": true,
-                  "lineInterpolation": "smooth",
-                  "lineStyle": {
-                    "dash": [
-                      10,
-                      10
-                    ],
-                    "fill": "solid"
+                    ]
                   },
-                  "lineWidth": 1,
-                  "type": "sparkline"
-                }
+                  "unit": "bytes"
+                },
+                "overrides": []
               },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 1
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Status"
-            },
-            "properties": [
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "0": {
-                        "color": "red",
-                        "index": 0,
-                        "text": "Down"
-                      },
-                      "1": {
-                        "color": "green",
-                        "index": 1,
-                        "text": "Up"
-                      }
-                    },
-                    "type": "value"
-                  }
-                ]
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 8
-      },
-      "id": 114,
-      "maxDataPoints": 250,
-      "options": {
-        "cellHeight": "sm",
-        "frameIndex": 0,
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum_over_time(metricshub_host_up{host_name=\"$host_name\"}[$__range]) / count_over_time(metricshub_host_up{host_name=\"$host_name\"}[$__range])",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Percentage"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "min_over_time(\r\n  (\r\n    (metricshub_host_response_time_seconds{host_name=\"$host_name\"} > 0) * 1 or\r\n    (metricshub_host_response_time_seconds{host_name=\"$host_name\"} <= 0) * +Inf\r\n  )[$__range:1m]\r\n)",
-          "format": "time_series",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Min"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg_over_time(metricshub_host_response_time_seconds{host_name=\"$host_name\"}[$__range])",
-          "format": "time_series",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "{{protocol}}",
-          "range": false,
-          "refId": "Avg"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max_over_time(metricshub_host_response_time_seconds{host_name=\"$host_name\"}[$__range])",
-          "format": "time_series",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "{{protocol}}",
-          "range": false,
-          "refId": "Max"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "metricshub_host_response_time_seconds{host_name=\"$host_name\"}",
-          "format": "time_series",
-          "instant": false,
-          "legendFormat": "{{protocol}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "metricshub_host_up{host_name=\"$host_name\"}",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{protocol}}",
-          "range": true,
-          "refId": "UP"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "metricshub_host_up{host_name=\"$host_name\"}",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "Status"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "timeSeriesTable",
-          "options": {
-            "A": {
-              "stat": "lastNotNull",
-              "timeField": "Time"
-            },
-            "Avg": {
-              "timeField": "Time"
-            },
-            "B": {
-              "timeField": "Time"
-            },
-            "Max": {
-              "timeField": "Time"
-            },
-            "Min": {
-              "timeField": "Time"
-            },
-            "Percentage": {
-              "timeField": "Time"
-            },
-            "Status": {
-              "timeField": "Time"
-            },
-            "UP": {
-              "timeField": "Time"
-            }
-          }
-        },
-        {
-          "id": "joinByField",
-          "options": {
-            "byField": "protocol",
-            "mode": "outer"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Status",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #Status"
-          }
-        },
-        {
-          "disabled": true,
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Status Over Time",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #UP"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Up Percentage",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #Percentage"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Lowest",
-                "path": "value"
-              }
-            ],
-            "keepTime": false,
-            "replace": false,
-            "source": "Trend #Min"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Average",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #Avg"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Highest",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #Max"
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Trend #Avg": true,
-              "Trend #Max": true,
-              "Trend #Min": true,
-              "Trend #Percentage": true,
-              "Trend #Status": true,
-              "Trend #UP": false,
-              "__name__": true,
-              "agent_host_name": true,
-              "host_id": true,
-              "host_name": true,
-              "host_type": true,
-              "id": true,
-              "is_endpoint": true,
-              "location": true,
-              "name": true,
-              "os_type": true,
-              "site": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Average": 5,
-              "Highest": 6,
-              "Lowest": 4,
-              "Status": 1,
-              "Trend #A": 7,
-              "Trend #Avg": 40,
-              "Trend #Max": 18,
-              "Trend #Min": 29,
-              "Trend #Percentage": 51,
-              "Trend #Status": 85,
-              "Trend #UP": 2,
-              "Up": 86,
-              "Up Percentage": 3,
-              "__name__ 1": 62,
-              "__name__ 2": 63,
-              "__name__ 3": 74,
-              "agent_host_name 1": 8,
-              "agent_host_name 2": 19,
-              "agent_host_name 3": 30,
-              "agent_host_name 4": 41,
-              "agent_host_name 5": 52,
-              "agent_host_name 6": 64,
-              "agent_host_name 7": 75,
-              "host_id 1": 9,
-              "host_id 2": 20,
-              "host_id 3": 31,
-              "host_id 4": 42,
-              "host_id 5": 53,
-              "host_id 6": 65,
-              "host_id 7": 76,
-              "host_name 1": 10,
-              "host_name 2": 21,
-              "host_name 3": 32,
-              "host_name 4": 43,
-              "host_name 5": 54,
-              "host_name 6": 66,
-              "host_name 7": 77,
-              "host_type 1": 11,
-              "host_type 2": 22,
-              "host_type 3": 33,
-              "host_type 4": 44,
-              "host_type 5": 55,
-              "host_type 6": 67,
-              "host_type 7": 78,
-              "id 1": 12,
-              "id 2": 23,
-              "id 3": 34,
-              "id 4": 45,
-              "id 5": 56,
-              "id 6": 68,
-              "id 7": 79,
-              "is_endpoint 1": 13,
-              "is_endpoint 2": 24,
-              "is_endpoint 3": 35,
-              "is_endpoint 4": 46,
-              "is_endpoint 5": 57,
-              "is_endpoint 6": 69,
-              "is_endpoint 7": 80,
-              "location 1": 14,
-              "location 2": 25,
-              "location 3": 36,
-              "location 4": 47,
-              "location 5": 58,
-              "location 6": 70,
-              "location 7": 81,
-              "name 1": 15,
-              "name 2": 26,
-              "name 3": 37,
-              "name 4": 48,
-              "name 5": 59,
-              "name 6": 71,
-              "name 7": 82,
-              "os_type 1": 16,
-              "os_type 2": 27,
-              "os_type 3": 38,
-              "os_type 4": 49,
-              "os_type 5": 60,
-              "os_type 6": 72,
-              "os_type 7": 83,
-              "protocol": 0,
-              "site 1": 17,
-              "site 2": 28,
-              "site 3": 39,
-              "site 4": 50,
-              "site 5": 61,
-              "site 6": 73,
-              "site 7": 84
-            },
-            "renameByName": {
-              "Lowest": "",
-              "Max": "Highest",
-              "Trend #A": "Response Time",
-              "Trend #UP": "Status Over Time",
-              "Up Percentage": "",
-              "name": "",
-              "protocol": "Protocol",
-              "site 2": ""
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 14
-      },
-      "id": 118,
-      "panels": [],
-      "title": "Performance Overview",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Utilization of the busiest core/processor, to identify CPU contention",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-GrYlRd"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 50,
-            "gradientMode": "scheme",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "stepBefore",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 0.8
-              },
-              {
-                "color": "red",
-                "value": 0.95
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 0,
-        "y": 15
-      },
-      "id": 119,
-      "interval": "5m",
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max(1 - sum by (name) (delta(system_cpu_time_seconds_total{host_name=\"$host_name\", system_cpu_state=\"idle\"}[$__rate_interval])) / sum by (name) (delta(system_cpu_time_seconds_total{host_name=\"$host_name\"}[$__rate_interval])))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "Max Core CPU Utilization",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Max CPU Utilization",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds",
-            "seriesBy": "last"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 41,
-            "gradientMode": "scheme",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 0.75
-              },
-              {
-                "color": "red",
-                "value": 0.9
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 6,
-        "y": 15
-      },
-      "id": 120,
-      "options": {
-        "legend": {
-          "calcs": [
-            "last"
-          ],
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(system_memory_utilization_ratio{host_name=\"$host_name\", system_memory_state!=\"free\"})",
-          "legendFormat": "Memory Utilization",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Memory Utilization",
-      "transformations": [
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {},
-            "includeByName": {},
-            "indexByName": {},
-            "renameByName": {
-              "{__name__=\"system_memory_utilization_ratio\", agent_host_name=\"mk-win.internal.sentrysoftware.net\", connector_id=\"Linux\", host_id=\"mk-deb2\", host_name=\"mk-deb2.internal.sentrysoftware.net\", host_type=\"compute\", id=\"memory_usage\", os_type=\"linux\", site=\"Paris\", system_memory_limit=\"2063106048\", system_memory_usage=\"used\"}": "Used memory"
-            }
-          }
-        }
-      ],
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Utilization of the busiest disk, to identify disk contention",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-GrYlRd"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 50,
-            "gradientMode": "scheme",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "stepBefore",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [
-            {
               "options": {
-                "io_wait": {
-                  "index": 0,
-                  "text": "IO Wait"
-                },
-                "nice": {
-                  "index": 3,
-                  "text": "Nice"
-                },
-                "system": {
-                  "index": 1,
-                  "text": "System"
-                },
-                "user": {
-                  "index": 2,
-                  "text": "User"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 0.6
-              },
-              {
-                "color": "red",
-                "value": 0.8
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 12,
-        "y": 15
-      },
-      "id": 121,
-      "interval": "5m",
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max(rate(system_disk_io_time_seconds_total{host_name=\"$host_name\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "Max Disk Time Utilization",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Max Disk Utilization",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "red",
-            "mode": "thresholds"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": true,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 50,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "fieldMinMax": false,
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 0.5
-              },
-              {
-                "color": "red",
-                "value": 0.8
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 6,
-        "x": 18,
-        "y": 15
-      },
-      "id": 135,
-      "interval": "20m",
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull",
-            "min",
-            "max",
-            "mean"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": false,
-          "sortBy": "Name",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "max(max by (network_interface_name) (rate(system_network_io_bytes_total{host_name=\"$host_name\"}[$__rate_interval])\r\n) / max by (network_interface_name) (system_network_bandwidth_limit_bytes{host_name=\"$host_name\"}))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Max Network Utilization",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Max Network Utilization",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 21
-      },
-      "id": 49,
-      "panels": [],
-      "title": "CPU",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "seconde"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "idle"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Idle"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "system"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "System"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "user"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "orange",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "User"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "io_wait"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "IO Wait"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "nice"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "Nice"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 5,
-        "x": 0,
-        "y": 22
-      },
-      "id": 8,
-      "options": {
-        "displayLabels": [
-          "name",
-          "percent"
-        ],
-        "legend": {
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": false,
-          "values": [
-            "percent"
-          ]
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "sort": "desc",
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum by (system_cpu_state) (delta(system_cpu_time_seconds_total{host_name=\"$host_name\"}[$__range]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": true,
-          "interval": "",
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "CPU Time",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 0,
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 0.8
-              },
-              {
-                "color": "red",
-                "value": 0.95
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 5,
-        "y": 22
-      },
-      "id": 6,
-      "options": {
-        "minVizHeight": 75,
-        "minVizWidth": 75,
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "last"
-          ],
-          "fields": "",
-          "values": true
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true,
-        "sizing": "auto"
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum by (name) (irate(system_cpu_time_seconds_total{host_name=\"$host_name\", system_cpu_state!=\"idle\"}[1h]))",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "{{name}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "CPU Core Utilization (Instant)",
-      "transformations": [
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "name"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "gauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-GrYlRd"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 50,
-            "gradientMode": "scheme",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "stepBefore",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [
-            {
-              "options": {
-                "io_wait": {
-                  "index": 0,
-                  "text": "IO Wait"
-                },
-                "nice": {
-                  "index": 3,
-                  "text": "Nice"
-                },
-                "system": {
-                  "index": 1,
-                  "text": "System"
-                },
-                "user": {
-                  "index": 2,
-                  "text": "User"
-                }
-              },
-              "type": "value"
-            }
-          ],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 0.8
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "B"
-            },
-            "properties": [
-              {
-                "id": "custom.lineStyle",
-                "value": {
-                  "dash": [
-                    10,
-                    10
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
                   ],
-                  "fill": "dash"
-                }
-              },
-              {
-                "id": "custom.fillOpacity",
-                "value": 0
-              },
-              {
-                "id": "custom.lineWidth",
-                "value": 0
-              },
-              {
-                "id": "custom.pointSize",
-                "value": 2
-              },
-              {
-                "id": "custom.showPoints",
-                "value": "always"
-              },
-              {
-                "id": "custom.stacking",
-                "value": {
-                  "group": "A",
-                  "mode": "none"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 11,
-        "x": 13,
-        "y": 22
-      },
-      "id": 110,
-      "interval": "5m",
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "avg by (host_name, system_cpu_state) (rate(system_cpu_time_seconds_total{host_name=\"$host_name\", system_cpu_state!=\"idle\"}[$__rate_interval]))",
-          "format": "time_series",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{system_cpu_state}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max by (host_name) (1 - rate(system_cpu_time_seconds_total{host_name=\"$host_name\", system_cpu_state=\"idle\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "legendFormat": "Max Core CPU Utilization",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "CPU Utilization",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 30
-      },
-      "id": 42,
-      "panels": [],
-      "title": "Memory",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "bytes"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "free"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Free"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "used"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Used"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "buffers"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "purple",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Buffers"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "cached"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "light-blue",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Cached"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 5,
-        "x": 0,
-        "y": 31
-      },
-      "id": 25,
-      "options": {
-        "displayLabels": [
-          "name",
-          "value"
-        ],
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "percent"
-          ]
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "sort": "desc",
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "system_memory_usage_bytes{host_name=\"$host_name\"}",
-          "instant": true,
-          "legendFormat": "{{system_memory_state}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Memory Usage",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds",
-            "seriesBy": "last"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 41,
-            "gradientMode": "scheme",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "normal"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 0.75
-              },
-              {
-                "color": "red",
-                "value": 0.9
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 5,
-        "y": 31
-      },
-      "id": 17,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "system_memory_utilization_ratio{host_name=\"$host_name\", system_memory_state!=\"free\"}",
-          "legendFormat": "{{system_memory_state}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Memory Utilization (Cumulated)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "log"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "sishort"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Minor"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "super-light-orange",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Major"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 13,
-        "y": 31
-      },
-      "id": 134,
-      "interval": "5m",
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "rate(system_paging_faults_total{host_name=\"$host_name\", system_paging_type=\"minor\"}[$__rate_interval])",
-          "legendFormat": "Minor",
-          "range": true,
-          "refId": "Minor"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "rate(system_paging_faults_total{host_name=\"$host_name\", system_paging_type=\"major\"}[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Major",
-          "range": true,
-          "refId": "Major"
-        }
-      ],
-      "title": "Memory Faults",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "fixed"
-          },
-          "custom": {
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            }
-          },
-          "mappings": [],
-          "unit": "bytes"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "free"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Free"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "used"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Used"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "cached"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "light-blue",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Cached"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 5,
-        "x": 19,
-        "y": 31
-      },
-      "id": 131,
-      "options": {
-        "displayLabels": [
-          "name",
-          "value"
-        ],
-        "legend": {
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true,
-          "values": [
-            "percent"
-          ]
-        },
-        "pieType": "donut",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "sort": "desc",
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "system_paging_usage_bytes{host_name=\"$host_name\"}",
-          "instant": true,
-          "legendFormat": "{{system_paging_state}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Paging Utilization",
-      "type": "piechart"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "red",
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": true,
-            "axisColorMode": "text",
-            "axisGridShow": false,
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 50,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "stepBefore",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "fieldMinMax": false,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "sishort"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "B"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "purple",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "A"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.transform",
-                "value": "negative-Y"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 13,
-        "y": 35
-      },
-      "id": 133,
-      "interval": "5m",
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull",
-            "min",
-            "max",
-            "mean"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": false,
-          "sortBy": "Name",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "rate(system_paging_operations_total{host_name=\"$host_name\", system_paging_direction=\"out\"}[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Out",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "rate(system_paging_operations_total{host_name=\"$host_name\", system_paging_direction=\"in\"}[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "In",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Paging Activity",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 39
-      },
-      "id": 33,
-      "panels": [],
-      "title": "Filesystems",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": true,
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Utilization"
-            },
-            "properties": [
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 1
-              },
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "lcd",
-                  "type": "gauge",
-                  "valueDisplayMode": "color"
-                }
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Filesystem"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Change"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-text"
-                }
-              },
-              {
-                "id": "custom.wrapText",
-                "value": false
-              },
-              {
-                "id": "decimals",
-                "value": 1
-              },
-              {
-                "id": "color"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "light-blue",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 0.01
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Type"
-            },
-            "properties": []
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Trend"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "drawStyle": "line",
-                  "hideValue": true,
-                  "lineInterpolation": "linear",
-                  "type": "sparkline"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Mountpoint"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Capacity"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge",
-                  "valueDisplayMode": "text"
-                }
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "light-blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Free"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "GrowthRate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "binBps"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-text"
-                }
-              },
-              {
-                "id": "color"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "light-blue",
-                      "value": 0
-                    },
-                    {
-                      "color": "light-red",
-                      "value": 1
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time Until Saturation"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 40
-      },
-      "id": 130,
-      "options": {
-        "cellHeight": "sm",
-        "enablePagination": false,
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Capacity"
-          }
-        ]
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "system_filesystem_usage_bytes{host_name=\"$host_name\", system_filesystem_state=\"free\", system_filesystem_type !~\"$filesystemFilter\"}",
-          "format": "time_series",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Free"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "system_filesystem_usage_bytes{host_name=\"$host_name\", system_filesystem_state=\"used\", system_filesystem_type !~\"$filesystemFilter\"}",
-          "format": "time_series",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Used & Reserved"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(system_filesystem_utilization_ratio{host_name=\"$host_name\",system_filesystem_state=~\"used|reserved\", system_filesystem_type !~\"$filesystemFilter\"}) by (system_device) - sum(system_filesystem_utilization_ratio{host_name=\"$host_name\",system_filesystem_state=~\"used|reserved\", system_filesystem_type !~\"$filesystemFilter\"} offset $__range) by (system_device) ",
-          "format": "time_series",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Change"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(system_filesystem_utilization_ratio{host_name=\"$host_name\",system_filesystem_state=~\"used|reserved\", system_filesystem_type !~\"$filesystemFilter\"}) by (system_device)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "Usage"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(system_filesystem_usage_bytes{host_name=\"$host_name\",system_filesystem_state=~\"used|reserved|free\", system_filesystem_type !~\"$filesystemFilter\"}) by (system_device)",
-          "format": "time_series",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Capacity"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(system_filesystem_utilization_ratio{host_name=\"$host_name\",system_filesystem_state=~\"used|reserved\", system_filesystem_type !~\"$filesystemFilter\"}) by (system_device)",
-          "hide": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "Main"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "delta(system_filesystem_usage_bytes{host_name=~\"$host_name\", system_filesystem_state=\"used\"}[$__range]) / $__range_s ",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "GrowthRate"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(\r\n  system_filesystem_usage_bytes{host_name=~\"$host_name\", system_filesystem_state=\"free\"} \r\n  / ignoring(system_filesystem_state)\r\n  (delta(system_filesystem_usage_bytes{host_name=~\"$host_name\", system_filesystem_state=\"used\"}[$__range]) / $__range_s)\r\n) \r\nand ignoring(system_filesystem_state)\r\ndelta(system_filesystem_usage_bytes{host_name=~\"$host_name\", system_filesystem_state=\"used\"}[$__range]) > 0",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "TimeUntilSaturation"
-        }
-      ],
-      "title": "Filesystems",
-      "transformations": [
-        {
-          "id": "timeSeriesTable",
-          "options": {
-            "A": {
-              "timeField": "Time"
-            },
-            "B": {
-              "timeField": "Time"
-            },
-            "C": {
-              "timeField": "Time"
-            },
-            "Capacity": {
-              "timeField": "Time"
-            },
-            "Change": {
-              "timeField": "Time"
-            },
-            "D": {
-              "timeField": "Time"
-            },
-            "E": {
-              "timeField": "Time"
-            },
-            "Free": {
-              "timeField": "Time"
-            },
-            "Usage": {
-              "timeField": "Time"
-            },
-            "Used & Reserved": {
-              "timeField": "Time"
-            }
-          }
-        },
-        {
-          "id": "joinByField",
-          "options": {
-            "byField": "system_device",
-            "mode": "outer"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Capacity",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #Capacity"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Used & Reserved",
-                "path": "value"
-              }
-            ],
-            "keepTime": false,
-            "replace": false,
-            "source": "Trend #Used & Reserved"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Utilization",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #Usage"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Free",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #Free"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "Change",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #Change"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "GrowthRate",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #GrowthRate"
-          }
-        },
-        {
-          "id": "extractFields",
-          "options": {
-            "delimiter": ",",
-            "format": "json",
-            "jsonPaths": [
-              {
-                "alias": "TimeUntilSaturation",
-                "path": "value"
-              }
-            ],
-            "source": "Trend #TimeUntilSaturation"
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Capacity": false,
-              "FreeAndUsedCapacity": true,
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Time 3": true,
-              "Time 4": true,
-              "Time 5": true,
-              "Trend #A": true,
-              "Trend #Capacity": true,
-              "Trend #Change": true,
-              "Trend #D": true,
-              "Trend #Free": true,
-              "Trend #GrowthRate": true,
-              "Trend #TimeUntilSaturation": true,
-              "Trend #Used & Reserved": true,
-              "Value": true,
-              "Value #B": false,
-              "Value #C": false,
-              "Value #E": true,
-              "__name__": true,
-              "__name__ 1": true,
-              "__name__ 2": true,
-              "__name__ 3": true,
-              "agent_host_name": true,
-              "agent_host_name 1": true,
-              "agent_host_name 2": true,
-              "agent_host_name 3": true,
-              "agent_host_name 4": true,
-              "connector_id": true,
-              "connector_id 1": true,
-              "connector_id 2": true,
-              "connector_id 3": true,
-              "connector_id 4": true,
-              "host_id": true,
-              "host_id 1": true,
-              "host_id 2": true,
-              "host_id 3": true,
-              "host_name": true,
-              "host_name 1": true,
-              "host_name 2": true,
-              "host_name 3": true,
-              "host_name 4": true,
-              "host_type": true,
-              "host_type 1": true,
-              "host_type 2": true,
-              "host_type 3": true,
-              "host_type 4": true,
-              "id 1": true,
-              "id 2": true,
-              "id 3": true,
-              "id 4": true,
-              "name 1": true,
-              "name 2": true,
-              "os_type": true,
-              "os_type 1": true,
-              "os_type 2": true,
-              "os_type 3": true,
-              "os_type 4": true,
-              "site": true,
-              "site 1": true,
-              "site 2": true,
-              "site 3": true,
-              "site 4": true,
-              "system_device": false,
-              "system_device 1": true,
-              "system_device 2": true,
-              "system_device 3": true,
-              "system_filesystem_device": true,
-              "system_filesystem_device 1": true,
-              "system_filesystem_device 2": true,
-              "system_filesystem_device 3": true,
-              "system_filesystem_mode 1": true,
-              "system_filesystem_mode 2": true,
-              "system_filesystem_mode 3": true,
-              "system_filesystem_mode 4": true,
-              "system_filesystem_mountpoint 1": true,
-              "system_filesystem_mountpoint 2": true,
-              "system_filesystem_mountpoint 3": true,
-              "system_filesystem_mountpoint 4": true,
-              "system_filesystem_state": true,
-              "system_filesystem_state 1": true,
-              "system_filesystem_state 2": true,
-              "system_filesystem_state 3": true,
-              "system_filesystem_type 2": true,
-              "system_filesystem_type 3": true,
-              "system_filesystem_type 4": true,
-              "system_filesystem_volumeName": true,
-              "system_filesystem_volumeName 2": true,
-              "system_filesystem_volumeName 3": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Capacity": 4,
-              "Change": 6,
-              "Free": 2,
-              "GrowthRate": 7,
-              "TimeUntilSaturation": 9,
-              "Trend #Capacity": 12,
-              "Trend #Change": 32,
-              "Trend #Free": 10,
-              "Trend #GrowthRate": 42,
-              "Trend #TimeUntilSaturation": 55,
-              "Trend #Usage": 8,
-              "Trend #Used & Reserved": 29,
-              "Used & Reserved": 3,
-              "Utilization": 5,
-              "__name__ 1": 11,
-              "__name__ 2": 20,
-              "agent_host_name 1": 13,
-              "agent_host_name 2": 21,
-              "agent_host_name 3": 33,
-              "agent_host_name 4": 46,
-              "connector_id 1": 14,
-              "connector_id 2": 22,
-              "connector_id 3": 34,
-              "connector_id 4": 47,
-              "host_name 1": 15,
-              "host_name 2": 23,
-              "host_name 3": 35,
-              "host_name 4": 48,
-              "host_type 1": 16,
-              "host_type 2": 24,
-              "host_type 3": 36,
-              "host_type 4": 49,
-              "id 1": 30,
-              "id 2": 31,
-              "id 3": 37,
-              "id 4": 50,
-              "os_type 1": 17,
-              "os_type 2": 25,
-              "os_type 3": 38,
-              "os_type 4": 51,
-              "site 1": 18,
-              "site 2": 26,
-              "site 3": 39,
-              "site 4": 52,
-              "system_device": 0,
-              "system_filesystem_mountpoint 1": 43,
-              "system_filesystem_mountpoint 2": 44,
-              "system_filesystem_mountpoint 3": 45,
-              "system_filesystem_mountpoint 4": 53,
-              "system_filesystem_state 1": 19,
-              "system_filesystem_state 2": 27,
-              "system_filesystem_state 3": 40,
-              "system_filesystem_type 1": 1,
-              "system_filesystem_type 2": 28,
-              "system_filesystem_type 3": 41,
-              "system_filesystem_type 4": 54
-            },
-            "renameByName": {
-              "Capacity": "Capacity",
-              "Change": "Change",
-              "Free": "Free",
-              "GrowthRate": "Growth Rate",
-              "Time 1": "",
-              "Time 2": "",
-              "Time 5": "",
-              "TimeUntilSaturation": "Time Until Saturation",
-              "Trend #A": "",
-              "Trend #Capacity": "",
-              "Trend #D": "",
-              "Trend #Free": "",
-              "Trend #TimeUntilSaturation": "",
-              "Trend #Usage": "Trend",
-              "Usage": "Usage",
-              "Used & Reserved": "Used & Reserved",
-              "Utilization": "Utilization",
-              "Value": "",
-              "Value #A": "Usage",
-              "Value #B": "Free",
-              "Value #C": "Used & Reserved",
-              "Value #Capacity": "Capacity",
-              "Value #D": "Change",
-              "Value #F": "Capacity",
-              "Value #Free": "Free",
-              "Value #Used & Reserved": "Used & Reserved",
-              "__name__ 1": "",
-              "agent_host_name 4": "",
-              "id": "Filesystem",
-              "system_device": "Filesystem",
-              "system_device 1": "",
-              "system_filesystem_mountpoint": "Mountpoint",
-              "system_filesystem_mountpoint 1": "Mountpoint",
-              "system_filesystem_state 1": "",
-              "system_filesystem_type": "Type",
-              "system_filesystem_type 1": "Type",
-              "system_filesystem_type 3": "",
-              "system_filesystem_volumeName 1": "Name",
-              "value": ""
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 50
-      },
-      "id": 37,
-      "panels": [],
-      "title": "Network Traffic - Total",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "red",
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": true,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 50,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "stepBefore",
-            "lineWidth": 2,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "fieldMinMax": false,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "binBps"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "A"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "purple",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byFrameRefID",
-              "options": "B"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.transform",
-                "value": "negative-Y"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 20,
-        "x": 0,
-        "y": 51
-      },
-      "id": 80,
-      "interval": "5m",
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull",
-            "min",
-            "max",
-            "mean"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true,
-          "sortBy": "Name",
-          "sortDesc": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "maxHeight": 600,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(system_network_io_bytes_total{host_name=\"$host_name\", network_io_direction=\"transmit\"}[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Transmitted",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(system_network_io_bytes_total{host_name=\"$host_name\", network_io_direction=\"receive\"}[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Received",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Network Total Traffic",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 3,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "purple",
-                "value": 0
-              },
-              {
-                "color": "orange",
-                "value": 0.000001
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 20,
-        "y": 51
-      },
-      "id": 124,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(delta(system_network_errors_total{host_name=\"$host_name\", network_io_direction=\"transmit\"}[$__range]))\r\n/\r\nsum (delta(system_network_packets_total{host_name=\"$host_name\", network_io_direction=\"transmit\"}[$__range]))",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Tx Errors",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 3,
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "purple",
-                "value": 0
-              },
-              {
-                "color": "orange",
-                "value": 0.000001
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 22,
-        "y": 51
-      },
-      "id": 126,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(delta(system_network_dropped_total{host_name=\"$host_name\", network_io_direction=\"transmit\"}[$__range]))\r\n/\r\nsum (delta(system_network_packets_total{host_name=\"$host_name\", network_io_direction=\"transmit\"}[$__range]))",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Tx Dropped",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 3,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              },
-              {
-                "color": "orange",
-                "value": 0.000001
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 20,
-        "y": 55
-      },
-      "id": 125,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(delta(system_network_errors_total{host_name=\"$host_name\", network_io_direction=\"receive\"}[$__range]))\r\n/\r\nsum (delta(system_network_packets_total{host_name=\"$host_name\", network_io_direction=\"receive\"}[$__range]))",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Rx Errors",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "decimals": 3,
-          "mappings": [],
-          "max": 100,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              },
-              {
-                "color": "orange",
-                "value": 1e-7
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 22,
-        "y": 55
-      },
-      "id": 127,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(delta(system_network_dropped_total{host_name=\"$host_name\", network_io_direction=\"receive\"}[$__range]))\r\n/\r\nsum (delta(system_network_packets_total{host_name=\"$host_name\", network_io_direction=\"receive\"}[$__range]))",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Rx Dropped",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 59
-      },
-      "id": 111,
-      "panels": [],
-      "title": "Network Traffic - Individual",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": true,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 50,
-            "gradientMode": "opacity",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "stepBefore",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
-            "pointSize": 7,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "binBps"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Received"
-            },
-            "properties": [
-              {
-                "id": "custom.axisCenteredZero",
-                "value": true
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.transform",
-                "value": "negative-Y"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Transmitted"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "purple",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
-        "y": 60
-      },
-      "id": 106,
-      "interval": "5m",
-      "maxPerRow": 4,
-      "options": {
-        "legend": {
-          "calcs": [
-            "last",
-            "min",
-            "max",
-            "mean"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "repeat": "network_id",
-      "repeatDirection": "h",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "rate(system_network_io_bytes_total{host_name=\"$host_name\", network_io_direction=\"transmit\", id=~\"$network_id\"}[$__rate_interval])",
-          "format": "time_series",
-          "instant": false,
-          "legendFormat": "Transmitted",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "rate(system_network_io_bytes_total{host_name=\"$host_name\", network_io_direction=\"receive\", id=~\"$network_id\"}[$__rate_interval])",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Received",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Traffic: $network_id",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 66
-      },
-      "id": 112,
-      "panels": [],
-      "title": "Disk Activity",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "green",
-            "mode": "fixed"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 20,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "stepBefore",
-            "lineStyle": {
-              "fill": "solid"
-            },
-            "lineWidth": 1,
-            "pointSize": 7,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "binBps"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "read"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Read"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "write"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "red",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "Write"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
-        "y": 67
-      },
-      "id": 107,
-      "interval": "5m",
-      "maxPerRow": 4,
-      "options": {
-        "legend": {
-          "calcs": [
-            "last",
-            "min",
-            "max",
-            "mean"
-          ],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.3.2",
-      "repeat": "physical_disk_system_device",
-      "repeatDirection": "h",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum by (disk_io_direction) (rate(system_disk_io_bytes_total{host_name=\"$host_name\", system_device=~\"$physical_disk_system_device\"}[$__rate_interval]))",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "{{disk_io_direction}}",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "title": "Disk Activity: $physical_disk_system_device",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 72
-      },
-      "id": 29,
-      "panels": [],
-      "title": "MetricsHub Agent Information",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": false,
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "mappings": [
-            {
-              "options": {
-                "linux": {
-                  "index": 1,
-                  "text": "https://dl.sentrysoftware.com/public/linux-logo-mh.svg"
+                  "fields": "",
+                  "values": false
                 },
-                "windows": {
-                  "index": 0,
-                  "text": "https://dl.sentrysoftware.com/public/windows-logo-mh.svg"
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-106": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "rate(system_network_io_bytes_total{host_name=\"$host_name\", network_io_direction=\"transmit\", id=~\"$network_id\"}[$__rate_interval])",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "Transmitted",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "rate(system_network_io_bytes_total{host_name=\"$host_name\", network_io_direction=\"receive\", id=~\"$network_id\"}[$__rate_interval])",
+                        "instant": false,
+                        "legendFormat": "Received",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
                 }
+              ],
+              "queryOptions": {
+                "interval": "5m"
               },
-              "type": "value"
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 106,
+          "links": [],
+          "title": "Traffic: $network_id",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": true,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 50,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "stepBefore",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 1,
+                    "pointSize": 7,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "binBps"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Received"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.axisCenteredZero",
+                        "value": true
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.transform",
+                        "value": "negative-Y"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Transmitted"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "purple",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "last",
+                    "min",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-107": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum by (disk_io_direction) (rate(system_disk_io_bytes_total{host_name=\"$host_name\", system_device=~\"$physical_disk_system_device\"}[$__rate_interval]))",
+                        "instant": false,
+                        "legendFormat": "{{disk_io_direction}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 107,
+          "links": [],
+          "title": "Disk Activity: $physical_disk_system_device",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 20,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "stepBefore",
+                    "lineStyle": {
+                      "fill": "solid"
+                    },
+                    "lineWidth": 1,
+                    "pointSize": 7,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "binBps"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "read"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Read"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "write"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Write"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "last",
+                    "min",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-110": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg by (host_name, system_cpu_state) (rate(system_cpu_time_seconds_total{host_name=\"$host_name\", system_cpu_state!=\"idle\"}[$__rate_interval]))",
+                        "format": "time_series",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "{{system_cpu_state}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "max by (host_name) (1 - rate(system_cpu_time_seconds_total{host_name=\"$host_name\", system_cpu_state=\"idle\"}[$__rate_interval]))",
+                        "format": "time_series",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "Max Core CPU Utilization",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 110,
+          "links": [],
+          "title": "CPU Utilization",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-GrYlRd"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 50,
+                    "gradientMode": "scheme",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "stepBefore",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "io_wait": {
+                          "index": 0,
+                          "text": "IO Wait"
+                        },
+                        "nice": {
+                          "index": 3,
+                          "text": "Nice"
+                        },
+                        "system": {
+                          "index": 1,
+                          "text": "System"
+                        },
+                        "user": {
+                          "index": 2,
+                          "text": "User"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.8
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.lineStyle",
+                        "value": {
+                          "dash": [
+                            10,
+                            10
+                          ],
+                          "fill": "dash"
+                        }
+                      },
+                      {
+                        "id": "custom.fillOpacity",
+                        "value": 0
+                      },
+                      {
+                        "id": "custom.lineWidth",
+                        "value": 0
+                      },
+                      {
+                        "id": "custom.pointSize",
+                        "value": 2
+                      },
+                      {
+                        "id": "custom.showPoints",
+                        "value": "always"
+                      },
+                      {
+                        "id": "custom.stacking",
+                        "value": {
+                          "group": "A",
+                          "mode": "none"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-114": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum_over_time(metricshub_host_up{host_name=\"$host_name\"}[$__range]) / count_over_time(metricshub_host_up{host_name=\"$host_name\"}[$__range])",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Percentage"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "min_over_time(\r\n  (\r\n    (metricshub_host_response_time_seconds{host_name=\"$host_name\"} > 0) * 1 or\r\n    (metricshub_host_response_time_seconds{host_name=\"$host_name\"} <= 0) * +Inf\r\n  )[$__range:1m]\r\n)",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Min"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "avg_over_time(metricshub_host_response_time_seconds{host_name=\"$host_name\"}[$__range])",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "{{protocol}}",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Avg"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "max_over_time(metricshub_host_response_time_seconds{host_name=\"$host_name\"}[$__range])",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "{{protocol}}",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Max"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "metricshub_host_response_time_seconds{host_name=\"$host_name\"}",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "{{protocol}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "metricshub_host_up{host_name=\"$host_name\"}",
+                        "instant": false,
+                        "legendFormat": "{{protocol}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "UP"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "metricshub_host_up{host_name=\"$host_name\"}",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Status"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 250
+              },
+              "transformations": [
+                {
+                  "kind": "timeSeriesTable",
+                  "spec": {
+                    "id": "timeSeriesTable",
+                    "options": {
+                      "A": {
+                        "stat": "lastNotNull",
+                        "timeField": "Time"
+                      },
+                      "Avg": {
+                        "timeField": "Time"
+                      },
+                      "B": {
+                        "timeField": "Time"
+                      },
+                      "Max": {
+                        "timeField": "Time"
+                      },
+                      "Min": {
+                        "timeField": "Time"
+                      },
+                      "Percentage": {
+                        "timeField": "Time"
+                      },
+                      "Status": {
+                        "timeField": "Time"
+                      },
+                      "UP": {
+                        "timeField": "Time"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "protocol",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Status",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #Status"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "disabled": true,
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Status Over Time",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #UP"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Up Percentage",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #Percentage"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Lowest",
+                          "path": "value"
+                        }
+                      ],
+                      "keepTime": false,
+                      "replace": false,
+                      "source": "Trend #Min"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Average",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #Avg"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Highest",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #Max"
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Trend #Avg": true,
+                        "Trend #Max": true,
+                        "Trend #Min": true,
+                        "Trend #Percentage": true,
+                        "Trend #Status": true,
+                        "Trend #UP": false,
+                        "__name__": true,
+                        "__name__ 1": true,
+                        "__name__ 2": true,
+                        "__name__ 3": true,
+                        "agent_host_name": true,
+                        "agent_host_name 1": true,
+                        "agent_host_name 3": true,
+                        "agent_host_name 4": true,
+                        "agent_host_name 5": true,
+                        "agent_host_name 6": true,
+                        "agent_host_name 7": true,
+                        "host_id": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_name 3": true,
+                        "host_name 4": true,
+                        "host_name 5": true,
+                        "host_name 6": true,
+                        "host_name 7": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "host_type 4": true,
+                        "host_type 5": true,
+                        "host_type 7": true,
+                        "id": true,
+                        "is_endpoint": true,
+                        "location": true,
+                        "name": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "os_type 3": true,
+                        "os_type 4": true,
+                        "os_type 5": true,
+                        "os_type 6": true,
+                        "os_type 7": true,
+                        "otel_scope_name 1": true,
+                        "otel_scope_name 2": true,
+                        "otel_scope_name 3": true,
+                        "otel_scope_name 4": true,
+                        "otel_scope_name 5": true,
+                        "otel_scope_name 6": true,
+                        "otel_scope_name 7": true,
+                        "site": true,
+                        "site 1": true,
+                        "site 2": true,
+                        "site 3": true,
+                        "site 4": true,
+                        "site 5": true,
+                        "site 6": true,
+                        "site 7": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Average": 5,
+                        "Highest": 6,
+                        "Lowest": 4,
+                        "Status": 1,
+                        "Trend #A": 7,
+                        "Trend #Avg": 40,
+                        "Trend #Max": 18,
+                        "Trend #Min": 29,
+                        "Trend #Percentage": 51,
+                        "Trend #Status": 85,
+                        "Trend #UP": 2,
+                        "Up": 86,
+                        "Up Percentage": 3,
+                        "__name__ 1": 62,
+                        "__name__ 2": 63,
+                        "__name__ 3": 74,
+                        "agent_host_name 1": 8,
+                        "agent_host_name 2": 19,
+                        "agent_host_name 3": 30,
+                        "agent_host_name 4": 41,
+                        "agent_host_name 5": 52,
+                        "agent_host_name 6": 64,
+                        "agent_host_name 7": 75,
+                        "host_id 1": 9,
+                        "host_id 2": 20,
+                        "host_id 3": 31,
+                        "host_id 4": 42,
+                        "host_id 5": 53,
+                        "host_id 6": 65,
+                        "host_id 7": 76,
+                        "host_name 1": 10,
+                        "host_name 2": 21,
+                        "host_name 3": 32,
+                        "host_name 4": 43,
+                        "host_name 5": 54,
+                        "host_name 6": 66,
+                        "host_name 7": 77,
+                        "host_type 1": 11,
+                        "host_type 2": 22,
+                        "host_type 3": 33,
+                        "host_type 4": 44,
+                        "host_type 5": 55,
+                        "host_type 6": 67,
+                        "host_type 7": 78,
+                        "id 1": 12,
+                        "id 2": 23,
+                        "id 3": 34,
+                        "id 4": 45,
+                        "id 5": 56,
+                        "id 6": 68,
+                        "id 7": 79,
+                        "is_endpoint 1": 13,
+                        "is_endpoint 2": 24,
+                        "is_endpoint 3": 35,
+                        "is_endpoint 4": 46,
+                        "is_endpoint 5": 57,
+                        "is_endpoint 6": 69,
+                        "is_endpoint 7": 80,
+                        "location 1": 14,
+                        "location 2": 25,
+                        "location 3": 36,
+                        "location 4": 47,
+                        "location 5": 58,
+                        "location 6": 70,
+                        "location 7": 81,
+                        "name 1": 15,
+                        "name 2": 26,
+                        "name 3": 37,
+                        "name 4": 48,
+                        "name 5": 59,
+                        "name 6": 71,
+                        "name 7": 82,
+                        "os_type 1": 16,
+                        "os_type 2": 27,
+                        "os_type 3": 38,
+                        "os_type 4": 49,
+                        "os_type 5": 60,
+                        "os_type 6": 72,
+                        "os_type 7": 83,
+                        "protocol": 0,
+                        "site 1": 17,
+                        "site 2": 28,
+                        "site 3": 39,
+                        "site 4": 50,
+                        "site 5": 61,
+                        "site 6": 73,
+                        "site 7": 84
+                      },
+                      "renameByName": {
+                        "Lowest": "",
+                        "Max": "Highest",
+                        "Trend #A": "Response Time",
+                        "Trend #UP": "Status Over Time",
+                        "Up Percentage": "",
+                        "name": "",
+                        "protocol": "Protocol",
+                        "site 2": ""
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 114,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "color-background"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Response Time"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "drawStyle": "line",
+                          "fillOpacity": 17,
+                          "gradientMode": "hue",
+                          "hideValue": true,
+                          "lineInterpolation": "stepBefore",
+                          "lineStyle": {
+                            "dash": [
+                              10,
+                              10
+                            ],
+                            "fill": "solid"
+                          },
+                          "type": "sparkline"
+                        }
+                      },
+                      {
+                        "id": "decimals"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Highest"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 7
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-GrYlRd"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Lowest"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 0.5
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-GrYlRd"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Average"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 2
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-GrYlRd"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Up Percentage"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 0.85
+                            },
+                            {
+                              "color": "green",
+                              "value": 0.99
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Response Time"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Protocol"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "http": {
+                                "index": 5,
+                                "text": "HTTP"
+                              },
+                              "jmx": {
+                                "index": 7,
+                                "text": "JMX"
+                              },
+                              "ping": {
+                                "index": 0,
+                                "text": "Ping"
+                              },
+                              "snmp": {
+                                "index": 1,
+                                "text": "SNMP"
+                              },
+                              "snmpv3": {
+                                "index": 6,
+                                "text": "SNMP v3"
+                              },
+                              "ssh": {
+                                "index": 2,
+                                "text": "SSH"
+                              },
+                              "wbem": {
+                                "index": 4,
+                                "text": "WBEM"
+                              },
+                              "wmi": {
+                                "index": 3,
+                                "text": "WMI"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "transparent",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend #UP"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "fillOpacity": 3,
+                          "hideValue": true,
+                          "lineInterpolation": "smooth",
+                          "lineStyle": {
+                            "dash": [
+                              10,
+                              10
+                            ],
+                            "fill": "solid"
+                          },
+                          "lineWidth": 1,
+                          "type": "sparkline"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Status"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "0": {
+                                "color": "red",
+                                "index": 0,
+                                "text": "Down"
+                              },
+                              "1": {
+                                "color": "green",
+                                "index": 1,
+                                "text": "Up"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "frameIndex": 0,
+                "showHeader": true,
+                "sortBy": []
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-117": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 117,
+          "links": [
+            {
+              "title": "Hardware Sentry OpenTelemetry Collector",
+              "url": "https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html"
             }
           ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
               },
-              {
-                "color": "red",
-                "value": 80
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<a href=\"https://metricshub.com/\" target=\"_blank\">\n  <div style=\"\n    display: block;\n    margin: 0 auto; \n    \n    background: transparent url(https://metricshub.com/images/logo-darkgrey.svg) no-repeat center center;\n    background-size: contain;\n    \n    width: 85px;   \n    height: 85px;\n    border-radius: 3px;\n  \">\n  </div>\n</a>",
+                "mode": "html"
               }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "OS"
             },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "image"
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-119": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "max(1 - sum by (name) (delta(system_cpu_time_seconds_total{host_name=\"$host_name\", system_cpu_state=\"idle\"}[$__rate_interval])) / sum by (name) (delta(system_cpu_time_seconds_total{host_name=\"$host_name\"}[$__rate_interval])))",
+                        "format": "time_series",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "Max Core CPU Utilization",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Utilization of the busiest core/processor, to identify CPU contention",
+          "id": 119,
+          "links": [],
+          "title": "Max CPU Utilization",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-GrYlRd"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 50,
+                    "gradientMode": "scheme",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "stepBefore",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 0.8
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.95
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
                 }
               }
-            ]
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-120": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(system_memory_utilization_ratio{host_name=\"$host_name\", system_memory_state!=\"free\"})",
+                        "legendFormat": "Memory Utilization",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {},
+                      "includeByName": {},
+                      "indexByName": {},
+                      "renameByName": {
+                        "{__name__=\"system_memory_utilization_ratio\", agent_host_name=\"mk-win.internal.sentrysoftware.net\", connector_id=\"Linux\", host_id=\"mk-deb2\", host_name=\"mk-deb2.internal.sentrysoftware.net\", host_type=\"compute\", id=\"memory_usage\", os_type=\"linux\", site=\"Paris\", system_memory_limit=\"2063106048\", system_memory_usage=\"used\"}": "Used memory"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 120,
+          "links": [],
+          "title": "Memory Utilization",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds",
+                    "seriesBy": "last"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 41,
+                    "gradientMode": "scheme",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 0.75
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.9
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-121": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "max(rate(system_disk_io_time_seconds_total{host_name=\"$host_name\"}[$__rate_interval]))",
+                        "format": "time_series",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "Max Disk Time Utilization",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Utilization of the busiest disk, to identify disk contention",
+          "id": 121,
+          "links": [],
+          "title": "Max Disk Utilization",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-GrYlRd"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 50,
+                    "gradientMode": "scheme",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "stepBefore",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "io_wait": {
+                          "index": 0,
+                          "text": "IO Wait"
+                        },
+                        "nice": {
+                          "index": 3,
+                          "text": "Nice"
+                        },
+                        "system": {
+                          "index": 1,
+                          "text": "System"
+                        },
+                        "user": {
+                          "index": 2,
+                          "text": "User"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 0.6
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.8
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-124": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(delta(system_network_errors_total{host_name=\"$host_name\", network_io_direction=\"transmit\"}[$__range]))\r\n/\r\nsum (delta(system_network_packets_total{host_name=\"$host_name\", network_io_direction=\"transmit\"}[$__range]))",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 124,
+          "links": [],
+          "title": "Tx Errors",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 3,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "purple",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.000001
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-125": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(delta(system_network_errors_total{host_name=\"$host_name\", network_io_direction=\"receive\"}[$__range]))\r\n/\r\nsum (delta(system_network_packets_total{host_name=\"$host_name\", network_io_direction=\"receive\"}[$__range]))",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 125,
+          "links": [],
+          "title": "Rx Errors",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 3,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.000001
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-126": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(delta(system_network_dropped_total{host_name=\"$host_name\", network_io_direction=\"transmit\"}[$__range]))\r\n/\r\nsum (delta(system_network_packets_total{host_name=\"$host_name\", network_io_direction=\"transmit\"}[$__range]))",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 126,
+          "links": [],
+          "title": "Tx Dropped",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 3,
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "purple",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.000001
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-127": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(delta(system_network_dropped_total{host_name=\"$host_name\", network_io_direction=\"receive\"}[$__range]))\r\n/\r\nsum (delta(system_network_packets_total{host_name=\"$host_name\", network_io_direction=\"receive\"}[$__range]))",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 127,
+          "links": [],
+          "title": "Rx Dropped",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 3,
+                  "max": 100,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1e-7
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "value",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-128": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 128,
+          "links": [],
+          "title": "Dashboard",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "2026.2",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "light-green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-130": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "system_filesystem_usage_bytes{host_name=\"$host_name\", system_filesystem_state=\"free\", system_filesystem_type !~\"$filesystemFilter\"}",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Free"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "system_filesystem_usage_bytes{host_name=\"$host_name\", system_filesystem_state=\"used\", system_filesystem_type !~\"$filesystemFilter\"}",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Used & Reserved"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(system_filesystem_utilization_ratio{host_name=\"$host_name\",system_filesystem_state=~\"used|reserved\", system_filesystem_type !~\"$filesystemFilter\"}) by (system_device) - sum(system_filesystem_utilization_ratio{host_name=\"$host_name\",system_filesystem_state=~\"used|reserved\", system_filesystem_type !~\"$filesystemFilter\"} offset $__range) by (system_device) ",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Change"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(system_filesystem_utilization_ratio{host_name=\"$host_name\",system_filesystem_state=~\"used|reserved\", system_filesystem_type !~\"$filesystemFilter\"}) by (system_device)",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Usage"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(system_filesystem_usage_bytes{host_name=\"$host_name\",system_filesystem_state=~\"used|reserved|free\", system_filesystem_type !~\"$filesystemFilter\"}) by (system_device)",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(system_filesystem_utilization_ratio{host_name=\"$host_name\",system_filesystem_state=~\"used|reserved\", system_filesystem_type !~\"$filesystemFilter\"}) by (system_device)",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Main"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "delta(system_filesystem_usage_bytes{host_name=~\"$host_name\", system_filesystem_state=\"used\"}[$__range]) / $__range_s ",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "GrowthRate"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  system_filesystem_usage_bytes{host_name=~\"$host_name\", system_filesystem_state=\"free\"} \r\n  / ignoring(system_filesystem_state)\r\n  (delta(system_filesystem_usage_bytes{host_name=~\"$host_name\", system_filesystem_state=\"used\"}[$__range]) / $__range_s)\r\n) \r\nand ignoring(system_filesystem_state)\r\ndelta(system_filesystem_usage_bytes{host_name=~\"$host_name\", system_filesystem_state=\"used\"}[$__range]) > 0",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "TimeUntilSaturation"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "timeSeriesTable",
+                  "spec": {
+                    "id": "timeSeriesTable",
+                    "options": {
+                      "A": {
+                        "timeField": "Time"
+                      },
+                      "B": {
+                        "timeField": "Time"
+                      },
+                      "C": {
+                        "timeField": "Time"
+                      },
+                      "Capacity": {
+                        "timeField": "Time"
+                      },
+                      "Change": {
+                        "timeField": "Time"
+                      },
+                      "D": {
+                        "timeField": "Time"
+                      },
+                      "E": {
+                        "timeField": "Time"
+                      },
+                      "Free": {
+                        "timeField": "Time"
+                      },
+                      "Usage": {
+                        "timeField": "Time"
+                      },
+                      "Used & Reserved": {
+                        "timeField": "Time"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "system_device",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Capacity",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #Capacity"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Used & Reserved",
+                          "path": "value"
+                        }
+                      ],
+                      "keepTime": false,
+                      "replace": false,
+                      "source": "Trend #Used & Reserved"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Utilization",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #Usage"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Free",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #Free"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "Change",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #Change"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "GrowthRate",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #GrowthRate"
+                    }
+                  }
+                },
+                {
+                  "kind": "extractFields",
+                  "spec": {
+                    "id": "extractFields",
+                    "options": {
+                      "delimiter": ",",
+                      "format": "json",
+                      "jsonPaths": [
+                        {
+                          "alias": "TimeUntilSaturation",
+                          "path": "value"
+                        }
+                      ],
+                      "source": "Trend #TimeUntilSaturation"
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Capacity": false,
+                        "FreeAndUsedCapacity": true,
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Time 5": true,
+                        "Trend #A": true,
+                        "Trend #Capacity": true,
+                        "Trend #Change": true,
+                        "Trend #D": true,
+                        "Trend #Free": true,
+                        "Trend #GrowthRate": true,
+                        "Trend #TimeUntilSaturation": true,
+                        "Trend #Used & Reserved": true,
+                        "Value": true,
+                        "Value #B": false,
+                        "Value #C": false,
+                        "Value #E": true,
+                        "__name__": true,
+                        "__name__ 1": true,
+                        "__name__ 2": true,
+                        "__name__ 3": true,
+                        "agent_host_name": true,
+                        "agent_host_name 1": true,
+                        "agent_host_name 2": true,
+                        "agent_host_name 3": true,
+                        "agent_host_name 4": true,
+                        "connector_id": true,
+                        "connector_id 1": true,
+                        "connector_id 2": true,
+                        "connector_id 3": true,
+                        "connector_id 4": true,
+                        "host_id": true,
+                        "host_id 1": true,
+                        "host_id 2": true,
+                        "host_id 3": true,
+                        "host_name": true,
+                        "host_name 1": true,
+                        "host_name 2": true,
+                        "host_name 3": true,
+                        "host_name 4": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "host_type 3": true,
+                        "host_type 4": true,
+                        "id 1": true,
+                        "id 2": true,
+                        "id 3": true,
+                        "id 4": true,
+                        "name 1": true,
+                        "name 2": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "os_type 3": true,
+                        "os_type 4": true,
+                        "otel_scope_name 1": true,
+                        "otel_scope_name 2": true,
+                        "otel_scope_name 3": true,
+                        "otel_scope_name 4": true,
+                        "site": true,
+                        "site 1": true,
+                        "site 2": true,
+                        "site 3": true,
+                        "site 4": true,
+                        "system_device": false,
+                        "system_device 1": true,
+                        "system_device 2": true,
+                        "system_device 3": true,
+                        "system_filesystem_device": true,
+                        "system_filesystem_device 1": true,
+                        "system_filesystem_device 2": true,
+                        "system_filesystem_device 3": true,
+                        "system_filesystem_mode 1": true,
+                        "system_filesystem_mode 2": true,
+                        "system_filesystem_mode 3": true,
+                        "system_filesystem_mode 4": true,
+                        "system_filesystem_mountpoint 1": true,
+                        "system_filesystem_mountpoint 2": true,
+                        "system_filesystem_mountpoint 3": true,
+                        "system_filesystem_mountpoint 4": true,
+                        "system_filesystem_state": true,
+                        "system_filesystem_state 1": true,
+                        "system_filesystem_state 2": true,
+                        "system_filesystem_state 3": true,
+                        "system_filesystem_type 2": true,
+                        "system_filesystem_type 3": true,
+                        "system_filesystem_type 4": true,
+                        "system_filesystem_volumeName": true,
+                        "system_filesystem_volumeName 2": true,
+                        "system_filesystem_volumeName 3": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Capacity": 4,
+                        "Change": 6,
+                        "Free": 2,
+                        "GrowthRate": 7,
+                        "TimeUntilSaturation": 9,
+                        "Trend #Capacity": 12,
+                        "Trend #Change": 32,
+                        "Trend #Free": 10,
+                        "Trend #GrowthRate": 42,
+                        "Trend #TimeUntilSaturation": 55,
+                        "Trend #Usage": 8,
+                        "Trend #Used & Reserved": 29,
+                        "Used & Reserved": 3,
+                        "Utilization": 5,
+                        "__name__ 1": 11,
+                        "__name__ 2": 20,
+                        "agent_host_name 1": 13,
+                        "agent_host_name 2": 21,
+                        "agent_host_name 3": 33,
+                        "agent_host_name 4": 46,
+                        "connector_id 1": 14,
+                        "connector_id 2": 22,
+                        "connector_id 3": 34,
+                        "connector_id 4": 47,
+                        "host_name 1": 15,
+                        "host_name 2": 23,
+                        "host_name 3": 35,
+                        "host_name 4": 48,
+                        "host_type 1": 16,
+                        "host_type 2": 24,
+                        "host_type 3": 36,
+                        "host_type 4": 49,
+                        "id 1": 30,
+                        "id 2": 31,
+                        "id 3": 37,
+                        "id 4": 50,
+                        "os_type 1": 17,
+                        "os_type 2": 25,
+                        "os_type 3": 38,
+                        "os_type 4": 51,
+                        "site 1": 18,
+                        "site 2": 26,
+                        "site 3": 39,
+                        "site 4": 52,
+                        "system_device": 0,
+                        "system_filesystem_mountpoint 1": 43,
+                        "system_filesystem_mountpoint 2": 44,
+                        "system_filesystem_mountpoint 3": 45,
+                        "system_filesystem_mountpoint 4": 53,
+                        "system_filesystem_state 1": 19,
+                        "system_filesystem_state 2": 27,
+                        "system_filesystem_state 3": 40,
+                        "system_filesystem_type 1": 1,
+                        "system_filesystem_type 2": 28,
+                        "system_filesystem_type 3": 41,
+                        "system_filesystem_type 4": 54
+                      },
+                      "renameByName": {
+                        "Capacity": "Capacity",
+                        "Change": "Change",
+                        "Free": "Free",
+                        "GrowthRate": "Growth Rate",
+                        "Time 1": "",
+                        "Time 2": "",
+                        "Time 5": "",
+                        "TimeUntilSaturation": "Time Until Saturation",
+                        "Trend #A": "",
+                        "Trend #Capacity": "",
+                        "Trend #D": "",
+                        "Trend #Free": "",
+                        "Trend #TimeUntilSaturation": "",
+                        "Trend #Usage": "Trend",
+                        "Usage": "Usage",
+                        "Used & Reserved": "Used & Reserved",
+                        "Utilization": "Utilization",
+                        "Value": "",
+                        "Value #A": "Usage",
+                        "Value #B": "Free",
+                        "Value #C": "Used & Reserved",
+                        "Value #Capacity": "Capacity",
+                        "Value #D": "Change",
+                        "Value #F": "Capacity",
+                        "Value #Free": "Free",
+                        "Value #Used & Reserved": "Used & Reserved",
+                        "__name__ 1": "",
+                        "agent_host_name 4": "",
+                        "id": "Filesystem",
+                        "system_device": "Filesystem",
+                        "system_device 1": "",
+                        "system_filesystem_mountpoint": "Mountpoint",
+                        "system_filesystem_mountpoint 1": "Mountpoint",
+                        "system_filesystem_state 1": "",
+                        "system_filesystem_type": "Type",
+                        "system_filesystem_type 1": "Type",
+                        "system_filesystem_type 3": "",
+                        "system_filesystem_volumeName 1": "Name",
+                        "value": ""
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 130,
+          "links": [],
+          "title": "Filesystems",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Utilization"
+                    },
+                    "properties": [
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge",
+                          "valueDisplayMode": "color"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-GrYlRd"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Filesystem"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Change"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "custom.wrapText",
+                        "value": false
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "light-blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.01
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Type"
+                    },
+                    "properties": []
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "drawStyle": "line",
+                          "hideValue": true,
+                          "lineInterpolation": "linear",
+                          "type": "sparkline"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Mountpoint"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "light-blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Free"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "GrowthRate"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "binBps"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "light-blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "light-red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Time Until Saturation"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Capacity"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-131": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "system_paging_usage_bytes{host_name=\"$host_name\"}",
+                        "instant": true,
+                        "legendFormat": "{{system_paging_state}}",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 131,
+          "links": [],
+          "title": "Paging Utilization",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "free"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Free"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "used"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Used"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "cached"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "light-blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Cached"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "displayLabels": [
+                  "name",
+                  "value"
+                ],
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true,
+                  "values": [
+                    "percent"
+                  ]
+                },
+                "pieType": "donut",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-133": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "rate(system_paging_operations_total{host_name=\"$host_name\", system_paging_direction=\"out\"}[$__rate_interval])",
+                        "instant": false,
+                        "legendFormat": "Out",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "rate(system_paging_operations_total{host_name=\"$host_name\", system_paging_direction=\"in\"}[$__rate_interval])",
+                        "instant": false,
+                        "legendFormat": "In",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 133,
+          "links": [],
+          "title": "Paging Activity",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "red",
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": true,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 50,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "stepBefore",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "sishort"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "purple",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "A"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.transform",
+                        "value": "negative-Y"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": false,
+                  "sortBy": "Name",
+                  "sortDesc": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-134": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "rate(system_paging_faults_total{host_name=\"$host_name\", system_paging_type=\"minor\"}[$__rate_interval])",
+                        "legendFormat": "Minor",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Minor"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "rate(system_paging_faults_total{host_name=\"$host_name\", system_paging_type=\"major\"}[$__rate_interval])",
+                        "instant": false,
+                        "legendFormat": "Major",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Major"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 134,
+          "links": [],
+          "title": "Memory Faults",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "smooth",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "log": 2,
+                      "type": "log"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "sishort"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Minor"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "super-light-orange",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Major"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-135": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "max(max by (network_interface_name) (rate(system_network_io_bytes_total{host_name=\"$host_name\"}[$__rate_interval])\r\n) / max by (network_interface_name) (system_network_bandwidth_limit_bytes{host_name=\"$host_name\"}))",
+                        "instant": false,
+                        "legendFormat": "Max Network Utilization",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "20m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 135,
+          "links": [],
+          "title": "Max Network Utilization",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "red",
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": true,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 50,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 0.5
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.8
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": false,
+                  "sortBy": "Name",
+                  "sortDesc": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-138": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "ALERTS_FOR_STATE{host_name=~\"$host_name\", alertname=~\"MetricsHub-System-.*\"}",
+                        "format": "table",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": ""
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "include": {
+                        "names": [
+                          "Time",
+                          "alertname",
+                          "severity",
+                          "system_device",
+                          "__name__"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": false,
+                        "Value": false,
+                        "Value #A": true,
+                        "__name__": true,
+                        "agent_host_name": true,
+                        "alertstatus": true,
+                        "alertstatus_code": true,
+                        "applies_to_os": true,
+                        "array_name": true,
+                        "bandwidth": true,
+                        "battery_state": true,
+                        "blade_name": true,
+                        "chemistry": true,
+                        "compiled_file_name": true,
+                        "connector_id": true,
+                        "description": true,
+                        "device_id": true,
+                        "device_type": true,
+                        "display_name": true,
+                        "driver_version": true,
+                        "firmware_version": true,
+                        "fqdn": true,
+                        "host_id": true,
+                        "host_name": true,
+                        "host_type": true,
+                        "hw_type": false,
+                        "id": true,
+                        "identifying_information": true,
+                        "info": true,
+                        "instance": true,
+                        "job": true,
+                        "local_device_name": true,
+                        "location": true,
+                        "model": true,
+                        "name": false,
+                        "os_type": true,
+                        "parent": true,
+                        "physical_address": true,
+                        "power_supply_type": true,
+                        "raid_level": true,
+                        "robotic_type": true,
+                        "sensor_location": true,
+                        "serial_number": true,
+                        "severity": false,
+                        "site": true,
+                        "state": true,
+                        "type": true,
+                        "vendor": true,
+                        "wwn": true,
+                        "zone": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Time": 0,
+                        "Value": 13,
+                        "array_name": 20,
+                        "battery_state": 23,
+                        "device_id": 14,
+                        "driver_version": 27,
+                        "firmware_version": 28,
+                        "host_id": 7,
+                        "host_name": 8,
+                        "host_type": 9,
+                        "hw_type": 2,
+                        "id": 5,
+                        "info": 15,
+                        "local_device_name": 21,
+                        "location": 19,
+                        "model": 16,
+                        "name": 3,
+                        "os_type": 10,
+                        "parent": 6,
+                        "power_supply_type": 26,
+                        "protocol": 4,
+                        "robotic_type": 25,
+                        "sensor_location": 29,
+                        "serial_number": 24,
+                        "severity": 1,
+                        "site": 11,
+                        "state": 12,
+                        "type": 17,
+                        "vendor": 18,
+                        "wwn": 22
+                      },
+                      "renameByName": {
+                        "Time": "Time",
+                        "alertname": "Alert Name",
+                        "fqdn": "",
+                        "hw_type": "Device Type",
+                        "id": "",
+                        "label": "Label",
+                        "name": "Device Name",
+                        "protocol": "Protocol",
+                        "severity": "Severity",
+                        "system_device": "Device"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "Time"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 138,
+          "links": [],
+          "title": "System Alerts",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": true,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "noValue": "None",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Severity"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 109
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "critical": {
+                                "color": "red",
+                                "index": 1,
+                                "text": "Critical"
+                              },
+                              "warning": {
+                                "color": "orange",
+                                "index": 0,
+                                "text": "Warning"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "basic",
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Time"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dateTimeAsLocal"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 200
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Alert Name"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "MetricsHub-System-CPU-High-Utilization-Warning": {
+                                "index": 1,
+                                "text": "CPU: High utilization"
+                              },
+                              "MetricsHub-System-Filesystem-Filesystem-High-Utilization-Warning": {
+                                "index": 0,
+                                "text": "Filesystem: High utilization"
+                              },
+                              "MetricsHub-System-Filesystem-High-Utilization-Critical": {
+                                "index": 2,
+                                "text": "Filesystem: Critically high utilization"
+                              },
+                              "MetricsHub-System-Filesystem-High-Utilization-Warning": {
+                                "index": 10,
+                                "text": "Filesystem: High utilization"
+                              },
+                              "MetricsHub-System-Memory-High-Utilization-Warning": {
+                                "index": 3,
+                                "text": "Memory: High utilization"
+                              },
+                              "MetricsHub-System-Network-Bandwidth-High-Critical": {
+                                "index": 5,
+                                "text": "Network: High bandwidth utilization"
+                              },
+                              "MetricsHub-System-Network-Bandwidth-High-Warning": {
+                                "index": 4,
+                                "text": "Network: High bandwidth utilization"
+                              },
+                              "MetricsHub-System-Network-Errors-Warning": {
+                                "index": 6,
+                                "text": "Network: High number of errors"
+                              },
+                              "MetricsHub-System-Network-Packets-Dropped-Warning": {
+                                "index": 7,
+                                "text": "Network: High number of packet drops"
+                              },
+                              "MetricsHub-System-Page-Fault-Rate-Critical": {
+                                "index": 9,
+                                "text": "Critical page fault rate"
+                              },
+                              "MetricsHub-System-Page-Fault-Rate-Warning": {
+                                "index": 8,
+                                "text": "Elevated page fault rate"
+                              }
+                            },
+                            "type": "value"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "Time"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-17": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "system_memory_utilization_ratio{host_name=\"$host_name\", system_memory_state!=\"free\"}",
+                        "legendFormat": "{{system_memory_state}}",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 17,
+          "links": [],
+          "title": "Memory Utilization (Cumulated)",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds",
+                    "seriesBy": "last"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisGridShow": false,
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 41,
+                    "gradientMode": "scheme",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "normal"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 0.75
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.9
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "right",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "desc"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-25": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "system_memory_usage_bytes{host_name=\"$host_name\"}",
+                        "instant": true,
+                        "legendFormat": "{{system_memory_state}}",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 25,
+          "links": [],
+          "title": "Memory Usage",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "fixed"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "free"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Free"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "used"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Used"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "buffers"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "purple",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Buffers"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "cached"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "light-blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Cached"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "displayLabels": [
+                  "name",
+                  "value"
+                ],
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "right",
+                  "showLegend": true,
+                  "values": [
+                    "percent"
+                  ]
+                },
+                "pieType": "donut",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-35": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "timestamp(metricshub_agent_info{agent_host_name=\"$agent\"})",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Last Collect",
+                      "binary": {
+                        "left": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value"
+                          }
+                        },
+                        "operator": "*",
+                        "right": {
+                          "fixed": "1000"
+                        }
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "include": [
+                          "Value"
+                        ],
+                        "reducer": "stdDev"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "convertFieldType",
+                  "spec": {
+                    "id": "convertFieldType",
+                    "options": {
+                      "conversions": [
+                        {
+                          "dateFormat": "",
+                          "destinationType": "time",
+                          "targetField": "Last Collect"
+                        }
+                      ],
+                      "fields": {}
+                    }
+                  }
+                },
+                {
+                  "kind": "formatTime",
+                  "spec": {
+                    "id": "formatTime",
+                    "options": {
+                      "outputFormat": "MM-DD HH:mm:ss",
+                      "timeField": "Last Collect",
+                      "useTimezone": true
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Value": true,
+                        "__name__": true,
+                        "host_id": true,
+                        "host_name": true,
+                        "host_type": true,
+                        "job": true,
+                        "name": true,
+                        "otel_scope_name": true,
+                        "site": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Last Collect": 7,
+                        "Time": 9,
+                        "Value": 11,
+                        "agent_host_name": 1,
+                        "build_date": 4,
+                        "build_number": 5,
+                        "cc_version": 6,
+                        "host_name": 12,
+                        "host_type": 13,
+                        "job": 10,
+                        "name": 8,
+                        "os_type": 2,
+                        "service_name": 0,
+                        "site": 14,
+                        "version": 3
+                      },
+                      "renameByName": {
+                        "Last": "lasy",
+                        "agent_host_name": "Agent Host Name",
+                        "build_date": "Build Date",
+                        "build_number": "Build Number",
+                        "cc_version": "CC Version",
+                        "os_type": "OS",
+                        "service_name": "Service Name",
+                        "version": "Version"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 35,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": false,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "linux": {
+                          "index": 1,
+                          "text": "https://dl.sentrysoftware.com/public/linux-logo-mh.svg"
+                        },
+                        "windows": {
+                          "index": 0,
+                          "text": "https://dl.sentrysoftware.com/public/windows-logo-mh.svg"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "OS"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "image"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Version"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 100
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Build Number"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 120
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "CC Version"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 100
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-6": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (name) (irate(system_cpu_time_seconds_total{host_name=\"$host_name\", system_cpu_state!=\"idle\"}[1h]))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "{{name}}",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "name"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 6,
+          "links": [],
+          "title": "CPU Core Utilization (Instant)",
+          "vizConfig": {
+            "group": "gauge",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "#EAB839",
+                        "value": 0.8
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.95
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "minVizHeight": 75,
+                "minVizWidth": 75,
+                "orientation": "auto",
+                "reduceOptions": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "fields": "",
+                  "values": true
+                },
+                "showThresholdLabels": false,
+                "showThresholdMarkers": true,
+                "sizing": "auto"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-8": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum by (system_cpu_state) (delta(system_cpu_time_seconds_total{host_name=\"$host_name\"}[$__range]))",
+                        "format": "time_series",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 8,
+          "links": [],
+          "title": "CPU Time",
+          "vizConfig": {
+            "group": "piechart",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    }
+                  },
+                  "unit": "seconde"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "idle"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "Idle"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "system"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "red",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "System"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "user"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "orange",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "displayName",
+                        "value": "User"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "io_wait"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "IO Wait"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "nice"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Nice"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "displayLabels": [
+                  "name",
+                  "percent"
+                ],
+                "legend": {
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": false,
+                  "values": [
+                    "percent"
+                  ]
+                },
+                "pieType": "donut",
+                "reduceOptions": {
+                  "calcs": [
+                    "last"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "sort": "desc",
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-80": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(system_network_io_bytes_total{host_name=\"$host_name\", network_io_direction=\"transmit\"}[$__rate_interval]))",
+                        "instant": false,
+                        "legendFormat": "Transmitted",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(rate(system_network_io_bytes_total{host_name=\"$host_name\", network_io_direction=\"receive\"}[$__rate_interval]))",
+                        "instant": false,
+                        "legendFormat": "Received",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "B"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 80,
+          "links": [],
+          "title": "Network Total Traffic",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "red",
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": true,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 50,
+                    "gradientMode": "opacity",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "stepBefore",
+                    "lineWidth": 2,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "never",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "binBps"
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "A"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "purple",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.transform",
+                        "value": "negative-Y"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "legend": {
+                  "calcs": [
+                    "lastNotNull",
+                    "min",
+                    "max",
+                    "mean"
+                  ],
+                  "displayMode": "table",
+                  "placement": "bottom",
+                  "showLegend": true,
+                  "sortBy": "Name",
+                  "sortDesc": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "maxHeight": 600,
+                  "mode": "multi",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-86": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "metricshub_connector_status{host_name=\"$host_name\", connector_id=~\"Linux|Windows|Aix|HPUX\", state=\"ok\"}",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "Connector",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 86,
+          "links": [],
+          "title": "Connector",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "0": {
+                          "color": "red",
+                          "index": 1,
+                          "text": "Failed"
+                        },
+                        "1": {
+                          "color": "green",
+                          "index": 0,
+                          "text": "OK"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "center",
+                "orientation": "vertical",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": false
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-91": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(system_cpu_utilization_ratio{host_name=\"$host_name\", system_cpu_state=\"idle\"})",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "Connector",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 91,
+          "links": [],
+          "title": "CPU Cores",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "vertical",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-92": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "system_uptime_seconds{host_name=\"$host_name\"}",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "Connector",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 92,
+          "links": [],
+          "title": "Uptime",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "#62615b",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "s"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "vertical",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-93": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "system_memory_limit_bytes{host_name=\"$host_name\"}",
+                        "format": "time_series",
+                        "instant": true,
+                        "legendFormat": "Connector",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 93,
+          "links": [],
+          "title": "Memory",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "decimals": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "light-blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "vertical",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-96": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "topk(1, label_join(system_uptime_seconds{host_name=\"$host_name\"}, \"joined_os\", \" \", \"name\", \"version\", \"os_version\")) # Make sure only one result is returned",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "formatTime",
+                  "spec": {
+                    "id": "formatTime",
+                    "options": {
+                      "outputFormat": "MM-DD HH:mm:ss",
+                      "timeField": "Uptime",
+                      "timezone": "browser",
+                      "useTimezone": true
+                    }
+                  }
+                },
+                {
+                  "kind": "concatenate",
+                  "spec": {
+                    "id": "concatenate",
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Uptime": false,
+                        "Value": true,
+                        "__name__": true,
+                        "agent_host_name": true,
+                        "build_number": false,
+                        "connector_id": true,
+                        "host_id": true,
+                        "host_name": true,
+                        "host_type": true,
+                        "id": true,
+                        "name": true,
+                        "os_type": false,
+                        "os_version": true,
+                        "serial_number": true,
+                        "site": true,
+                        "version": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Time": 6,
+                        "Value": 13,
+                        "__name__": 7,
+                        "agent_host_name": 8,
+                        "connector_id": 9,
+                        "host_name": 2,
+                        "host_type": 10,
+                        "id": 11,
+                        "joined_os": 0,
+                        "name": 3,
+                        "os_type": 1,
+                        "os_version": 5,
+                        "site": 12,
+                        "version": 4
+                      },
+                      "renameByName": {
+                        "Value": "Uptime",
+                        "Value 2": "Uptime",
+                        "agent_host_name": "",
+                        "build_number": "Build Number",
+                        "count(system_cpu_utilization_ratio{host_name=\"hegel\", system_cpu_state=\"idle\"})": "CPU Core",
+                        "count(system_cpu_utilization_ratio{site=\"Sentry-Thésée\", host_name=\"dev-px-01\", system_cpu_state=\"idle\"})": "CPU Core",
+                        "count(system_cpu_utilization_ratio{site=\"Sentry-Thésée\", host_name=\"ecs2-01\", system_cpu_state=\"idle\"})": "CPU Core",
+                        "count(system_cpu_utilization_ratio{site=\"Sentry-Thésée\", host_name=\"scotus\", system_cpu_state=\"idle\"})": "CPU Core",
+                        "host_name": "",
+                        "joined_os": "Operating System",
+                        "name": "",
+                        "os_type": "OS",
+                        "os_version": "",
+                        "serial_number": "Serial Number",
+                        "site": "",
+                        "version": "",
+                        "{__name__=\"system_memory_limit_bytes\", agent_host_name=\"lab-win-01.internal.sentrysoftware.net\", connector_id=\"Linux\", host_id=\"dev-px-01\", host_name=\"dev-px-01\", host_type=\"compute\", id=\"memory_usage\", os_type=\"linux\", site=\"Sentry-Thésée\"}": "Memory",
+                        "{__name__=\"system_memory_limit_bytes\", agent_host_name=\"lab-win-01.internal.sentrysoftware.net\", connector_id=\"Linux\", host_id=\"ecs2-01-system\", host_name=\"ecs2-01\", host_type=\"compute\", id=\"memory_usage\", os_type=\"linux\", site=\"Sentry-Thésée\"}": "Memory",
+                        "{__name__=\"system_memory_limit_bytes\", agent_host_name=\"lab-win-01.internal.sentrysoftware.net\", connector_id=\"Linux\", host_id=\"hegel\", host_name=\"hegel\", host_type=\"compute\", id=\"memory_usage\", os_type=\"linux\", site=\"Sentry-Thésée\"}": "Memory",
+                        "{__name__=\"system_memory_limit_bytes\", agent_host_name=\"lab-win-01.internal.sentrysoftware.net\", connector_id=\"Windows\", host_id=\"scotus\", host_name=\"scotus\", host_type=\"compute\", id=\"memory_usage\", os_type=\"windows\", site=\"Sentry-Thésée\"}": "Memory"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 96,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "decimals": 0,
+                  "mappings": [
+                    {
+                      "options": {
+                        "aix": {
+                          "index": 2,
+                          "text": "https://dl.sentrysoftware.com/public/ibmaix-logo-mh.svg"
+                        },
+                        "hpux": {
+                          "index": 4,
+                          "text": "https://dl.sentrysoftware.com/public/hpux-logo-mh.svg"
+                        },
+                        "linux": {
+                          "index": 1,
+                          "text": "https://dl.sentrysoftware.com/public/linux-logo-mh.svg"
+                        },
+                        "windows": {
+                          "index": 0,
+                          "text": "https://dl.sentrysoftware.com/public/windows-logo-mh.svg"
+                        }
+                      },
+                      "type": "value"
+                    },
+                    {
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "index": 3,
+                          "text": "https://dl.sentrysoftware.com/public/unknown-logo-mh.svg"
+                        }
+                      },
+                      "type": "special"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "OS"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "image"
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 182
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": []
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-96"
+                        },
+                        "height": 3,
+                        "width": 10,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-138"
+                        },
+                        "height": 6,
+                        "width": 12,
+                        "x": 10,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-117"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 22,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-91"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 0,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-93"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 2,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-100"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 4,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-92"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 6,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-86"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 8,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-128"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 22,
+                        "y": 3
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Host Global Information"
+            }
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "Version"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 100
-              }
-            ]
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-114"
+                        },
+                        "height": 6,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Protocols"
+            }
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "Build Number"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 120
-              }
-            ]
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-119"
+                        },
+                        "height": 6,
+                        "width": 6,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-120"
+                        },
+                        "height": 6,
+                        "width": 6,
+                        "x": 6,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-121"
+                        },
+                        "height": 6,
+                        "width": 6,
+                        "x": 12,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-135"
+                        },
+                        "height": 6,
+                        "width": 6,
+                        "x": 18,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Performance Overview"
+            }
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "CC Version"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 100
-              }
-            ]
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-8"
+                        },
+                        "height": 8,
+                        "width": 5,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-6"
+                        },
+                        "height": 8,
+                        "width": 8,
+                        "x": 5,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-110"
+                        },
+                        "height": 8,
+                        "width": 11,
+                        "x": 13,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "CPU"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-25"
+                        },
+                        "height": 8,
+                        "width": 5,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-17"
+                        },
+                        "height": 8,
+                        "width": 8,
+                        "x": 5,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-134"
+                        },
+                        "height": 4,
+                        "width": 6,
+                        "x": 13,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-131"
+                        },
+                        "height": 8,
+                        "width": 5,
+                        "x": 19,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-133"
+                        },
+                        "height": 4,
+                        "width": 6,
+                        "x": 13,
+                        "y": 4
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Memory"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-130"
+                        },
+                        "height": 10,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Filesystems"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-80"
+                        },
+                        "height": 8,
+                        "width": 20,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-124"
+                        },
+                        "height": 4,
+                        "width": 2,
+                        "x": 20,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-126"
+                        },
+                        "height": 4,
+                        "width": 2,
+                        "x": 22,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-125"
+                        },
+                        "height": 4,
+                        "width": 2,
+                        "x": 20,
+                        "y": 4
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-127"
+                        },
+                        "height": 4,
+                        "width": 2,
+                        "x": 22,
+                        "y": 4
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Network Traffic - Total"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-106"
+                        },
+                        "height": 6,
+                        "repeat": {
+                          "direction": "h",
+                          "maxPerRow": 4,
+                          "mode": "variable",
+                          "value": "network_id"
+                        },
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Network Traffic - Individual"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-107"
+                        },
+                        "height": 5,
+                        "repeat": {
+                          "direction": "h",
+                          "maxPerRow": 4,
+                          "mode": "variable",
+                          "value": "physical_disk_system_device"
+                        },
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Disk Activity"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-35"
+                        },
+                        "height": 3,
+                        "repeat": {
+                          "direction": "h",
+                          "mode": "variable",
+                          "value": "agent"
+                        },
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "MetricsHub Agent Information"
+            }
           }
         ]
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 73
-      },
-      "id": 35,
-      "options": {
-        "cellHeight": "sm",
-        "showHeader": true
-      },
-      "pluginVersion": "12.3.2",
-      "repeat": "agent",
-      "repeatDirection": "h",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+      }
+    },
+    "links": [
+      {
+        "asDropdown": false,
+        "icon": "external link",
+        "includeVars": false,
+        "keepTime": false,
+        "tags": [
+          "System Overview"
+        ],
+        "targetBlank": false,
+        "title": "Systems - Overview",
+        "tooltip": "",
+        "type": "dashboards",
+        "url": ""
+      }
+    ],
+    "liveNow": true,
+    "preload": false,
+    "tags": [
+      "System",
+      "Otel",
+      "MetricsHub"
+    ],
+    "timeSettings": {
+      "autoRefresh": "30s",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "fiscalYearStartMonth": 0,
+      "from": "now-7d",
+      "hideTimepicker": false,
+      "timezone": "",
+      "to": "now"
+    },
+    "title": "System Performance Metrics (MetricsHub)",
+    "variables": [
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
           },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "timestamp(metricshub_agent_info{agent_host_name=\"$agent\"})",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A"
+          "definition": "label_values(system_uptime_seconds,os_type)",
+          "hide": "dontHide",
+          "includeAll": true,
+          "label": "System",
+          "multi": true,
+          "name": "system",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(system_uptime_seconds,os_type)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
         }
-      ],
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Last Collect",
-            "binary": {
-              "left": {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Value"
-                }
-              },
-              "operator": "*",
-              "right": {
-                "fixed": "1000"
-              }
+      },
+      {
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(system_network_io_bytes_total{host_name=\"$host_name\"},id)",
+          "description": "",
+          "hide": "hideVariable",
+          "includeAll": true,
+          "multi": true,
+          "name": "network_id",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(system_network_io_bytes_total{host_name=\"$host_name\"},id)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
-            "mode": "binary",
-            "reduce": {
-              "include": [
-                "Value"
-              ],
-              "reducer": "stdDev"
-            }
-          }
-        },
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
-              {
-                "dateFormat": "",
-                "destinationType": "time",
-                "targetField": "Last Collect"
-              }
-            ],
-            "fields": {}
-          }
-        },
-        {
-          "id": "formatTime",
-          "options": {
-            "outputFormat": "MM-DD HH:mm:ss",
-            "timeField": "Last Collect",
-            "useTimezone": true
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Value": true,
-              "__name__": true,
-              "host_id": true,
-              "host_name": true,
-              "host_type": true,
-              "job": true,
-              "name": true,
-              "site": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Last Collect": 7,
-              "Time": 9,
-              "Value": 11,
-              "agent_host_name": 1,
-              "build_date": 4,
-              "build_number": 5,
-              "cc_version": 6,
-              "host_name": 12,
-              "host_type": 13,
-              "job": 10,
-              "name": 8,
-              "os_type": 2,
-              "service_name": 0,
-              "site": 14,
-              "version": 3
-            },
-            "renameByName": {
-              "Last": "lasy",
-              "agent_host_name": "Agent Host Name",
-              "build_date": "Build Date",
-              "build_number": "Build Number",
-              "cc_version": "CC Version",
-              "os_type": "OS",
-              "service_name": "Service Name",
-              "version": "Version"
-            }
-          }
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "alphabeticalAsc"
         }
-      ],
-      "type": "table"
-    }
-  ],
-  "preload": false,
-  "refresh": "30s",
-  "schemaVersion": 42,
-  "tags": [
-    "System",
-    "Otel",
-    "MetricsHub"
-  ],
-  "templating": {
-    "list": [
-      {
-        "allowCustomValue": false,
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(system_uptime_seconds,os_type)",
-        "includeAll": true,
-        "label": "System",
-        "multi": true,
-        "name": "system",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(system_uptime_seconds,os_type)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "type": "query"
       },
       {
-        "allowCustomValue": false,
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(system_network_io_bytes_total{host_name=\"$host_name\"},id)",
-        "description": "",
-        "hide": 2,
-        "includeAll": true,
-        "multi": true,
-        "name": "network_id",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(system_network_io_bytes_total{host_name=\"$host_name\"},id)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "sort": 1,
-        "type": "query"
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(system_disk_io_bytes_total{host_name=\"$host_name\"},system_device)",
+          "description": "",
+          "hide": "hideVariable",
+          "includeAll": true,
+          "multi": true,
+          "name": "physical_disk_system_device",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(system_disk_io_bytes_total{host_name=\"$host_name\"},system_device)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onTimeRangeChanged",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "alphabeticalAsc"
+        }
       },
       {
-        "allowCustomValue": false,
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(system_disk_io_bytes_total{host_name=\"$host_name\"},system_device)",
-        "description": "",
-        "hide": 2,
-        "includeAll": true,
-        "multi": true,
-        "name": "physical_disk_system_device",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(system_disk_io_bytes_total{host_name=\"$host_name\"},system_device)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 2,
-        "regex": "",
-        "sort": 1,
-        "type": "query"
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(system_uptime_seconds{os_type=~\"$system\"},host_name)",
+          "description": "Name of the monitored host",
+          "hide": "dontHide",
+          "includeAll": false,
+          "label": "Hostname",
+          "multi": false,
+          "name": "host_name",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(system_uptime_seconds{os_type=~\"$system\"},host_name)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "alphabeticalAsc"
+        }
       },
       {
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(system_uptime_seconds{os_type=~\"$system\"},host_name)",
-        "description": "Name of the monitored host",
-        "includeAll": false,
-        "label": "Hostname",
-        "name": "host_name",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(system_uptime_seconds{os_type=~\"$system\"},host_name)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "sort": 1,
-        "type": "query"
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(system_uptime_seconds{host_name=\"$host_name\"},agent_host_name)",
+          "description": "",
+          "hide": "hideVariable",
+          "includeAll": false,
+          "label": "agent",
+          "multi": false,
+          "name": "agent",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(system_uptime_seconds{host_name=\"$host_name\"},agent_host_name)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": ".*",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
       },
       {
-        "allowCustomValue": false,
-        "current": {},
-        "datasource": {
-          "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
-        },
-        "definition": "label_values(system_uptime_seconds{host_name=\"$host_name\"},agent_host_name)",
-        "description": "",
-        "hide": 2,
-        "label": "agent",
-        "name": "agent",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(system_uptime_seconds{host_name=\"$host_name\"},agent_host_name)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": ".*",
-        "type": "query"
-      },
-      {
-        "current": {
-          "text": ".*tmpfs|nfs.*|overlay",
-          "value": ".*tmpfs|nfs.*|overlay"
-        },
-        "description": "Excludes all filesystems whose type matches the specified regular expression",
-        "label": "Exclude Filesystem Types",
-        "name": "filesystemFilter",
-        "options": [
-          {
-            "selected": true,
+        "kind": "TextVariable",
+        "spec": {
+          "current": {
             "text": ".*tmpfs|nfs.*|overlay",
             "value": ".*tmpfs|nfs.*|overlay"
-          }
-        ],
-        "query": ".*tmpfs|nfs.*|overlay",
-        "type": "textbox"
+          },
+          "description": "Excludes all filesystems whose type matches the specified regular expression",
+          "hide": "dontHide",
+          "label": "Exclude Filesystem Types",
+          "name": "filesystemFilter",
+          "query": ".*tmpfs|nfs.*|overlay",
+          "skipUrlSync": false
+        }
       }
     ]
   },
-  "time": {
-    "from": "now-30d",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "",
-  "title": "System Performance Metrics (MetricsHub)",
-  "uid": "eWQoMUTIk",
-  "version": 695,
-  "weekStart": "",
-  "id": null
+  "status": {}
 }

--- a/src/dashboards/System/System Performance Metrics - Overview (MetricsHub).json
+++ b/src/dashboards/System/System Performance Metrics - Overview (MetricsHub).json
@@ -1,4031 +1,4766 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "alertlist",
-      "name": "Alert list",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "bargauge",
-      "name": "Bar gauge",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "12.3.2"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "text",
-      "name": "Text",
-      "version": ""
-    }
-  ],
-  "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "grafana",
-          "uid": "-- Grafana --"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "target": {
-          "limit": 100,
-          "matchAny": false,
-          "tags": [],
-          "type": "dashboard"
-        },
-        "type": "dashboard"
-      }
-    ]
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "addp7fx",
+    "generation": 4,
+    "creationTimestamp": "2026-04-22T14:34:35Z",
+    "labels": {},
+    "annotations": {}
   },
-  "description": "General OS performance metrics to assess the availability and performance of Linux and Windows systems. Leverages OpenTelemetry metrics collected with MetricsHub and stored in Prometheus.",
-  "editable": true,
-  "fiscalYearStartMonth": 0,
-  "graphTooltip": 1,
-  "id": null,
-  "links": [],
-  "liveNow": true,
-  "panels": [
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 54,
-      "panels": [],
-      "title": "Overview & Current Issues",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "query": {
+            "group": "grafana",
+            "kind": "DataQuery",
+            "spec": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "version": "v0"
           }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 1
-      },
-      "id": 139,
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(ALERTS_FOR_STATE{severity=\"critical\", alertname=~\"MetricsHub-System-.*\"})",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "Critical Alerts",
-          "range": true,
-          "refId": "A"
         }
-      ],
-      "title": "Critical Alerts",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
+      }
+    ],
+    "cursorSync": "Crosshair",
+    "description": "General OS performance metrics to assess the availability and performance of Linux and Windows systems. Leverages OpenTelemetry metrics collected with MetricsHub and stored in Prometheus.",
+    "editable": true,
+    "elements": {
+      "panel-117": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
           },
-          "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "decimals": 1,
+          "description": "",
+          "id": 117,
           "links": [
             {
-              "title": "Host",
-              "url": "d/eWQoMUTIk/system-performance-metrics-metricshub?orgId=1&var-host_name=${__data.fields.Hostname}"
+              "title": "Hardware Sentry OpenTelemetry Collector",
+              "url": "https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html"
             }
           ],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
+          "title": "",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "<a href=\"https://metricshub.com/\" target=\"_blank\">\n  <div style=\"\n    display: block;\n    margin: 0 auto; \n    \n    background: transparent url(https://metricshub.com/images/logo-darkgrey.svg) no-repeat center center;\n    background-size: contain;\n    \n    width: 85px;   \n    height: 85px;\n    border-radius: 3px;\n  \">\n  </div>\n</a>",
+                "mode": "html"
               }
-            ]
+            },
+            "version": "12.3.2"
           }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Hostname"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byType",
-              "options": "number"
-            },
-            "properties": [
-              {
-                "id": "decimals",
-                "value": 0
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Critical Alerts"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "color"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 1
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Warnings"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "color"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "orange",
-                      "value": 1
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Failed Protocols"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "color"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 1
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Operating System"
-            },
-            "properties": [
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "aix": {
-                        "index": 2,
-                        "text": "https://dl.sentrysoftware.com/public/ibmaix-logo-mh.svg"
-                      },
-                      "hpux": {
-                        "index": 4,
-                        "text": "https://dl.sentrysoftware.com/public/hpux-logo-mh.svg"
-                      },
-                      "linux": {
-                        "index": 1,
-                        "text": "https://dl.sentrysoftware.com/public/linux-logo-mh.svg"
-                      },
-                      "windows": {
-                        "index": 0,
-                        "text": "https://dl.sentrysoftware.com/public/windows-logo-mh.svg"
-                      }
-                    },
-                    "type": "value"
-                  },
-                  {
-                    "options": {
-                      "match": "null",
-                      "result": {
-                        "index": 3,
-                        "text": "https://dl.sentrysoftware.com/public/unknown-logo-mh.svg"
-                      }
-                    },
-                    "type": "special"
-                  }
-                ]
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "alt": "",
-                  "type": "image"
-                }
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 9,
-        "w": 11,
-        "x": 3,
-        "y": 1
-      },
-      "id": 148,
-      "options": {
-        "cellHeight": "sm",
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Critical Alerts"
-          }
-        ]
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(count by (host_name) (metricshub_host_up{os_type=~\"$system\"} == 0)) \r\nor \r\n(count by (host_name) (metricshub_host_up{os_type=~\"$system\"}) * 0)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "ProtocolErrors",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          }
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(\r\n  count(ALERTS_FOR_STATE{severity=\"critical\", alertname=~\"MetricsHub-System-.*\"}) by (host_name)\r\n  or \r\n  (0 * count by (host_name) (system_uptime_seconds)) # This is used to make sure a column is always created\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "CriticalAlerts"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(\r\n  count(ALERTS_FOR_STATE{severity=\"warning\", alertname=~\"MetricsHub-System-.*\"}) by (host_name)\r\n  or \r\n  (0 * count by (host_name) (system_uptime_seconds)) # This is used to make sure a column is always created\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Warnings"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "system_uptime_seconds",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "OperatingSystem"
         }
-      ],
-      "title": "Current Issues",
-      "transformations": [
-        {
-          "id": "joinByField",
-          "options": {
-            "byField": "host_name",
-            "mode": "outer"
-          }
-        },
-        {
-          "id": "filterByValue",
-          "options": {
-            "filters": [
-              {
-                "config": {
-                  "id": "greater",
-                  "options": {
-                    "value": 0
+      },
+      "panel-128": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "expr": "",
+                        "instant": false,
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 128,
+          "links": [],
+          "title": "Dashboard",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "2026.2",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "light-green",
+                        "value": 0
+                      }
+                    ]
                   }
                 },
-                "fieldName": "Value #ProtocolErrors"
+                "overrides": []
               },
-              {
-                "config": {
-                  "id": "greater",
-                  "options": {
-                    "value": 0
-                  }
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
                 },
-                "fieldName": "Value #CriticalAlerts"
-              },
-              {
-                "config": {
-                  "id": "greater",
-                  "options": {
-                    "value": 0
-                  }
-                },
-                "fieldName": "Value #Warnings"
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
               }
-            ],
-            "match": "any",
-            "type": "include"
+            },
+            "version": "12.3.2"
           }
-        },
-        {
-          "id": "filterFieldsByName",
-          "options": {
-            "byVariable": false,
-            "include": {
-              "names": [
-                "host_name",
-                "Value #ProtocolErrors",
-                "Value #CriticalAlerts",
-                "Value #Warnings",
-                "os_type",
-                "site"
+        }
+      },
+      "panel-139": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(ALERTS_FOR_STATE{severity=\"critical\", alertname=~\"MetricsHub-System-.*\"})",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "Critical Alerts",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 100
+              },
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 139,
+          "links": [],
+          "title": "Critical Alerts",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-140": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(ALERTS_FOR_STATE{severity=\"warning\", alertname=~\"MetricsHub-System-.*\"})",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "Warning Alerts",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "maxDataPoints": 100
+              },
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 140,
+          "links": [],
+          "title": "Warnings",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-141": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(count by (host_name) (system_uptime_seconds))",
+                        "instant": true,
+                        "interval": "",
+                        "legendFormat": "Hosts"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "2m"
+              },
+              "transformations": []
+            }
+          },
+          "description": "Total number of monitored hosts.",
+          "id": 141,
+          "links": [],
+          "title": "Hosts",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "blue",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "none",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-143": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_join(\r\n     sum(system_filesystem_utilization_ratio{system_filesystem_state=~\"used|reserved\"}) by (site, host_name, system_device),\r\n     \"id\", \":\", \"host_name\", \"system_device\"\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "UtilizationRatio"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_join(\r\n    sum(system_filesystem_usage_bytes{system_filesystem_state=~\"used|reserved|free\"}) by (site, host_name, system_device),\r\n    \"id\", \":\", \"host_name\", \"system_device\"\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Capacity"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_join(\r\n    sum by (site, host_name, system_device) (\r\n        system_filesystem_usage_bytes{system_filesystem_state=~\"free\"}),\r\n    \"id\", \":\", \"host_name\", \"system_device\"\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Free"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_join(\r\n  sum by (site, host_name, system_device) (\r\n    system_filesystem_utilization_ratio{system_filesystem_state=~\"used|reserved\", system_filesystem_type!~\"$filesystemFilter\"}),\r\n  \"id\", \":\", \"host_name\", \"system_device\"\r\n)\r\n-\r\nlabel_join(\r\n  sum by (site, host_name, system_device) (\r\n    system_filesystem_utilization_ratio{system_filesystem_state=~\"used|reserved\", system_filesystem_type!~\"$filesystemFilter\"} offset $__range\r\n  ),\r\n  \"id\", \":\", \"host_name\", \"system_device\"\r\n)\r\n",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Change"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "label_join(\r\n     sum by (site, host_name, system_device) (\r\n           system_filesystem_utilization_ratio{system_filesystem_state=~\"used|reserved\", system_filesystem_type !~\"$filesystemFilter\"}\r\n     ),\r\n     \"id\", \":\", \"host_name\", \"system_device\"\r\n)",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Usage"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_join(\r\n     sum by (site, host_name, system_device) (\r\n            delta(system_filesystem_usage_bytes{system_filesystem_state=\"used\"}[$__range]) / $__range_s \r\n            ),\r\n     \"id\", \":\", \"host_name\", \"system_device\"\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "GrowthRate"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "label_join(\r\n  (\r\n    sum by (site, host_name, system_device) (\r\n      system_filesystem_usage_bytes{system_filesystem_state=\"free\"}\r\n    )\r\n    / ignoring(system_filesystem_state)\r\n    sum by (site, host_name, system_device) (\r\n      delta(system_filesystem_usage_bytes{system_filesystem_state=\"used\"}[$__range]) / $__range_s\r\n    )\r\n  ) \r\n  and ignoring(system_filesystem_state)\r\n  sum by (site, host_name, system_device) (\r\n    delta(system_filesystem_usage_bytes{system_filesystem_state=\"used\"}[$__range])\r\n  ) > 0,\r\n  \"id\", \":\", \"host_name\", \"system_device\"\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "TimeUntilSaturation"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "timeSeriesTable",
+                  "spec": {
+                    "id": "timeSeriesTable",
+                    "options": {
+                      "B": {
+                        "timeField": "Time"
+                      },
+                      "Usage": {
+                        "timeField": "Time"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "id",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "desc": true,
+                          "field": "Value #UtilizationRatio"
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "kind": "limit",
+                  "spec": {
+                    "id": "limit",
+                    "options": {
+                      "limitField": "5"
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Capacity": false,
+                        "FreeAndUsedCapacity": true,
+                        "Time": true,
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Time 5": true,
+                        "Time 6": true,
+                        "Trend #A": true,
+                        "Trend #Capacity": true,
+                        "Trend #Change": true,
+                        "Trend #D": true,
+                        "Trend #Free": true,
+                        "Trend #Used & Reserved": true,
+                        "Value": true,
+                        "Value #B": false,
+                        "Value #C": false,
+                        "Value #E": true,
+                        "__name__": true,
+                        "__name__ 1": true,
+                        "__name__ 2": true,
+                        "__name__ 3": true,
+                        "agent_host_name": true,
+                        "agent_host_name 1": true,
+                        "agent_host_name 2": true,
+                        "agent_host_name 3": true,
+                        "connector_id": true,
+                        "connector_id 1": true,
+                        "connector_id 2": true,
+                        "connector_id 3": true,
+                        "host_id": true,
+                        "host_id 1": true,
+                        "host_id 2": true,
+                        "host_id 3": true,
+                        "host_name": false,
+                        "host_name 1": false,
+                        "host_name 2": true,
+                        "host_name 3": true,
+                        "host_name 4": true,
+                        "host_name 5": true,
+                        "host_name 6": true,
+                        "host_name 7": true,
+                        "host_type": true,
+                        "host_type 1": true,
+                        "host_type 2": true,
+                        "host_type 3": true,
+                        "id": true,
+                        "id 1": true,
+                        "id 2": true,
+                        "name 1": true,
+                        "name 2": true,
+                        "os_type": true,
+                        "os_type 1": true,
+                        "os_type 2": true,
+                        "os_type 3": true,
+                        "site": true,
+                        "site 1": false,
+                        "site 2": true,
+                        "site 3": true,
+                        "site 4": true,
+                        "site 5": true,
+                        "site 6": true,
+                        "site 7": true,
+                        "system_device": false,
+                        "system_device 1": false,
+                        "system_device 2": true,
+                        "system_device 3": true,
+                        "system_device 4": true,
+                        "system_device 5": true,
+                        "system_device 6": true,
+                        "system_device 7": true,
+                        "system_filesystem_device": true,
+                        "system_filesystem_device 1": true,
+                        "system_filesystem_device 2": true,
+                        "system_filesystem_device 3": true,
+                        "system_filesystem_mountpoint 2": true,
+                        "system_filesystem_mountpoint 3": true,
+                        "system_filesystem_state": true,
+                        "system_filesystem_state 1": true,
+                        "system_filesystem_state 2": true,
+                        "system_filesystem_state 3": true,
+                        "system_filesystem_type 2": true,
+                        "system_filesystem_type 3": true,
+                        "system_filesystem_volumeName": true,
+                        "system_filesystem_volumeName 2": true,
+                        "system_filesystem_volumeName 3": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Time 1": 10,
+                        "Time 2": 11,
+                        "Time 3": 15,
+                        "Time 4": 18,
+                        "Time 5": 27,
+                        "Time 6": 31,
+                        "Trend #Usage": 8,
+                        "Value #Capacity": 4,
+                        "Value #Change": 6,
+                        "Value #Free": 3,
+                        "Value #GrowthRate": 7,
+                        "Value #TimeUntilSaturation": 9,
+                        "Value #UtilizationRatio": 5,
+                        "host_name 1": 1,
+                        "host_name 2": 12,
+                        "host_name 3": 16,
+                        "host_name 4": 19,
+                        "host_name 5": 24,
+                        "host_name 6": 28,
+                        "host_name 7": 32,
+                        "id": 13,
+                        "site 1": 0,
+                        "site 2": 21,
+                        "site 3": 22,
+                        "site 4": 23,
+                        "site 5": 25,
+                        "site 6": 29,
+                        "site 7": 33,
+                        "system_device 1": 2,
+                        "system_device 2": 14,
+                        "system_device 3": 17,
+                        "system_device 4": 20,
+                        "system_device 5": 26,
+                        "system_device 6": 30,
+                        "system_device 7": 34
+                      },
+                      "renameByName": {
+                        "Capacity": "Capacity",
+                        "Change": "Change",
+                        "Free": "Free",
+                        "Time 1": "",
+                        "Time 2": "",
+                        "Time 5": "",
+                        "Trend #A": "",
+                        "Trend #Capacity": "",
+                        "Trend #D": "",
+                        "Trend #Free": "",
+                        "Trend #Usage": "Trend",
+                        "Usage": "Usage",
+                        "Used & Reserved": "Used & Reserved",
+                        "Utilization": "Utilization",
+                        "Value": "",
+                        "Value #A": "Usage",
+                        "Value #B": "Free",
+                        "Value #C": "Used & Reserved",
+                        "Value #Capacity": "Capacity",
+                        "Value #Change": "Change",
+                        "Value #D": "Change",
+                        "Value #F": "Capacity",
+                        "Value #Free": "Free",
+                        "Value #GrowthRate": "Growth Rate",
+                        "Value #TimeUntilSaturation": "Time Until Saturation",
+                        "Value #Used & Reserved": "Used & Reserved",
+                        "Value #UtilizationRatio": "Utilization",
+                        "__name__ 1": "",
+                        "connector_id 1": "",
+                        "host_name 1": "Hostname",
+                        "id": "",
+                        "site 1": "Site",
+                        "system_device": "Filesystem",
+                        "system_device 1": "Filesystem",
+                        "system_filesystem_mountpoint": "Mountpoint",
+                        "system_filesystem_mountpoint 1": "Mountpoint",
+                        "system_filesystem_state 1": "",
+                        "system_filesystem_type": "Type",
+                        "system_filesystem_type 1": "Type",
+                        "system_filesystem_type 3": "",
+                        "system_filesystem_volumeName 1": "Name",
+                        "value": ""
+                      }
+                    }
+                  }
+                }
               ]
             }
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time 1": true,
-              "__name__ 1": true,
-              "agent_host_name 1": true,
-              "host_type 1": true,
-              "site": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Value #CriticalAlerts": 3,
-              "Value #ProtocolErrors": 5,
-              "Value #Warnings": 4,
-              "host_name": 1,
-              "os_type": 2,
-              "site": 0
-            },
-            "renameByName": {
-              "Value #CriticalAlerts": "Critical Alerts",
-              "Value #ProtocolErrors": "Failed Protocols",
-              "Value #Warnings": "Warnings",
-              "host_name": "Hostname",
-              "os_type": "Operating System",
-              "site": "Site"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "field": "Critical Alerts"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Total number of monitored hosts.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "fixed"
           },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "blue",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 14,
-        "y": 1
-      },
-      "id": 141,
-      "interval": "2m",
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(count by (host_name) (system_uptime_seconds))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "Hosts",
-          "refId": "A"
-        }
-      ],
-      "title": "Hosts",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Number of Hosts with at least one warning, one critical alert or one protocol down.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "orange",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "none"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 16,
-        "y": 1
-      },
-      "id": 149,
-      "interval": "5min",
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(\r\n  group by (host_name) (\r\n    (metricshub_host_up{os_type=~\"$system\"} == 0) or \r\n    (ALERTS_FOR_STATE{severity=\"critical\", alertname=~\"MetricsHub-System-.*\"}) or \r\n    (ALERTS_FOR_STATE{severity=\"warning\", alertname=~\"MetricsHub-System-.*\"})\r\n   )\r\n)   ",
-          "format": "time_series",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          }
-        }
-      ],
-      "title": "Unhealthy Hosts",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Percentage of Hosts with at least one warning, one critical alert or one protocol down.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "orange",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "percent"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 19,
-        "y": 1
-      },
-      "id": 147,
-      "interval": "5min",
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "100 * (\r\n  count(\r\n    group by (host_name) (\r\n      (metricshub_host_up{os_type=~\"$system\"} == 0) or \r\n      (ALERTS_FOR_STATE{severity=\"critical\", alertname=~\"MetricsHub-System-.*\"}) or \r\n      (ALERTS_FOR_STATE{severity=\"warning\", alertname=~\"MetricsHub-System-.*\"})\r\n    )\r\n  ) \r\n  / \r\n  count(count by (host_name) (system_uptime_seconds))\r\n)",
-          "format": "time_series",
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          }
-        }
-      ],
-      "title": "Unhealthy Hosts (%)",
-      "type": "stat"
-    },
-    {
-      "gridPos": {
-        "h": 3,
-        "w": 2,
-        "x": 22,
-        "y": 1
-      },
-      "id": 117,
-      "links": [
-        {
-          "title": "Hardware Sentry OpenTelemetry Collector",
-          "url": "https://www.sentrysoftware.com/products/hardware-sentry-opentelemetry-collector.html"
-        }
-      ],
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "<a href=\"https://metricshub.com/\" target=\"_blank\">\n  <div style=\"\n    display: block;\n    margin: 0 auto; \n    \n    background: transparent url(https://metricshub.com/images/logo-darkgrey.svg) no-repeat center center;\n    background-size: contain;\n    \n    width: 85px;   \n    height: 85px;\n    border-radius: 3px;\n  \">\n  </div>\n</a>",
-        "mode": "html"
-      },
-      "pluginVersion": "12.3.2",
-      "type": "text"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
+          "description": "",
+          "id": 143,
           "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent",
-                "value": 0
-              },
-              {
-                "color": "orange",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 4
-      },
-      "id": 140,
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(ALERTS_FOR_STATE{severity=\"warning\", alertname=~\"MetricsHub-System-.*\"})",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "Warning Alerts",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Warnings",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "decimals": 0,
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Hosts Count"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "unit",
-                "value": "none"
-              },
-              {
-                "id": "noValue",
-                "value": "0"
-              },
-              {
-                "id": "custom.width",
-                "value": 122
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Host Count (%)"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "decimals",
-                "value": 1
-              },
-              {
-                "id": "noValue",
-                "value": "0"
-              },
-              {
-                "id": "unit",
-                "value": "percent"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge",
-                  "valueDisplayMode": "text"
-                }
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "light-blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Unhealthy Hosts"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              },
-              {
-                "id": "noValue",
-                "value": "0"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Unhealthy Hosts %"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "percent"
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "noValue",
-                "value": "0"
-              },
-              {
-                "id": "decimals",
-                "value": 1
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge",
-                  "valueDisplayMode": "text"
-                }
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "#EAB839",
-                      "value": 1
-                    },
-                    {
-                      "color": "red",
-                      "value": 50
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "System"
-            },
-            "properties": [
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "aix": {
-                        "index": 2,
-                        "text": "https://dl.sentrysoftware.com/public/ibmaix-logo-mh.svg"
-                      },
-                      "hpux": {
-                        "index": 4,
-                        "text": "https://dl.sentrysoftware.com/public/hpux-logo-mh.svg"
-                      },
-                      "linux": {
-                        "index": 0,
-                        "text": "https://dl.sentrysoftware.com/public/linux-logo-mh.svg"
-                      },
-                      "windows": {
-                        "index": 1,
-                        "text": "https://dl.sentrysoftware.com/public/windows-logo-mh.svg"
-                      }
-                    },
-                    "type": "value"
+          "title": "Filesystems - Top 5 Utilization",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
                   },
-                  {
-                    "options": {
-                      "match": "null",
-                      "result": {
-                        "index": 3,
-                        "text": "https://dl.sentrysoftware.com/public/unknown-logo-mh.svg"
-                      }
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
                     },
-                    "type": "special"
-                  }
-                ]
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "image"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "System"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 6,
-        "w": 10,
-        "x": 14,
-        "y": 4
-      },
-      "id": 150,
-      "options": {
-        "cellHeight": "sm",
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": false,
-            "displayName": "System"
-          }
-        ]
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "100 * (\r\n  count by (os_type) (\r\n    group by (host_name, os_type) (\r\n      (metricshub_host_up{os_type=~\"$system\"} == 0) or \r\n      ((ALERTS_FOR_STATE{severity=~\"critical|warning\", alertname=~\"MetricsHub-System-.*\"}) \r\n       * on(host_name) group_left(os_type) \r\n       (group by (host_name, os_type) (system_uptime_seconds{os_type=~\"$system\"})))\r\n    )\r\n  ) \r\n  / \r\n  count by (os_type) (count by (host_name, os_type) (system_uptime_seconds{os_type=~\"$system\"}))\r\n)",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "UnhealthyHostsPctByOs",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          }
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count by (os_type) (system_uptime_seconds)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "OsList"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "100 * count by (os_type) (group by (host_name, os_type) (system_uptime_seconds)) / scalar(count(count by (host_name) (system_uptime_seconds)))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "HostCountPctByOs"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count by (os_type) (group by (host_name, os_type) (system_uptime_seconds))",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "HostCountByOS"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count by (os_type) (\r\n    group by (host_name, os_type) (\r\n      (metricshub_host_up{os_type=~\"$system\"} == 0) or \r\n      ((ALERTS_FOR_STATE{severity=~\"critical|warning\", alertname=~\"MetricsHub-System-.*\"}) \r\n       * on(host_name) group_left(os_type) \r\n       (group by (host_name, os_type) (metricshub_host_up{os_type=~\"$system\"})))\r\n    )\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "UnhealthyHostsByOs"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "joinByField",
-          "options": {
-            "byField": "os_type",
-            "mode": "outer"
-          }
-        },
-        {
-          "disabled": true,
-          "id": "filterByValue",
-          "options": {
-            "filters": [
-              {
-                "config": {
-                  "id": "regex",
-                  "options": {
-                    "value": "^$"
-                  }
+                    "filterable": false,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "links": [
+                    {
+                      "title": "Host",
+                      "url": "d/eWQoMUTIk/system-performance-metrics-metricshub?orgId=1&var-host_name=${__data.fields.Hostname}"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
                 },
-                "fieldName": "os_type"
-              }
-            ],
-            "match": "any",
-            "type": "exclude"
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time 1": true,
-              "Time 2": true,
-              "Time 3": true,
-              "Time 4": true,
-              "Time 5": true,
-              "Value #B": true,
-              "Value #OsList": true,
-              "Value #UnhealthyHostsPctByOs": false
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Time 1": 1,
-              "Time 2": 6,
-              "Time 3": 8,
-              "Time 4": 9,
-              "Time 5": 10,
-              "Value #HostCountByOS": 2,
-              "Value #HostCountPctByOs": 3,
-              "Value #OsList": 7,
-              "Value #UnhealthyHostsByOs": 4,
-              "Value #UnhealthyHostsPctByOs": 5,
-              "os_type": 0
-            },
-            "renameByName": {
-              "Time 1": "",
-              "Time 4": "",
-              "Value #HostCountByOS": "Hosts Count",
-              "Value #HostCountPctByOs": "Host Count (%)",
-              "Value #UnhealthyHostsByOs": "Unhealthy Hosts",
-              "Value #UnhealthyHostsPctByOS": "Unhealthy Hosts (%)",
-              "Value #UnhealthyHostsPctByOs": "Unhealthy Hosts %",
-              "os_type": "System"
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "links": [],
-          "mappings": [],
-          "noValue": "0",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 1
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 3,
-        "w": 3,
-        "x": 0,
-        "y": 7
-      },
-      "id": 151,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "center",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {},
-        "textMode": "value",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(metricshub_host_up{os_type=~\"$system\"} == 0)",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Failed Protocols",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 10
-      },
-      "id": 176,
-      "panels": [],
-      "title": "Alerts",
-      "type": "row"
-    },
-    {
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 11
-      },
-      "id": 175,
-      "options": {
-        "alertInstanceLabelFilter": "",
-        "alertName": "MetricsHub-System",
-        "dashboardAlerts": false,
-        "groupBy": [],
-        "groupMode": "custom",
-        "maxItems": 20,
-        "showInactiveAlerts": false,
-        "sortOrder": 1,
-        "stateFilter": {
-          "error": true,
-          "firing": true,
-          "noData": false,
-          "normal": false,
-          "pending": true,
-          "recovering": true
-        },
-        "viewMode": "list"
-      },
-      "pluginVersion": "12.3.2",
-      "title": "Current Alerts",
-      "type": "alertlist"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 19
-      },
-      "id": 116,
-      "panels": [],
-      "title": "Hosts",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "links": [
-            {
-              "targetBlank": false,
-              "title": "Host",
-              "url": "d/eWQoMUTIk/system-performance-metrics-metricshub?orgId=1&var-host_name=${__data.fields.Hostname}"
-            }
-          ],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Protocols Up"
-            },
-            "properties": [
-              {
-                "id": "noValue",
-                "value": "0"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "custom.wrapText",
-                "value": false
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "red",
-                      "value": 0
-                    },
-                    {
-                      "color": "transparent",
-                      "value": 1
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Failed Protocols"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "custom.wrapText",
-                "value": false
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "noValue",
-                "value": "0"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 1
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Critical Alerts"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "noValue",
-                "value": "0"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 1
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "noValue",
-                "value": "0"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Warning Alerts"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "noValue",
-                "value": "0"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "orange",
-                      "value": 1
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Memory Usage"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "lcd",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "#EAB839",
-                      "value": 0.75
-                    },
-                    {
-                      "color": "red",
-                      "value": 0.9
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 1
-              },
-              {
-                "id": "min",
-                "value": 0
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "CPU Usage"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "lcd",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "green",
-                      "value": 0
-                    },
-                    {
-                      "color": "red",
-                      "value": 0.8
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 1
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "thresholds"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Trend #ProtocolUpPct"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "hideValue": true,
-                  "type": "sparkline"
-                }
-              },
-              {
-                "id": "unit",
-                "value": "percent"
-              },
-              {
-                "id": "min",
-                "value": -2
-              },
-              {
-                "id": "max",
-                "value": 100
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value #ProtocolUpPctValue"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "red",
-                      "value": 0
-                    },
-                    {
-                      "color": "green",
-                      "value": 100
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "unit",
-                "value": "percent"
-              },
-              {
-                "id": "custom.filterable",
-                "value": true
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Operating System"
-            },
-            "properties": [
-              {
-                "id": "mappings",
-                "value": [
+                "overrides": [
                   {
-                    "options": {
-                      "aix": {
-                        "index": 2,
-                        "text": "https://dl.sentrysoftware.com/public/ibmaix-logo-mh.svg"
-                      },
-                      "hpux": {
-                        "index": 4,
-                        "text": "https://dl.sentrysoftware.com/public/hpux-logo-mh.svg"
-                      },
-                      "linux": {
-                        "index": 1,
-                        "text": "https://dl.sentrysoftware.com/public/linux-logo-mh.svg"
-                      },
-                      "windows": {
-                        "index": 0,
-                        "text": "https://dl.sentrysoftware.com/public/windows-logo-mh.svg"
-                      }
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Utilization"
                     },
-                    "type": "value"
+                    "properties": [
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge",
+                          "valueDisplayMode": "color"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-GrYlRd"
+                        }
+                      }
+                    ]
                   },
                   {
-                    "options": {
-                      "match": "null",
-                      "result": {
-                        "index": 3,
-                        "text": "https://dl.sentrysoftware.com/public/unknown-logo-mh.svg"
-                      }
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Filesystem"
                     },
-                    "type": "special"
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Change"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "custom.wrapText",
+                        "value": false
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "light-green",
+                              "value": 0
+                            },
+                            {
+                              "color": "light-blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "light-red",
+                              "value": 0.01
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 87
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Type"
+                    },
+                    "properties": []
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "green",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "drawStyle": "line",
+                          "hideValue": true,
+                          "lineInterpolation": "linear",
+                          "type": "sparkline"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Capacity"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 73
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #UtilizationRatio"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "continuous-GrYlRd"
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Hostname"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 115
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Growth Rate"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "binBps"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      },
+                      {
+                        "id": "custom.wrapText",
+                        "value": false
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "light-green",
+                              "value": 0
+                            },
+                            {
+                              "color": "light-blue",
+                              "value": 0
+                            },
+                            {
+                              "color": "light-red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 96
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #TimeUntilSaturation"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Free"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 70
+                      }
+                    ]
                   }
                 ]
               },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "image"
-                }
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "custom.filterable",
-                "value": true
-              },
-              {
-                "id": "custom.width",
-                "value": 213
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Hostname"
-            },
-            "properties": [
-              {
-                "id": "custom.filterable",
-                "value": true
-              },
-              {
-                "id": "custom.width",
-                "value": 153
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value #Ping"
-            },
-            "properties": [
-              {
-                "id": "noValue",
-                "value": "N/A"
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-background"
-                }
-              },
-              {
-                "id": "mappings",
-                "value": [
-                  {
-                    "options": {
-                      "-1": {
-                        "color": "red",
-                        "index": 0,
-                        "text": "Down"
-                      },
-                      "0-1000000": {
-                        "index": 2,
-                        "text": "${__value} "
-                      }
-                    },
-                    "type": "value"
-                  },
-                  {
-                    "options": {
-                      "match": "null",
-                      "result": {
-                        "color": "transparent",
-                        "index": 1,
-                        "text": "N/A"
-                      }
-                    },
-                    "type": "special"
-                  }
-                ]
-              },
-              {
-                "id": "unit",
-                "value": "ms"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "transparent",
-                      "value": 0
-                    },
-                    {
-                      "color": "orange",
-                      "value": 50
-                    }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Uptime"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "dtdurations"
-              },
-              {
-                "id": "custom.align",
-                "value": "center"
-              },
-              {
-                "id": "custom.width",
-                "value": 177
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 15,
-        "w": 24,
-        "x": 0,
-        "y": 20
-      },
-      "id": 145,
-      "interval": "15min",
-      "options": {
-        "cellHeight": "sm",
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Uptime"
-          }
-        ]
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(metricshub_host_up) by (host_name)",
-          "format": "table",
-          "hide": true,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "ProtocolsUp",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          }
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "count(metricshub_host_up == 0) by (host_name)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "ProtocolsDown"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "system_uptime_seconds",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Generic"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(\r\n  count(ALERTS_FOR_STATE{severity=\"critical\", alertname=~\"MetricsHub-System-.*\"}) by (host_name)\r\n  or \r\n  (0 * count by (host_name) (system_uptime_seconds)) # This is used to make sure a column is always created\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "CriticalAlerts"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(\r\n  count(ALERTS_FOR_STATE{severity=\"warning\", alertname=~\"MetricsHub-System-.*\"}) by (host_name)\r\n  or \r\n  (0 * count by (host_name) (system_uptime_seconds)) # This is used to make sure a column is always created\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "WarningAlerts"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(system_memory_utilization_ratio{system_memory_state!=\"free\"}) by (host_name)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Memory"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(\r\n  sum by (host_name) (\r\n    rate(system_cpu_time_seconds_total{system_cpu_state!=\"idle\"}[5m])\r\n  )\r\n/\r\n  sum by (host_name) (\r\n    rate(system_cpu_time_seconds_total[5m])\r\n  )\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "CPU"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(metricshub_host_up) by (host_name) * 100 / count(metricshub_host_up) by (host_name)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "ProtocolUpPct"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sum(metricshub_host_up) by (host_name) * 100 / count(metricshub_host_up) by (host_name)",
-          "format": "table",
-          "hide": true,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "ProtocolUpPctValue"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "(\r\n  # Case 1: Ping is down for selected OS types\r\n  (max by (host_name) (metricshub_host_up{protocol=\"ping\"} == 0)) - 1\r\n  or\r\n  # Case 2: Ping is up for selected OS types → Show response time\r\n  (max by (host_name) (metricshub_host_up{protocol=\"ping\"} == 1))\r\n  * on(host_name)\r\n  (max by (host_name) (metricshub_host_response_time_seconds{protocol=\"ping\"}) * 1000)\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "Ping"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "timeSeriesTable",
-          "options": {
-            "Ping": {
-              "timeField": "Time"
-            },
-            "ProtocolUpPct": {
-              "timeField": "Time"
-            }
-          }
-        },
-        {
-          "id": "joinByField",
-          "options": {
-            "byField": "host_name",
-            "mode": "outer"
-          }
-        },
-        {
-          "id": "filterByValue",
-          "options": {
-            "filters": [
-              {
-                "config": {
-                  "id": "isNotNull",
-                  "options": {}
-                },
-                "fieldName": "os_type"
-              }
-            ],
-            "match": "all",
-            "type": "include"
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time 1": true,
-              "Time 2": true,
-              "Time 3": true,
-              "Time 4": true,
-              "Time 5": true,
-              "Time 6": true,
-              "Time 7": true,
-              "Time 8": true,
-              "Value #A": false,
-              "Value #Generic": false,
-              "__name__": true,
-              "agent_host_name": true,
-              "connector_id": true,
-              "host_type": true,
-              "id": true,
-              "name": true,
-              "os_version": true,
-              "serial_number": true,
-              "site": true,
-              "system_memory_state": true,
-              "version": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Time 1": 13,
-              "Time 2": 14,
-              "Time 3": 15,
-              "Time 4": 24,
-              "Time 5": 25,
-              "Time 6": 26,
-              "Time 7": 27,
-              "Time 8": 28,
-              "Trend #ProtocolUpPct": 7,
-              "Value #CPU": 10,
-              "Value #CriticalAlerts": 8,
-              "Value #Generic": 2,
-              "Value #Memory": 11,
-              "Value #Ping": 4,
-              "Value #ProtocolUpPctValue": 5,
-              "Value #ProtocolsDown": 6,
-              "Value #WarningAlerts": 9,
-              "__name__": 16,
-              "agent_host_name": 17,
-              "connector_id": 18,
-              "host_name": 1,
-              "host_type": 19,
-              "id": 20,
-              "name": 12,
-              "os_type": 3,
-              "os_version": 21,
-              "serial_number": 23,
-              "site": 0,
-              "version": 22
-            },
-            "renameByName": {
-              "Trend #ProtocolUpPct": "Protocols Availability (%)",
-              "Value #CPU": "CPU Usage",
-              "Value #CriticalAlerts": "Critical Alerts",
-              "Value #Generic": "Uptime",
-              "Value #Memory": "Memory Usage",
-              "Value #Ping": "Ping",
-              "Value #ProtocolUpPctValue": "Available Protocols",
-              "Value #ProtocolsDown": "Failed Protocols",
-              "Value #ProtocolsUp": "Protocols Up",
-              "Value #WarningAlerts": "Warning Alerts",
-              "host_name": "Hostname",
-              "id": "",
-              "name": "",
-              "os_type": "Operating System",
-              "site": "Site"
-            }
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": true,
-                "field": "Hostname"
-              }
-            ]
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 35
-      },
-      "id": 33,
-      "panels": [],
-      "title": "Filesystems",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": false,
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "links": [
-            {
-              "title": "Host",
-              "url": "d/eWQoMUTIk/system-performance-metrics-metricshub?orgId=1&var-host_name=${__data.fields.Hostname}"
-            }
-          ],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Utilization"
-            },
-            "properties": [
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 1
-              },
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "lcd",
-                  "type": "gauge",
-                  "valueDisplayMode": "color"
-                }
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Filesystem"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Change"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-text"
-                }
-              },
-              {
-                "id": "custom.wrapText",
-                "value": false
-              },
-              {
-                "id": "decimals",
-                "value": 1
-              },
-              {
-                "id": "color"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "light-green",
-                      "value": 0
-                    },
-                    {
-                      "color": "light-blue",
-                      "value": 0
-                    },
-                    {
-                      "color": "light-red",
-                      "value": 0.01
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "custom.width",
-                "value": 87
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Type"
-            },
-            "properties": []
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Trend"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "drawStyle": "line",
-                  "hideValue": true,
-                  "lineInterpolation": "linear",
-                  "type": "sparkline"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Capacity"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 73
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value #UtilizationRatio"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "percentunit"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "lcd",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "min",
-                "value": 0
-              },
-              {
-                "id": "max",
-                "value": 1
-              },
-              {
-                "id": "color",
-                "value": {
-                  "mode": "continuous-GrYlRd"
-                }
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Hostname"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
-              },
-              {
-                "id": "custom.width",
-                "value": 115
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Growth Rate"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "binBps"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "color-text"
-                }
-              },
-              {
-                "id": "custom.wrapText",
-                "value": false
-              },
-              {
-                "id": "color"
-              },
-              {
-                "id": "thresholds",
-                "value": {
-                  "mode": "absolute",
-                  "steps": [
-                    {
-                      "color": "light-green",
-                      "value": 0
-                    },
-                    {
-                      "color": "light-blue",
-                      "value": 0
-                    },
-                    {
-                      "color": "light-red",
-                      "value": 1
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "custom.width",
-                "value": 96
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value #TimeUntilSaturation"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Free"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 70
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 15,
-        "x": 0,
-        "y": 36
-      },
-      "id": 143,
-      "options": {
-        "cellHeight": "sm",
-        "enablePagination": false,
-        "showHeader": true,
-        "sortBy": [
-          {
-            "desc": true,
-            "displayName": "Utilization"
-          }
-        ]
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "label_join(\r\n     sum(system_filesystem_utilization_ratio{system_filesystem_state=~\"used|reserved\"}) by (site, host_name, system_device),\r\n     \"id\", \":\", \"host_name\", \"system_device\"\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "UtilizationRatio"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "label_join(\r\n    sum(system_filesystem_usage_bytes{system_filesystem_state=~\"used|reserved|free\"}) by (site, host_name, system_device),\r\n    \"id\", \":\", \"host_name\", \"system_device\"\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Capacity"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "label_join(\r\n    sum by (site, host_name, system_device) (\r\n        system_filesystem_usage_bytes{system_filesystem_state=~\"free\"}),\r\n    \"id\", \":\", \"host_name\", \"system_device\"\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Free"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "label_join(\r\n  sum by (site, host_name, system_device) (\r\n    system_filesystem_utilization_ratio{system_filesystem_state=~\"used|reserved\", system_filesystem_type!~\"$filesystemFilter\"}),\r\n  \"id\", \":\", \"host_name\", \"system_device\"\r\n)\r\n-\r\nlabel_join(\r\n  sum by (site, host_name, system_device) (\r\n    system_filesystem_utilization_ratio{system_filesystem_state=~\"used|reserved\", system_filesystem_type!~\"$filesystemFilter\"} offset $__range\r\n  ),\r\n  \"id\", \":\", \"host_name\", \"system_device\"\r\n)\r\n",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "Change"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "label_join(\r\n     sum by (site, host_name, system_device) (\r\n           system_filesystem_utilization_ratio{system_filesystem_state=~\"used|reserved\", system_filesystem_type !~\"$filesystemFilter\"}\r\n     ),\r\n     \"id\", \":\", \"host_name\", \"system_device\"\r\n)",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "Usage"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "label_join(\r\n     sum by (site, host_name, system_device) (\r\n            delta(system_filesystem_usage_bytes{system_filesystem_state=\"used\"}[$__range]) / $__range_s \r\n            ),\r\n     \"id\", \":\", \"host_name\", \"system_device\"\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "GrowthRate"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "label_join(\r\n  (\r\n    sum by (site, host_name, system_device) (\r\n      system_filesystem_usage_bytes{system_filesystem_state=\"free\"}\r\n    )\r\n    / ignoring(system_filesystem_state)\r\n    sum by (site, host_name, system_device) (\r\n      delta(system_filesystem_usage_bytes{system_filesystem_state=\"used\"}[$__range]) / $__range_s\r\n    )\r\n  ) \r\n  and ignoring(system_filesystem_state)\r\n  sum by (site, host_name, system_device) (\r\n    delta(system_filesystem_usage_bytes{system_filesystem_state=\"used\"}[$__range])\r\n  ) > 0,\r\n  \"id\", \":\", \"host_name\", \"system_device\"\r\n)",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "TimeUntilSaturation"
-        }
-      ],
-      "title": "Filesystems - Top 5 Utilization",
-      "transformations": [
-        {
-          "id": "timeSeriesTable",
-          "options": {
-            "B": {
-              "timeField": "Time"
-            },
-            "Usage": {
-              "timeField": "Time"
-            }
-          }
-        },
-        {
-          "id": "joinByField",
-          "options": {
-            "byField": "id",
-            "mode": "outer"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": true,
-                "field": "Value #UtilizationRatio"
-              }
-            ]
-          }
-        },
-        {
-          "id": "limit",
-          "options": {
-            "limitField": "5"
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Capacity": false,
-              "FreeAndUsedCapacity": true,
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "Time 3": true,
-              "Time 4": true,
-              "Time 5": true,
-              "Time 6": true,
-              "Trend #A": true,
-              "Trend #Capacity": true,
-              "Trend #Change": true,
-              "Trend #D": true,
-              "Trend #Free": true,
-              "Trend #Used & Reserved": true,
-              "Value": true,
-              "Value #B": false,
-              "Value #C": false,
-              "Value #E": true,
-              "__name__": true,
-              "__name__ 1": true,
-              "__name__ 2": true,
-              "__name__ 3": true,
-              "agent_host_name": true,
-              "agent_host_name 1": true,
-              "agent_host_name 2": true,
-              "agent_host_name 3": true,
-              "connector_id": true,
-              "connector_id 1": true,
-              "connector_id 2": true,
-              "connector_id 3": true,
-              "host_id": true,
-              "host_id 1": true,
-              "host_id 2": true,
-              "host_id 3": true,
-              "host_name": false,
-              "host_name 1": false,
-              "host_name 2": true,
-              "host_name 3": true,
-              "host_name 4": true,
-              "host_name 5": true,
-              "host_name 6": true,
-              "host_name 7": true,
-              "host_type": true,
-              "host_type 1": true,
-              "host_type 2": true,
-              "host_type 3": true,
-              "id": true,
-              "id 1": true,
-              "id 2": true,
-              "name 1": true,
-              "name 2": true,
-              "os_type": true,
-              "os_type 1": true,
-              "os_type 2": true,
-              "os_type 3": true,
-              "site": true,
-              "site 1": false,
-              "site 2": true,
-              "site 3": true,
-              "site 4": true,
-              "site 5": true,
-              "site 6": true,
-              "site 7": true,
-              "system_device": false,
-              "system_device 1": false,
-              "system_device 2": true,
-              "system_device 3": true,
-              "system_device 4": true,
-              "system_device 5": true,
-              "system_device 6": true,
-              "system_device 7": true,
-              "system_filesystem_device": true,
-              "system_filesystem_device 1": true,
-              "system_filesystem_device 2": true,
-              "system_filesystem_device 3": true,
-              "system_filesystem_mountpoint 2": true,
-              "system_filesystem_mountpoint 3": true,
-              "system_filesystem_state": true,
-              "system_filesystem_state 1": true,
-              "system_filesystem_state 2": true,
-              "system_filesystem_state 3": true,
-              "system_filesystem_type 2": true,
-              "system_filesystem_type 3": true,
-              "system_filesystem_volumeName": true,
-              "system_filesystem_volumeName 2": true,
-              "system_filesystem_volumeName 3": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Time 1": 10,
-              "Time 2": 11,
-              "Time 3": 15,
-              "Time 4": 18,
-              "Time 5": 27,
-              "Time 6": 31,
-              "Trend #Usage": 8,
-              "Value #Capacity": 4,
-              "Value #Change": 6,
-              "Value #Free": 3,
-              "Value #GrowthRate": 7,
-              "Value #TimeUntilSaturation": 9,
-              "Value #UtilizationRatio": 5,
-              "host_name 1": 1,
-              "host_name 2": 12,
-              "host_name 3": 16,
-              "host_name 4": 19,
-              "host_name 5": 24,
-              "host_name 6": 28,
-              "host_name 7": 32,
-              "id": 13,
-              "site 1": 0,
-              "site 2": 21,
-              "site 3": 22,
-              "site 4": 23,
-              "site 5": 25,
-              "site 6": 29,
-              "site 7": 33,
-              "system_device 1": 2,
-              "system_device 2": 14,
-              "system_device 3": 17,
-              "system_device 4": 20,
-              "system_device 5": 26,
-              "system_device 6": 30,
-              "system_device 7": 34
-            },
-            "renameByName": {
-              "Capacity": "Capacity",
-              "Change": "Change",
-              "Free": "Free",
-              "Time 1": "",
-              "Time 2": "",
-              "Time 5": "",
-              "Trend #A": "",
-              "Trend #Capacity": "",
-              "Trend #D": "",
-              "Trend #Free": "",
-              "Trend #Usage": "Trend",
-              "Usage": "Usage",
-              "Used & Reserved": "Used & Reserved",
-              "Utilization": "Utilization",
-              "Value": "",
-              "Value #A": "Usage",
-              "Value #B": "Free",
-              "Value #C": "Used & Reserved",
-              "Value #Capacity": "Capacity",
-              "Value #Change": "Change",
-              "Value #D": "Change",
-              "Value #F": "Capacity",
-              "Value #Free": "Free",
-              "Value #GrowthRate": "Growth Rate",
-              "Value #TimeUntilSaturation": "Time Until Saturation",
-              "Value #Used & Reserved": "Used & Reserved",
-              "Value #UtilizationRatio": "Utilization",
-              "__name__ 1": "",
-              "connector_id 1": "",
-              "host_name 1": "Hostname",
-              "id": "",
-              "site 1": "Site",
-              "system_device": "Filesystem",
-              "system_device 1": "Filesystem",
-              "system_filesystem_mountpoint": "Mountpoint",
-              "system_filesystem_mountpoint 1": "Mountpoint",
-              "system_filesystem_state 1": "",
-              "system_filesystem_type": "Type",
-              "system_filesystem_type 1": "Type",
-              "system_filesystem_type 3": "",
-              "system_filesystem_volumeName 1": "Name",
-              "value": ""
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "links": [
-            {
-              "title": "Host",
-              "url": "d/eWQoMUTIk/system-performance-metrics-metricshub?orgId=1&var-host_name=${__data.fields.Hostname}"
-            }
-          ],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Filesystem"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value"
-            },
-            "properties": [
-              {
-                "id": "unit",
-                "value": "s"
-              },
-              {
-                "id": "custom.align",
-                "value": "left"
-              },
-              {
-                "id": "decimals",
-                "value": 0
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Hostname"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 166
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time to Saturation"
-            },
-            "properties": [
-              {
-                "id": "custom.width",
-                "value": 156
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 9,
-        "x": 15,
-        "y": 36
-      },
-      "id": 173,
-      "options": {
-        "cellHeight": "sm",
-        "showHeader": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "bottomk(5,\r\n  label_join(\r\n    (\r\n      sum by (site, host_name, system_device) (\r\n        system_filesystem_usage_bytes{system_filesystem_state=\"free\"}\r\n      )\r\n      / ignoring(system_filesystem_state)\r\n      sum by (site, host_name, system_device) (\r\n        delta(system_filesystem_usage_bytes{system_filesystem_state=\"used\"}[$__range]) / $__range_s\r\n      )\r\n    ) \r\n    and ignoring(system_filesystem_state)\r\n    sum by (site, host_name, system_device) (\r\n      delta(system_filesystem_usage_bytes{system_filesystem_state=\"used\"}[$__range])\r\n    ) > 0,\r\n    \"id\", \":\", \"host_name\", \"system_device\"\r\n  )\r\n)",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          }
-        }
-      ],
-      "title": "Earliest Saturation Time",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {}
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "id": true,
-              "site": true
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Time": 0,
-              "Value": 1,
-              "host_name": 2,
-              "id": 4,
-              "site": 5,
-              "system_device": 3
-            },
-            "renameByName": {
-              "Time": "",
-              "Value": "Time to Saturation",
-              "host_name": "Hostname",
-              "system_device": "Filesystem"
-            }
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 43
-      },
-      "id": 153,
-      "panels": [],
-      "title": "Disk Activity",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "thresholds"
-          },
-          "links": [
-            {
-              "title": "Host",
-              "url": "d/eWQoMUTIk/system?orgId=1&var-host_name=${__field.labels.host_name}"
-            }
-          ],
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-purple",
-                "value": 0
-              },
-              {
-                "color": "purple",
-                "value": 25000000
-              },
-              {
-                "color": "semi-dark-purple",
-                "value": 50000000
-              },
-              {
-                "color": "dark-purple",
-                "value": 75000000
-              }
-            ]
-          },
-          "unit": "binBps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 0,
-        "y": 44
-      },
-      "id": 168,
-      "options": {
-        "displayMode": "gradient",
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "maxVizHeight": 300,
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "namePlacement": "top",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "sizing": "auto",
-        "valueMode": "color"
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(5, sum by (site, host_name, system_device) (rate(system_disk_io_bytes_total[$__range])))",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "{{host_name}} - {{system_device}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Top Drives by Traffic",
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "thresholds"
-          },
-          "links": [
-            {
-              "title": "Host",
-              "url": "d/eWQoMUTIk/system?orgId=1&var-host_name=${__field.labels.host_name}"
-            }
-          ],
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "orange",
-                "value": 0.6
-              },
-              {
-                "color": "red",
-                "value": 0.8
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 6,
-        "y": 44
-      },
-      "id": 157,
-      "options": {
-        "displayMode": "lcd",
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "maxVizHeight": 300,
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "namePlacement": "top",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "sizing": "auto",
-        "valueMode": "color"
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(5,\r\n  max by (host_name, system_device) (rate(system_disk_io_time_seconds_total[$__range]))\r\n)",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "{{host_name}} - {{system_device}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Top Drives by Utilization",
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-purples"
-          },
-          "links": [
-            {
-              "title": "Host",
-              "url": "d/eWQoMUTIk/system?orgId=1&var-host_name=${__field.labels.host_name}"
-            }
-          ],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "purple",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 44
-      },
-      "id": 164,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sort_desc(sum by (host_name) (increase(system_disk_io_bytes_total[$__range])))",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          }
-        }
-      ],
-      "title": "Total Host Disk Activity - Heatmap",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 52
-      },
-      "id": 170,
-      "panels": [],
-      "title": "Network Activity",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "thresholds"
-          },
-          "links": [
-            {
-              "title": "Host",
-              "url": "d/eWQoMUTIk/system?orgId=1&var-host_name=${__field.labels.host_name}"
-            }
-          ],
-          "mappings": [],
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-blue",
-                "value": 0
-              },
-              {
-                "color": "blue",
-                "value": 62500000
-              },
-              {
-                "color": "semi-dark-blue",
-                "value": 87500000
-              },
-              {
-                "color": "dark-blue",
-                "value": 106250000
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 0,
-        "y": 53
-      },
-      "id": 166,
-      "options": {
-        "displayMode": "gradient",
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "maxVizHeight": 300,
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "namePlacement": "top",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "sizing": "auto",
-        "valueMode": "color"
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(5, sum by (site, host_name, network_interface_name) (rate(system_network_io_bytes_total[$__range])))",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "{{host_name}} - {{network_interface_name}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Top Network Interfaces by Traffic",
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "blue",
-            "mode": "thresholds"
-          },
-          "links": [
-            {
-              "title": "Host",
-              "url": "d/eWQoMUTIk/system?orgId=1&var-host_name=${__field.labels.host_name}"
-            }
-          ],
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "orange",
-                "value": 0.5
-              },
-              {
-                "color": "red",
-                "value": 0.8
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 6,
-        "x": 6,
-        "y": 53
-      },
-      "id": 167,
-      "options": {
-        "displayMode": "lcd",
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": false
-        },
-        "maxVizHeight": 300,
-        "minVizHeight": 10,
-        "minVizWidth": 0,
-        "namePlacement": "top",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": false,
-        "sizing": "auto",
-        "valueMode": "color"
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "topk(5,\r\n  max by (host_name, network_interface_name) (rate(system_network_io_bytes_total[$__range])) / on(host_name, network_interface_name)\r\n  max by (host_name, network_interface_name) (system_network_bandwidth_limit_bytes)\r\n)",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "{{host_name}} - {{network_interface_name}}",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "title": "Top Network Interfaces by Utilization",
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-blues"
-          },
-          "links": [
-            {
-              "title": "Host",
-              "url": "d/eWQoMUTIk/system?orgId=1&var-host_name=${__field.labels.host_name}"
-            }
-          ],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 53
-      },
-      "id": 163,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "sort_desc(sum by (host_name) (increase(system_network_io_bytes_total[$__range])))",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A",
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          }
-        }
-      ],
-      "title": "Total Host Network Activity - Heatmap",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 61
-      },
-      "id": 29,
-      "panels": [],
-      "title": "MetricsHub Agents Information",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {
-            "align": "center",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "filterable": false,
-            "footer": {
-              "reducers": []
-            },
-            "inspect": false
-          },
-          "mappings": [
-            {
               "options": {
-                "linux": {
-                  "index": 1,
-                  "text": "https://dl.sentrysoftware.com/public/linux-logo-mh.svg"
+                "cellHeight": "sm",
+                "enablePagination": false,
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Utilization"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-145": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(metricshub_host_up) by (host_name)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "ProtocolsUp"
+                  }
                 },
-                "windows": {
-                  "index": 0,
-                  "text": "https://dl.sentrysoftware.com/public/windows-logo-mh.svg"
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(metricshub_host_up == 0) by (host_name)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "ProtocolsDown"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "system_uptime_seconds",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Generic"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  count(ALERTS_FOR_STATE{severity=\"critical\", alertname=~\"MetricsHub-System-.*\"}) by (host_name)\r\n  or \r\n  (0 * count by (host_name) (system_uptime_seconds)) # This is used to make sure a column is always created\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "CriticalAlerts"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  count(ALERTS_FOR_STATE{severity=\"warning\", alertname=~\"MetricsHub-System-.*\"}) by (host_name)\r\n  or \r\n  (0 * count by (host_name) (system_uptime_seconds)) # This is used to make sure a column is always created\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "WarningAlerts"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(system_memory_utilization_ratio{system_memory_state!=\"free\"}) by (host_name)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Memory"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  sum by (host_name) (\r\n    rate(system_cpu_time_seconds_total{system_cpu_state!=\"idle\"}[5m])\r\n  )\r\n/\r\n  sum by (host_name) (\r\n    rate(system_cpu_time_seconds_total[5m])\r\n  )\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "CPU"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "sum(metricshub_host_up) by (host_name) * 100 / count(metricshub_host_up) by (host_name)",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "ProtocolUpPct"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": true,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sum(metricshub_host_up) by (host_name) * 100 / count(metricshub_host_up) by (host_name)",
+                        "format": "table",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "ProtocolUpPctValue"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  # Case 1: Ping is down for selected OS types\r\n  (max by (host_name) (metricshub_host_up{protocol=\"ping\"} == 0)) - 1\r\n  or\r\n  # Case 2: Ping is up for selected OS types → Show response time\r\n  (max by (host_name) (metricshub_host_up{protocol=\"ping\"} == 1))\r\n  * on(host_name)\r\n  (max by (host_name) (metricshub_host_response_time_seconds{protocol=\"ping\"}) * 1000)\r\n)",
+                        "format": "table",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Ping"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "15min"
+              },
+              "transformations": [
+                {
+                  "kind": "timeSeriesTable",
+                  "spec": {
+                    "id": "timeSeriesTable",
+                    "options": {
+                      "Ping": {
+                        "timeField": "Time"
+                      },
+                      "ProtocolUpPct": {
+                        "timeField": "Time"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "host_name",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "filterByValue",
+                  "spec": {
+                    "id": "filterByValue",
+                    "options": {
+                      "filters": [
+                        {
+                          "config": {
+                            "id": "isNotNull",
+                            "options": {}
+                          },
+                          "fieldName": "os_type"
+                        }
+                      ],
+                      "match": "all",
+                      "type": "include"
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Time 5": true,
+                        "Time 6": true,
+                        "Time 7": true,
+                        "Time 8": true,
+                        "Value #A": false,
+                        "Value #Generic": false,
+                        "__name__": true,
+                        "agent_host_name": true,
+                        "connector_id": true,
+                        "entityName": true,
+                        "entityTypeId": true,
+                        "host_type": true,
+                        "id": true,
+                        "instanceName": true,
+                        "name": true,
+                        "os_version": true,
+                        "otel_scope_name": true,
+                        "serial_number": true,
+                        "site": true,
+                        "system_memory_state": true,
+                        "version": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Time 1": 13,
+                        "Time 2": 14,
+                        "Time 3": 15,
+                        "Time 4": 24,
+                        "Time 5": 25,
+                        "Time 6": 26,
+                        "Time 7": 27,
+                        "Time 8": 28,
+                        "Trend #ProtocolUpPct": 7,
+                        "Value #CPU": 10,
+                        "Value #CriticalAlerts": 8,
+                        "Value #Generic": 2,
+                        "Value #Memory": 11,
+                        "Value #Ping": 4,
+                        "Value #ProtocolUpPctValue": 5,
+                        "Value #ProtocolsDown": 6,
+                        "Value #WarningAlerts": 9,
+                        "__name__": 16,
+                        "agent_host_name": 17,
+                        "connector_id": 18,
+                        "host_name": 1,
+                        "host_type": 19,
+                        "id": 20,
+                        "name": 12,
+                        "os_type": 3,
+                        "os_version": 21,
+                        "serial_number": 23,
+                        "site": 0,
+                        "version": 22
+                      },
+                      "renameByName": {
+                        "Trend #ProtocolUpPct": "Protocols Availability (%)",
+                        "Value #CPU": "CPU Usage",
+                        "Value #CriticalAlerts": "Critical Alerts",
+                        "Value #Generic": "Uptime",
+                        "Value #Memory": "Memory Usage",
+                        "Value #Ping": "Ping",
+                        "Value #ProtocolUpPctValue": "Available Protocols",
+                        "Value #ProtocolsDown": "Failed Protocols",
+                        "Value #ProtocolsUp": "Protocols Up",
+                        "Value #WarningAlerts": "Warning Alerts",
+                        "host_name": "Hostname",
+                        "id": "",
+                        "name": "",
+                        "os_type": "Operating System",
+                        "site": "Site"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "desc": true,
+                          "field": "Hostname"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 145,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "links": [
+                    {
+                      "targetBlank": false,
+                      "title": "Host",
+                      "url": "d/eWQoMUTIk/system-performance-metrics-metricshub?orgId=1&var-host_name=${__data.fields.Hostname}"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Protocols Up"
+                    },
+                    "properties": [
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.wrapText",
+                        "value": false
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "transparent",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Failed Protocols"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "custom.wrapText",
+                        "value": false
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Critical Alerts"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Warning Alerts"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Memory Usage"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "#EAB839",
+                              "value": 0.75
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.9
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "CPU Usage"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "lcd",
+                          "type": "gauge"
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percentunit"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 0.8
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 1
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "mode": "thresholds"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Trend #ProtocolUpPct"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "hideValue": true,
+                          "type": "sparkline"
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "min",
+                        "value": -2
+                      },
+                      {
+                        "id": "max",
+                        "value": 100
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #ProtocolUpPctValue"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "red",
+                              "value": 0
+                            },
+                            {
+                              "color": "green",
+                              "value": 100
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Operating System"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "aix": {
+                                "index": 2,
+                                "text": "https://dl.sentrysoftware.com/public/ibmaix-logo-mh.svg"
+                              },
+                              "hpux": {
+                                "index": 4,
+                                "text": "https://dl.sentrysoftware.com/public/hpux-logo-mh.svg"
+                              },
+                              "linux": {
+                                "index": 1,
+                                "text": "https://dl.sentrysoftware.com/public/linux-logo-mh.svg"
+                              },
+                              "windows": {
+                                "index": 0,
+                                "text": "https://dl.sentrysoftware.com/public/windows-logo-mh.svg"
+                              }
+                            },
+                            "type": "value"
+                          },
+                          {
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "index": 3,
+                                "text": "https://dl.sentrysoftware.com/public/unknown-logo-mh.svg"
+                              }
+                            },
+                            "type": "special"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "image"
+                        }
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 213
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Hostname"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.filterable",
+                        "value": true
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 153
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value #Ping"
+                    },
+                    "properties": [
+                      {
+                        "id": "noValue",
+                        "value": "N/A"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "-1": {
+                                "color": "red",
+                                "index": 0,
+                                "text": "Down"
+                              },
+                              "0-1000000": {
+                                "index": 2,
+                                "text": "${__value} "
+                              }
+                            },
+                            "type": "value"
+                          },
+                          {
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "color": "transparent",
+                                "index": 1,
+                                "text": "N/A"
+                              }
+                            },
+                            "type": "special"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "unit",
+                        "value": "ms"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 50
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Uptime"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "dtdurations"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 177
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Uptime"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-147": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "100 * (\r\n  count(\r\n    group by (host_name) (\r\n      (metricshub_host_up{os_type=~\"$system\"} == 0) or \r\n      (ALERTS_FOR_STATE{severity=\"critical\", alertname=~\"MetricsHub-System-.*\"}) or \r\n      (ALERTS_FOR_STATE{severity=\"warning\", alertname=~\"MetricsHub-System-.*\"})\r\n    )\r\n  ) \r\n  / \r\n  count(count by (host_name) (system_uptime_seconds))\r\n)",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5min",
+                "maxDataPoints": 100
+              },
+              "transformations": []
+            }
+          },
+          "description": "Percentage of Hosts with at least one warning, one critical alert or one protocol down.",
+          "id": 147,
+          "links": [],
+          "title": "Unhealthy Hosts (%)",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "percent"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-148": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(count by (host_name) (metricshub_host_up{os_type=~\"$system\"} == 0)) \r\nor \r\n(count by (host_name) (metricshub_host_up{os_type=~\"$system\"}) * 0)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "ProtocolErrors"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  count(ALERTS_FOR_STATE{severity=\"critical\", alertname=~\"MetricsHub-System-.*\"}) by (host_name)\r\n  or \r\n  (0 * count by (host_name) (system_uptime_seconds)) # This is used to make sure a column is always created\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "CriticalAlerts"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "(\r\n  count(ALERTS_FOR_STATE{severity=\"warning\", alertname=~\"MetricsHub-System-.*\"}) by (host_name)\r\n  or \r\n  (0 * count by (host_name) (system_uptime_seconds)) # This is used to make sure a column is always created\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "Warnings"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "system_uptime_seconds",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "OperatingSystem"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "host_name",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "filterByValue",
+                  "spec": {
+                    "id": "filterByValue",
+                    "options": {
+                      "filters": [
+                        {
+                          "config": {
+                            "id": "greater",
+                            "options": {
+                              "value": 0
+                            }
+                          },
+                          "fieldName": "Value #ProtocolErrors"
+                        },
+                        {
+                          "config": {
+                            "id": "greater",
+                            "options": {
+                              "value": 0
+                            }
+                          },
+                          "fieldName": "Value #CriticalAlerts"
+                        },
+                        {
+                          "config": {
+                            "id": "greater",
+                            "options": {
+                              "value": 0
+                            }
+                          },
+                          "fieldName": "Value #Warnings"
+                        }
+                      ],
+                      "match": "any",
+                      "type": "include"
+                    }
+                  }
+                },
+                {
+                  "kind": "filterFieldsByName",
+                  "spec": {
+                    "id": "filterFieldsByName",
+                    "options": {
+                      "byVariable": false,
+                      "include": {
+                        "names": [
+                          "host_name",
+                          "Value #ProtocolErrors",
+                          "Value #CriticalAlerts",
+                          "Value #Warnings",
+                          "os_type",
+                          "site"
+                        ]
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time 1": true,
+                        "__name__ 1": true,
+                        "agent_host_name 1": true,
+                        "host_type 1": true,
+                        "site": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Value #CriticalAlerts": 3,
+                        "Value #ProtocolErrors": 5,
+                        "Value #Warnings": 4,
+                        "host_name": 1,
+                        "os_type": 2,
+                        "site": 0
+                      },
+                      "renameByName": {
+                        "Value #CriticalAlerts": "Critical Alerts",
+                        "Value #ProtocolErrors": "Failed Protocols",
+                        "Value #Warnings": "Warnings",
+                        "host_name": "Hostname",
+                        "os_type": "Operating System",
+                        "site": "Site"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "sortBy",
+                  "spec": {
+                    "id": "sortBy",
+                    "options": {
+                      "fields": {},
+                      "sort": [
+                        {
+                          "field": "Critical Alerts"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 148,
+          "links": [],
+          "title": "Current Issues",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "decimals": 1,
+                  "links": [
+                    {
+                      "title": "Host",
+                      "url": "d/eWQoMUTIk/system-performance-metrics-metricshub?orgId=1&var-host_name=${__data.fields.Hostname}"
+                    }
+                  ],
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Hostname"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byType",
+                      "options": "number"
+                    },
+                    "properties": [
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Critical Alerts"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Warnings"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "orange",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Failed Protocols"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      },
+                      {
+                        "id": "color"
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "transparent",
+                              "value": 0
+                            },
+                            {
+                              "color": "red",
+                              "value": 1
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Operating System"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "aix": {
+                                "index": 2,
+                                "text": "https://dl.sentrysoftware.com/public/ibmaix-logo-mh.svg"
+                              },
+                              "hpux": {
+                                "index": 4,
+                                "text": "https://dl.sentrysoftware.com/public/hpux-logo-mh.svg"
+                              },
+                              "linux": {
+                                "index": 1,
+                                "text": "https://dl.sentrysoftware.com/public/linux-logo-mh.svg"
+                              },
+                              "windows": {
+                                "index": 0,
+                                "text": "https://dl.sentrysoftware.com/public/windows-logo-mh.svg"
+                              }
+                            },
+                            "type": "value"
+                          },
+                          {
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "index": 3,
+                                "text": "https://dl.sentrysoftware.com/public/unknown-logo-mh.svg"
+                              }
+                            },
+                            "type": "special"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "alt": "",
+                          "type": "image"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Critical Alerts"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-149": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(\r\n  group by (host_name) (\r\n    (metricshub_host_up{os_type=~\"$system\"} == 0) or \r\n    (ALERTS_FOR_STATE{severity=\"critical\", alertname=~\"MetricsHub-System-.*\"}) or \r\n    (ALERTS_FOR_STATE{severity=\"warning\", alertname=~\"MetricsHub-System-.*\"})\r\n   )\r\n)   ",
+                        "format": "time_series",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {
+                "interval": "5min",
+                "maxDataPoints": 100
+              },
+              "transformations": []
+            }
+          },
+          "description": "Number of Hosts with at least one warning, one critical alert or one protocol down.",
+          "id": 149,
+          "links": [],
+          "title": "Unhealthy Hosts",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 1
+                      }
+                    ]
+                  },
+                  "unit": "none"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-150": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "100 * (\r\n  count by (os_type) (\r\n    group by (host_name, os_type) (\r\n      (metricshub_host_up{os_type=~\"$system\"} == 0) or \r\n      ((ALERTS_FOR_STATE{severity=~\"critical|warning\", alertname=~\"MetricsHub-System-.*\"}) \r\n       * on(host_name) group_left(os_type) \r\n       (group by (host_name, os_type) (system_uptime_seconds{os_type=~\"$system\"})))\r\n    )\r\n  ) \r\n  / \r\n  count by (os_type) (count by (host_name, os_type) (system_uptime_seconds{os_type=~\"$system\"}))\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "UnhealthyHostsPctByOs"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count by (os_type) (system_uptime_seconds)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "OsList"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "100 * count by (os_type) (group by (host_name, os_type) (system_uptime_seconds)) / scalar(count(count by (host_name) (system_uptime_seconds)))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "HostCountPctByOs"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count by (os_type) (group by (host_name, os_type) (system_uptime_seconds))",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "HostCountByOS"
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count by (os_type) (\r\n    group by (host_name, os_type) (\r\n      (metricshub_host_up{os_type=~\"$system\"} == 0) or \r\n      ((ALERTS_FOR_STATE{severity=~\"critical|warning\", alertname=~\"MetricsHub-System-.*\"}) \r\n       * on(host_name) group_left(os_type) \r\n       (group by (host_name, os_type) (metricshub_host_up{os_type=~\"$system\"})))\r\n    )\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "UnhealthyHostsByOs"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "joinByField",
+                  "spec": {
+                    "id": "joinByField",
+                    "options": {
+                      "byField": "os_type",
+                      "mode": "outer"
+                    }
+                  }
+                },
+                {
+                  "kind": "filterByValue",
+                  "spec": {
+                    "disabled": true,
+                    "id": "filterByValue",
+                    "options": {
+                      "filters": [
+                        {
+                          "config": {
+                            "id": "regex",
+                            "options": {
+                              "value": "^$"
+                            }
+                          },
+                          "fieldName": "os_type"
+                        }
+                      ],
+                      "match": "any",
+                      "type": "exclude"
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time 1": true,
+                        "Time 2": true,
+                        "Time 3": true,
+                        "Time 4": true,
+                        "Time 5": true,
+                        "Value #B": true,
+                        "Value #OsList": true,
+                        "Value #UnhealthyHostsPctByOs": false
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Time 1": 1,
+                        "Time 2": 6,
+                        "Time 3": 8,
+                        "Time 4": 9,
+                        "Time 5": 10,
+                        "Value #HostCountByOS": 2,
+                        "Value #HostCountPctByOs": 3,
+                        "Value #OsList": 7,
+                        "Value #UnhealthyHostsByOs": 4,
+                        "Value #UnhealthyHostsPctByOs": 5,
+                        "os_type": 0
+                      },
+                      "renameByName": {
+                        "Time 1": "",
+                        "Time 4": "",
+                        "Value #HostCountByOS": "Hosts Count",
+                        "Value #HostCountPctByOs": "Host Count (%)",
+                        "Value #UnhealthyHostsByOs": "Unhealthy Hosts",
+                        "Value #UnhealthyHostsPctByOS": "Unhealthy Hosts (%)",
+                        "Value #UnhealthyHostsPctByOs": "Unhealthy Hosts %",
+                        "os_type": "System"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 150,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "auto",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "decimals": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Hosts Count"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "none"
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      },
+                      {
+                        "id": "custom.width",
+                        "value": 122
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Host Count (%)"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      },
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "light-blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Unhealthy Hosts"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Unhealthy Hosts %"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      },
+                      {
+                        "id": "noValue",
+                        "value": "0"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 1
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "mode": "gradient",
+                          "type": "gauge",
+                          "valueDisplayMode": "text"
+                        }
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": 0
+                            },
+                            {
+                              "color": "#EAB839",
+                              "value": 1
+                            },
+                            {
+                              "color": "red",
+                              "value": 50
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "System"
+                    },
+                    "properties": [
+                      {
+                        "id": "mappings",
+                        "value": [
+                          {
+                            "options": {
+                              "aix": {
+                                "index": 2,
+                                "text": "https://dl.sentrysoftware.com/public/ibmaix-logo-mh.svg"
+                              },
+                              "hpux": {
+                                "index": 4,
+                                "text": "https://dl.sentrysoftware.com/public/hpux-logo-mh.svg"
+                              },
+                              "linux": {
+                                "index": 0,
+                                "text": "https://dl.sentrysoftware.com/public/linux-logo-mh.svg"
+                              },
+                              "windows": {
+                                "index": 1,
+                                "text": "https://dl.sentrysoftware.com/public/windows-logo-mh.svg"
+                              }
+                            },
+                            "type": "value"
+                          },
+                          {
+                            "options": {
+                              "match": "null",
+                              "result": {
+                                "index": 3,
+                                "text": "https://dl.sentrysoftware.com/public/unknown-logo-mh.svg"
+                              }
+                            },
+                            "type": "special"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "image"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "System"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": false,
+                    "displayName": "System"
+                  }
+                ]
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-151": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "count(metricshub_host_up{os_type=~\"$system\"} == 0)",
+                        "instant": false,
+                        "interval": "",
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 151,
+          "links": [],
+          "title": "Failed Protocols",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "noValue": "0",
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "transparent",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 1
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "center",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "text": {},
+                "textMode": "value",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-157": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "topk(5,\r\n  max by (host_name, system_device) (rate(system_disk_io_time_seconds_total[$__range]))\r\n)",
+                        "instant": true,
+                        "legendFormat": "{{host_name}} - {{system_device}}",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 157,
+          "links": [],
+          "title": "Top Drives by Utilization",
+          "vizConfig": {
+            "group": "bargauge",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "thresholds"
+                  },
+                  "links": [
+                    {
+                      "title": "Host",
+                      "url": "d/eWQoMUTIk/system?orgId=1&var-host_name=${__field.labels.host_name}"
+                    }
+                  ],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.6
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.8
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "displayMode": "lcd",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "top",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-163": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sort_desc(sum by (host_name) (increase(system_network_io_bytes_total[$__range])))",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 163,
+          "links": [],
+          "title": "Total Host Network Activity - Heatmap",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-blues"
+                  },
+                  "links": [
+                    {
+                      "title": "Host",
+                      "url": "d/eWQoMUTIk/system?orgId=1&var-host_name=${__field.labels.host_name}"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-164": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "sort_desc(sum by (host_name) (increase(system_disk_io_bytes_total[$__range])))",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 164,
+          "links": [],
+          "title": "Total Host Disk Activity - Heatmap",
+          "vizConfig": {
+            "group": "stat",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "continuous-purples"
+                  },
+                  "links": [
+                    {
+                      "title": "Host",
+                      "url": "d/eWQoMUTIk/system?orgId=1&var-host_name=${__field.labels.host_name}"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "purple",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "colorMode": "background",
+                "graphMode": "area",
+                "justifyMode": "auto",
+                "orientation": "auto",
+                "percentChangeColorMode": "standard",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showPercentChange": false,
+                "textMode": "auto",
+                "wideLayout": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-166": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "topk(5, sum by (site, host_name, network_interface_name) (rate(system_network_io_bytes_total[$__range])))",
+                        "instant": true,
+                        "legendFormat": "{{host_name}} - {{network_interface_name}}",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 166,
+          "links": [],
+          "title": "Top Network Interfaces by Traffic",
+          "vizConfig": {
+            "group": "bargauge",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "thresholds"
+                  },
+                  "links": [
+                    {
+                      "title": "Host",
+                      "url": "d/eWQoMUTIk/system?orgId=1&var-host_name=${__field.labels.host_name}"
+                    }
+                  ],
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "light-blue",
+                        "value": 0
+                      },
+                      {
+                        "color": "blue",
+                        "value": 62500000
+                      },
+                      {
+                        "color": "semi-dark-blue",
+                        "value": 87500000
+                      },
+                      {
+                        "color": "dark-blue",
+                        "value": 106250000
+                      }
+                    ]
+                  },
+                  "unit": "bytes"
+                },
+                "overrides": []
+              },
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "top",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-167": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "topk(5,\r\n  max by (host_name, network_interface_name) (rate(system_network_io_bytes_total[$__range])) / on(host_name, network_interface_name)\r\n  max by (host_name, network_interface_name) (system_network_bandwidth_limit_bytes)\r\n)",
+                        "instant": true,
+                        "legendFormat": "{{host_name}} - {{network_interface_name}}",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 167,
+          "links": [],
+          "title": "Top Network Interfaces by Utilization",
+          "vizConfig": {
+            "group": "bargauge",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "thresholds"
+                  },
+                  "links": [
+                    {
+                      "title": "Host",
+                      "url": "d/eWQoMUTIk/system?orgId=1&var-host_name=${__field.labels.host_name}"
+                    }
+                  ],
+                  "max": 1,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "orange",
+                        "value": 0.5
+                      },
+                      {
+                        "color": "red",
+                        "value": 0.8
+                      }
+                    ]
+                  },
+                  "unit": "percentunit"
+                },
+                "overrides": []
+              },
+              "options": {
+                "displayMode": "lcd",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "top",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": false,
+                "sizing": "auto",
+                "valueMode": "color"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-168": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "topk(5, sum by (site, host_name, system_device) (rate(system_disk_io_bytes_total[$__range])))",
+                        "instant": true,
+                        "legendFormat": "{{host_name}} - {{system_device}}",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 168,
+          "links": [],
+          "title": "Top Drives by Traffic",
+          "vizConfig": {
+            "group": "bargauge",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "fixedColor": "blue",
+                    "mode": "thresholds"
+                  },
+                  "links": [
+                    {
+                      "title": "Host",
+                      "url": "d/eWQoMUTIk/system?orgId=1&var-host_name=${__field.labels.host_name}"
+                    }
+                  ],
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "light-purple",
+                        "value": 0
+                      },
+                      {
+                        "color": "purple",
+                        "value": 25000000
+                      },
+                      {
+                        "color": "semi-dark-purple",
+                        "value": 50000000
+                      },
+                      {
+                        "color": "dark-purple",
+                        "value": 75000000
+                      }
+                    ]
+                  },
+                  "unit": "binBps"
+                },
+                "overrides": []
+              },
+              "options": {
+                "displayMode": "gradient",
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "maxVizHeight": 300,
+                "minVizHeight": 10,
+                "minVizWidth": 0,
+                "namePlacement": "top",
+                "orientation": "horizontal",
+                "reduceOptions": {
+                  "calcs": [
+                    "lastNotNull"
+                  ],
+                  "fields": "",
+                  "values": false
+                },
+                "showUnfilled": true,
+                "sizing": "auto",
+                "valueMode": "color"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-173": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "bottomk(5,\r\n  label_join(\r\n    (\r\n      sum by (site, host_name, system_device) (\r\n        system_filesystem_usage_bytes{system_filesystem_state=\"free\"}\r\n      )\r\n      / ignoring(system_filesystem_state)\r\n      sum by (site, host_name, system_device) (\r\n        delta(system_filesystem_usage_bytes{system_filesystem_state=\"used\"}[$__range]) / $__range_s\r\n      )\r\n    ) \r\n    and ignoring(system_filesystem_state)\r\n    sum by (site, host_name, system_device) (\r\n      delta(system_filesystem_usage_bytes{system_filesystem_state=\"used\"}[$__range])\r\n    ) > 0,\r\n    \"id\", \":\", \"host_name\", \"system_device\"\r\n  )\r\n)",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "labelsToFields",
+                  "spec": {
+                    "id": "labelsToFields",
+                    "options": {}
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "id": true,
+                        "site": true
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Time": 0,
+                        "Value": 1,
+                        "host_name": 2,
+                        "id": 4,
+                        "site": 5,
+                        "system_device": 3
+                      },
+                      "renameByName": {
+                        "Time": "",
+                        "Value": "Time to Saturation",
+                        "host_name": "Hostname",
+                        "system_device": "Filesystem"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 173,
+          "links": [],
+          "title": "Earliest Saturation Time",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "links": [
+                    {
+                      "title": "Host",
+                      "url": "d/eWQoMUTIk/system-performance-metrics-metricshub?orgId=1&var-host_name=${__data.fields.Hostname}"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Filesystem"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Value"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "s"
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 0
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Hostname"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 166
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Time to Saturation"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 156
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-175": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 175,
+          "links": [],
+          "title": "Current Alerts",
+          "vizConfig": {
+            "group": "alertlist",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "alertInstanceLabelFilter": "",
+                "alertName": "MetricsHub-System",
+                "dashboardAlerts": false,
+                "groupBy": [],
+                "groupMode": "custom",
+                "maxItems": 20,
+                "showInactiveAlerts": false,
+                "sortOrder": 1,
+                "stateFilter": {
+                  "error": true,
+                  "firing": true,
+                  "noData": false,
+                  "normal": false,
+                  "pending": true,
+                  "recovering": true
+                },
+                "viewMode": "list"
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      },
+      "panel-35": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "exemplar": false,
+                        "expr": "last_over_time(timestamp(metricshub_agent_info)[6h:])",
+                        "format": "table",
+                        "instant": true,
+                        "legendFormat": "__auto",
+                        "range": false
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": [
+                {
+                  "kind": "calculateField",
+                  "spec": {
+                    "id": "calculateField",
+                    "options": {
+                      "alias": "Last Collect",
+                      "binary": {
+                        "left": {
+                          "matcher": {
+                            "id": "byName",
+                            "options": "Value"
+                          }
+                        },
+                        "operator": "*",
+                        "right": {
+                          "fixed": "1000"
+                        }
+                      },
+                      "mode": "binary",
+                      "reduce": {
+                        "include": [
+                          "Value"
+                        ],
+                        "reducer": "stdDev"
+                      }
+                    }
+                  }
+                },
+                {
+                  "kind": "convertFieldType",
+                  "spec": {
+                    "id": "convertFieldType",
+                    "options": {
+                      "conversions": [
+                        {
+                          "dateFormat": "",
+                          "destinationType": "time",
+                          "targetField": "Last Collect"
+                        }
+                      ],
+                      "fields": {}
+                    }
+                  }
+                },
+                {
+                  "kind": "formatTime",
+                  "spec": {
+                    "id": "formatTime",
+                    "options": {
+                      "outputFormat": "MM-DD HH:mm:ss",
+                      "timeField": "Last Collect",
+                      "useTimezone": true
+                    }
+                  }
+                },
+                {
+                  "kind": "organize",
+                  "spec": {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "Value": true,
+                        "__name__": true,
+                        "entityName": true,
+                        "entityTypeId": true,
+                        "host_id": true,
+                        "host_name": true,
+                        "host_type": true,
+                        "instanceName": true,
+                        "job": true,
+                        "name": true,
+                        "otel_scope_name": true,
+                        "service_name": true,
+                        "site": false
+                      },
+                      "includeByName": {},
+                      "indexByName": {
+                        "Last Collect": 8,
+                        "Time": 10,
+                        "Value": 12,
+                        "agent_host_name": 2,
+                        "build_date": 5,
+                        "build_number": 6,
+                        "cc_version": 7,
+                        "host_name": 13,
+                        "host_type": 14,
+                        "job": 11,
+                        "name": 9,
+                        "os_type": 3,
+                        "service_name": 0,
+                        "site": 1,
+                        "version": 4
+                      },
+                      "renameByName": {
+                        "Last": "lasy",
+                        "agent_host_name": "Agent Host Name",
+                        "build_date": "Build Date",
+                        "build_number": "Build Number",
+                        "cc_version": "CC Version",
+                        "os_type": "OS",
+                        "service_name": "Service Name",
+                        "site": "Site",
+                        "version": "Version"
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "description": "",
+          "id": 35,
+          "links": [],
+          "title": "",
+          "vizConfig": {
+            "group": "table",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "thresholds"
+                  },
+                  "custom": {
+                    "align": "center",
+                    "cellOptions": {
+                      "type": "auto"
+                    },
+                    "filterable": false,
+                    "footer": {
+                      "reducers": []
+                    },
+                    "inspect": false
+                  },
+                  "mappings": [
+                    {
+                      "options": {
+                        "linux": {
+                          "index": 1,
+                          "text": "https://dl.sentrysoftware.com/public/linux-logo-mh.svg"
+                        },
+                        "windows": {
+                          "index": 0,
+                          "text": "https://dl.sentrysoftware.com/public/windows-logo-mh.svg"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ],
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      }
+                    ]
+                  }
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "OS"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "image"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Service Name"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Agent Host Name"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "Site"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.align",
+                        "value": "left"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": []
+              }
+            },
+            "version": "12.3.2"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "RowsLayout",
+      "spec": {
+        "rows": [
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-139"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-148"
+                        },
+                        "height": 9,
+                        "width": 11,
+                        "x": 3,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-141"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 14,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-149"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 16,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-147"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 19,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-117"
+                        },
+                        "height": 3,
+                        "width": 2,
+                        "x": 22,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-140"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-150"
+                        },
+                        "height": 6,
+                        "width": 10,
+                        "x": 14,
+                        "y": 3
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-151"
+                        },
+                        "height": 3,
+                        "width": 3,
+                        "x": 0,
+                        "y": 6
+                      }
+                    }
+                  ]
                 }
               },
-              "type": "value"
+              "title": "Overview & Current Issues"
             }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": [
+          },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "OS"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "type": "image"
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-175"
+                        },
+                        "height": 8,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
                 }
-              }
-            ]
+              },
+              "title": "Alerts"
+            }
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "Service Name"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
-              }
-            ]
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-145"
+                        },
+                        "height": 15,
+                        "width": 24,
+                        "x": 0,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Hosts"
+            }
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "Agent Host Name"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
-              }
-            ]
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-143"
+                        },
+                        "height": 7,
+                        "width": 15,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-173"
+                        },
+                        "height": 7,
+                        "width": 9,
+                        "x": 15,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Filesystems"
+            }
           },
           {
-            "matcher": {
-              "id": "byName",
-              "options": "Site"
-            },
-            "properties": [
-              {
-                "id": "custom.align",
-                "value": "left"
-              }
-            ]
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-168"
+                        },
+                        "height": 8,
+                        "width": 6,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-157"
+                        },
+                        "height": 8,
+                        "width": 6,
+                        "x": 6,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-164"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 12,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Disk Activity"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-166"
+                        },
+                        "height": 8,
+                        "width": 6,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-167"
+                        },
+                        "height": 8,
+                        "width": 6,
+                        "x": 6,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-163"
+                        },
+                        "height": 8,
+                        "width": 12,
+                        "x": 12,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "Network Activity"
+            }
+          },
+          {
+            "kind": "RowsLayoutRow",
+            "spec": {
+              "collapse": false,
+              "layout": {
+                "kind": "GridLayout",
+                "spec": {
+                  "items": [
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-35"
+                        },
+                        "height": 4,
+                        "width": 22,
+                        "x": 0,
+                        "y": 0
+                      }
+                    },
+                    {
+                      "kind": "GridLayoutItem",
+                      "spec": {
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-128"
+                        },
+                        "height": 4,
+                        "width": 2,
+                        "x": 22,
+                        "y": 0
+                      }
+                    }
+                  ]
+                }
+              },
+              "title": "MetricsHub Agents Information"
+            }
           }
         ]
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 22,
-        "x": 0,
-        "y": 62
-      },
-      "id": 35,
-      "options": {
-        "cellHeight": "sm",
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "last_over_time(timestamp(metricshub_agent_info)[6h:])",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "A"
-        }
-      ],
-      "transformations": [
-        {
-          "id": "calculateField",
-          "options": {
-            "alias": "Last Collect",
-            "binary": {
-              "left": {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Value"
-                }
-              },
-              "operator": "*",
-              "right": {
-                "fixed": "1000"
-              }
-            },
-            "mode": "binary",
-            "reduce": {
-              "include": [
-                "Value"
-              ],
-              "reducer": "stdDev"
-            }
-          }
-        },
-        {
-          "id": "convertFieldType",
-          "options": {
-            "conversions": [
-              {
-                "dateFormat": "",
-                "destinationType": "time",
-                "targetField": "Last Collect"
-              }
-            ],
-            "fields": {}
-          }
-        },
-        {
-          "id": "formatTime",
-          "options": {
-            "outputFormat": "MM-DD HH:mm:ss",
-            "timeField": "Last Collect",
-            "useTimezone": true
-          }
-        },
-        {
-          "id": "organize",
-          "options": {
-            "excludeByName": {
-              "Time": true,
-              "Value": true,
-              "__name__": true,
-              "host_id": true,
-              "host_name": true,
-              "host_type": true,
-              "job": true,
-              "name": true,
-              "service_name": true,
-              "site": false
-            },
-            "includeByName": {},
-            "indexByName": {
-              "Last Collect": 8,
-              "Time": 10,
-              "Value": 12,
-              "agent_host_name": 2,
-              "build_date": 5,
-              "build_number": 6,
-              "cc_version": 7,
-              "host_name": 13,
-              "host_type": 14,
-              "job": 11,
-              "name": 9,
-              "os_type": 3,
-              "service_name": 0,
-              "site": 1,
-              "version": 4
-            },
-            "renameByName": {
-              "Last": "lasy",
-              "agent_host_name": "Agent Host Name",
-              "build_date": "Build Date",
-              "build_number": "Build Number",
-              "cc_version": "CC Version",
-              "os_type": "OS",
-              "service_name": "Service Name",
-              "site": "Site",
-              "version": "Version"
-            }
-          }
-        }
-      ],
-      "type": "table"
+      }
     },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "noValue": "2026.1",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "light-green",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 2,
-        "x": 22,
-        "y": 62
-      },
-      "id": 128,
-      "options": {
-        "colorMode": "background",
-        "graphMode": "none",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.3.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "expr": "",
-          "instant": false,
-          "range": true,
-          "refId": "A"
-        }
+    "links": [],
+    "liveNow": true,
+    "preload": false,
+    "tags": [
+      "System Overview"
+    ],
+    "timeSettings": {
+      "autoRefresh": "30s",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
       ],
-      "title": "Dashboard",
-      "type": "stat"
-    }
-  ],
-  "preload": false,
-  "refresh": "30s",
-  "schemaVersion": 42,
-  "tags": [
-    "System Overview"
-  ],
-  "templating": {
-    "list": [
+      "fiscalYearStartMonth": 0,
+      "from": "now-7d",
+      "hideTimepicker": false,
+      "timezone": "",
+      "to": "now"
+    },
+    "title": "System Performance Metrics - Overview (MetricsHub)",
+    "variables": [
       {
-        "current": {
-          "text": ".*tmpfs|nfs.*|overlay",
-          "value": ".*tmpfs|nfs.*|overlay"
-        },
-        "description": "Excludes all filesystems whose type matches the specified regular expression",
-        "hide": 2,
-        "label": "Exclude Filesystem Types",
-        "name": "filesystemFilter",
-        "options": [
-          {
-            "selected": true,
+        "kind": "TextVariable",
+        "spec": {
+          "current": {
             "text": ".*tmpfs|nfs.*|overlay",
             "value": ".*tmpfs|nfs.*|overlay"
-          }
-        ],
-        "query": ".*tmpfs|nfs.*|overlay",
-        "type": "textbox"
+          },
+          "description": "Excludes all filesystems whose type matches the specified regular expression",
+          "hide": "hideVariable",
+          "label": "Exclude Filesystem Types",
+          "name": "filesystemFilter",
+          "query": ".*tmpfs|nfs.*|overlay",
+          "skipUrlSync": false
+        }
       },
       {
-        "allowCustomValue": false,
-        "current": {},
-        "definition": "label_values(system_uptime_seconds,os_type)",
-        "hide": 2,
-        "includeAll": true,
-        "multi": true,
-        "name": "system",
-        "options": [],
-        "query": {
-          "qryType": 1,
-          "query": "label_values(system_uptime_seconds,os_type)",
-          "refId": "PrometheusVariableQueryEditor-VariableQuery"
-        },
-        "refresh": 1,
-        "regex": "",
-        "type": "query"
+        "kind": "QueryVariable",
+        "spec": {
+          "allowCustomValue": true,
+          "current": {
+            "text": "",
+            "value": ""
+          },
+          "definition": "label_values(system_uptime_seconds,os_type)",
+          "hide": "hideVariable",
+          "includeAll": true,
+          "multi": true,
+          "name": "system",
+          "options": [],
+          "query": {
+            "group": "prometheus",
+            "kind": "DataQuery",
+            "spec": {
+              "qryType": 1,
+              "query": "label_values(system_uptime_seconds,os_type)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "version": "v0"
+          },
+          "refresh": "onDashboardLoad",
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": "disabled"
+        }
       }
     ]
   },
-  "time": {
-    "from": "now-7d",
-    "to": "now"
-  },
-  "timepicker": {},
-  "timezone": "",
-  "title": "System Performance Metrics - Overview (MetricsHub)",
-  "uid": "24bfe0f7-2bf6-4f08-ba13-e2134ae9039c",
-  "version": 430,
-  "weekStart": ""
+  "status": {}
 }


### PR DESCRIPTION
- add storage system dashboard with capacity, usage, and activity metrics
- migrate existing dashboards to Grafana v2 resource format
- remove unnecessary columns from tables
- update README documentation

Closes #42
Closes #43